### PR TITLE
Fixed nymph and Oceanid immunity to ice bolt and Frost Ring

### DIFF
--- a/hota/Mods/cove/Content/config/hota/cove/creatures/nymph.json
+++ b/hota/Mods/cove/Content/config/hota/cove/creatures/nymph.json
@@ -28,9 +28,15 @@
 				"type" : "FLYING",
 				"subtype" : 1
 			},
-			"immuneToWater" : {
-				"type" : "WATER_IMMUNITY",
-				"subtype" : 2
+			"iceBoltImmunity" :
+			{
+				"type" : "SPELL_IMMUNITY",
+				"subtype" : "spell.iceBolt"
+			},
+			"frostRingImmunity" :
+			{
+				"type" : "SPELL_IMMUNITY",
+				"subtype" : "spell.frostRing"
 			}
 		},
 		"graphics" : {

--- a/hota/Mods/cove/Content/config/hota/cove/creatures/oceanid.json
+++ b/hota/Mods/cove/Content/config/hota/cove/creatures/oceanid.json
@@ -27,9 +27,15 @@
 				"type" : "FLYING",
 				"subtype" : 1
 			},
-			"immuneToWater" : {
-				"type" : "WATER_IMMUNITY",
-				"subtype" : 2
+			"iceBoltImmunity" :
+			{
+				"type" : "SPELL_IMMUNITY",
+				"subtype" : "spell.iceBolt"
+			},
+			"frostRingImmunity" :
+			{
+				"type" : "SPELL_IMMUNITY",
+				"subtype" : "spell.frostRing"
 			}
 		},
 		"graphics" : {


### PR DESCRIPTION
Until there is another generic Water damage immunity that will not include Magic Arrow, this will work like intended.