### PR TITLE
Clearer magic shrines names

### DIFF
--- a/hota/Mods/mapDecorations/content/config/hotaMapDecorations/vanillaInteractive/shrineOfMagicGesture.json
+++ b/hota/Mods/mapDecorations/content/config/hotaMapDecorations/vanillaInteractive/shrineOfMagicGesture.json
@@ -1,15 +1,17 @@
 {
-	"core:shrineOfMagicLevel2"	: {
+	"core:shrineOfMagicLevel2" : {
+		"name" : "Shrine of Magic Gesture (teaches a level 2 spell)",
 		"types" : {
 			"object" : {
+				"name" : "Shrine of Magic Gesture (teaches a level 2 spell)",
 				"templates" : {
-					"AVXl2sh0w" : { "animation" : "hota/shrines/AVXl2sh0w",  
-						"mask" : [ "VB","VA" ], 
+					"AVXl2sh0w" : { "animation" : "hota/shrines/AVXl2sh0w",
+						"mask" : [ "VB","VA" ],
 						"visitableFrom" : [ "---", "+++", "+++" ],
 						"allowedTerrains": [ "water" ]
-					}	
+					}
 				}
 			}
 		}
-	}		
+	}
 }

--- a/hota/Mods/mapDecorations/content/config/hotaMapDecorations/vanillaInteractive/shrineOfMagicIncantation.json
+++ b/hota/Mods/mapDecorations/content/config/hotaMapDecorations/vanillaInteractive/shrineOfMagicIncantation.json
@@ -1,15 +1,17 @@
 {
-	"core:shrineOfMagicLevel1"	: {
+	"core:shrineOfMagicLevel1" : {
+		"name" : "Shrine of Magic Incantation (teaches a level 1 spell)",
 		"types" : {
 			"object" : {
+				"name" : "Shrine of Magic Incantation (teaches a level 1 spell)",
 				"templates" : {
-					"AVXl1sh0w" : { "animation" : "hota/shrines/AVXl1sh0w", 
-						"mask" : [ "VB","VA" ], 
+					"AVXl1sh0w" : { "animation" : "hota/shrines/AVXl1sh0w",
+						"mask" : [ "VB","VA" ],
 						"visitableFrom" : [ "---", "+++", "+++" ],
 						"allowedTerrains": [ "water" ]
 					}
 				}
 			}
 		}
-	}		
+	}
 }

--- a/hota/Mods/mapDecorations/content/config/hotaMapDecorations/vanillaInteractive/shrineOfMagicThought.json
+++ b/hota/Mods/mapDecorations/content/config/hotaMapDecorations/vanillaInteractive/shrineOfMagicThought.json
@@ -1,15 +1,17 @@
 {
 	"core:shrineOfMagicLevel3" : {
+		"name" : "Shrine of Magic Incantation (teaches a level 3 spell)",
 		"types" : {
 			"object" : {
+				"name" : "Shrine of Magic Thought (teaches a level 3 spell)",
 				"templates" : {
-					"AVXl3sh0w" : { "animation" : "hota/shrines/AVXl3sh0w", 
-						"mask" : [ "VB", "VA" ], 
+					"AVXl3sh0w" : { "animation" : "hota/shrines/AVXl3sh0w",
+						"mask" : [ "VB", "VA" ],
 						"visitableFrom" : [ "---", "+++", "+++" ],
 						"allowedTerrains": [ "water"]
 					}
 				}
 			}
 		}
-	}		
+	}
 }

--- a/hota/Mods/mapObjects/content/config/hotaMapObjects/shrineOfMagicMystery.json
+++ b/hota/Mods/mapObjects/content/config/hotaMapObjects/shrineOfMagicMystery.json
@@ -1,6 +1,6 @@
 {
 	"shrineOfMagicLevel4" : {
-		"name" : "Shrine of Magic Mystery (learn level 4 spell)",
+		"name" : "Shrine of Magic Mystery (teaches a level 4 spell)",
 		"handler" : "shrine",
 		"base" : {
 			"sounds" : {
@@ -10,7 +10,7 @@
 		},
 		"types" : {
 			"shrineOfMagicMystery" : {
-				"name" : "Shrine of Magic Mystery (learn level 4 spell)",
+				"name" : "Shrine of Magic Mystery (teaches a level 4 spell)",
 				"rmg" : {
 					"value"		: 7000,
 					"rarity"	: 100,

--- a/hota/mod.json
+++ b/hota/mod.json
@@ -6,12 +6,13 @@
 	"contact" : "http://forum.vcmi.eu/viewtopic.php?t=748",
 	"licenseName" : "Creative Commons Attribution-ShareAlike",
 	"licenseURL" : "http://creativecommons.org/licenses/by-sa/4.0/deed",
-	"version" : "1.6.13",
+	"version" : "1.6.14",
 	"downloadSize" : 114.9,
 	"changelog" : 
 	{
-		"1.6.13"   : [ "Removed unavailable LAND type from terrains.", "Fixed Magic Shrine level 4 definitions", "Fixed miniHillFort templates for wasteland and highlands", "Fixed warlocks lab template" ],
-		"1.6.12"   : [ "Normalized submod names, to be more clear and look more consistent" ],
+		"1.6.14"  : [ "More clear and consistent names for magic shrines" ],
+		"1.6.13"  : [ "Removed unavailable LAND type from terrains.", "Fixed Magic Shrine level 4 definitions", "Fixed miniHillFort templates for wasteland and highlands", "Fixed warlocks lab template" ],
+		"1.6.12"  : [ "Normalized submod names, to be more clear and look more consistent" ],
 		"1.6.11"  : [ "WoG MainMenu mod name updated in Conflicts section" ],
 		"1.6.10"  : [ "Fixed Water Spells damage imunity for Nymphs and Oceanids" ],
 		"1.6.9"   : [ "Small changes with some highlands and wastelands decorative objects" ],


### PR DESCRIPTION
All names look like:
![image](https://github.com/vcmi-mods/horn-of-the-abyss/assets/15194321/19442d4c-5b0c-44cb-87ce-d6d4c305b0d1)

Except level 1 that for some reason looks like:
![image](https://github.com/vcmi-mods/horn-of-the-abyss/assets/15194321/0cf8d326-16a8-497d-991a-385c9913b534)

(should be fixed later in a VCMI PR)