### PR TITLE
Cove faction name starts with capital 'C' now

### DIFF
--- a/hota/Mods/cove/Content/config/hota/cove/faction.json
+++ b/hota/Mods/cove/Content/config/hota/cove/faction.json
@@ -1,7 +1,7 @@
 {
 	"cove" :
 	{
-		"name" : "cove",
+		"name" : "Cove",
 		"alignment" : "neutral",
 		"nativeTerrain" : "swamp",
 		"boat" : "boatCove",


### PR DESCRIPTION
Fixes https://github.com/vcmi-mods/horn-of-the-abyss/issues/48

![image](https://github.com/vcmi-mods/horn-of-the-abyss/assets/15194321/a5841e54-da50-4aed-be5f-b391159a07be)
