### PR TITLE
Fix magic shrine level 4 definition

### DIFF
--- a/hota/Mods/mapObjects/content/config/hotaMapObjects/shrineOfMagicMystery.json
+++ b/hota/Mods/mapObjects/content/config/hotaMapObjects/shrineOfMagicMystery.json
@@ -1,5 +1,13 @@
 {
-	"core:shrineOfMagicLevel1" : {
+	"shrineOfMagicLevel4" : {
+		"name" : "Shrine of Magic Mystery (learn level 4 spell)",
+		"handler" : "shrine",
+		"base" : {
+			"sounds" : {
+				"ambient" : ["LOOPSHRIN"],
+				"visit" : ["TEMPLE"]
+			}
+		},
 		"types" : {
 			"shrineOfMagicMystery" : {
 				"name" : "Shrine of Magic Mystery (learn level 4 spell)",
@@ -16,24 +24,23 @@
 				"spell" : {
 					"level" : 4
 				},
-
 				"templates" :
 				{
 					"water" :
 					{
-						"animation" : "hota/shrines/AVXl4sh0", 
+						"animation" : "hota/shrines/AVXl4sh0",
 						"mask" : [ "VV", "VA" ], 
 						"visitableFrom" : [ "---", "+++", "+++" ],
 						"allowedTerrains": [ "water"]
 					},	
 					"land" :
 					{
-						"animation" : "hota/shrines/4lvlxshrn", 
+						"animation" : "hota/shrines/4lvlxshrn",
 						"mask" : [ "VV","VA" ], 
 						"visitableFrom" : [ "---", "+++", "+++" ]
 					}
 				}
 			}
 		}
-	}		
+	}
 }

--- a/hota/Mods/mapSupport/mod.json
+++ b/hota/Mods/mapSupport/mod.json
@@ -174,7 +174,7 @@
 					"townGate" : [146, 3],
 					"grave" : [ 212, 1001],
 					
-					"shrineOfMagicLevel1" : {
+					"shrineOfMagicLevel4" : {
 						"shrineOfMagicMystery" : [ 88, 3]
 					},
 					

--- a/hota/mod.json
+++ b/hota/mod.json
@@ -6,11 +6,12 @@
 	"contact" : "http://forum.vcmi.eu/viewtopic.php?t=748",
 	"licenseName" : "Creative Commons Attribution-ShareAlike",
 	"licenseURL" : "http://creativecommons.org/licenses/by-sa/4.0/deed",
-	"version" : "1.6.12",
+	"version" : "1.6.14",
 	"downloadSize" : 114.9,
 	"changelog" : 
 	{
-		"1.6.12"   : [ "Normalized submod names, to be more clear and look more consistent" ],
+		"1.6.14"  : [ "Fixed Magic Shrine level 4 definitions" ],
+		"1.6.12"  : [ "Normalized submod names, to be more clear and look more consistent" ],
 		"1.6.11"  : [ "WoG MainMenu mod name updated in Conflicts section" ],
 		"1.6.10"  : [ "Fixed Water Spells damage imunity for Nymphs and Oceanids" ],
 		"1.6.9"   : [ "Small changes with some highlands and wastelands decorative objects" ],


### PR DESCRIPTION
Tooltip for magic shrine level 4 was wrong because its definition was based on magic shrine level 1?!