### PR TITLE
Adding Cartographer to modded mapObjects, changed limiter to 10,000

### DIFF
--- a/hota/Mods/gameBalance/content/config/hotaGameBalance/mapObjects.json
+++ b/hota/Mods/gameBalance/content/config/hotaGameBalance/mapObjects.json
@@ -1,0 +1,101 @@
+{
+	"core:cartographer" : {
+		"name": "Cartographer",
+		"handler": "configurable",
+		"base" : {
+			"sounds" : {
+				"visit" : ["LIGHTHOUSE"]
+			}
+		},
+		"types" : {
+			"cartographerWater" : {
+				"aiValue" : 5000,
+				"rmg" : {
+					"zoneLimit" : 1,
+					"value" : 5000,
+					"rarity" : 20
+				},
+				"compatibilityIdentifiers" : [ "water" ],
+				"visitMode" : "unlimited",
+				"canRefuse" : true,
+				"rewards" : [
+					{
+						"limiter" : { "resources" : { "gold" : 10000 } },
+						"message" : 25,
+						"resources" : {
+							"gold" : -10000
+						},
+						"revealTiles" : {
+							"water" : 1
+						}
+					}
+				],
+				"onEmptyMessage" : "{Cartographer}\r\n\r\n28",
+				"onSelectMessage" : "{Cartographer}\r\n\r\nA big show is taking place at the Colosseum today. You enter the arena and hold the audience in awe with your magical prowess. Insatiable hunger for knowledge is what makes a true mage, so you gladly accept the first prize, which is one the newest academical handbooks",
+				"onVisitedMessage": "{Cartographer}\r\n\r\nModerator of the Colosseum instantly recognises you but respectfully denies entrance to the competitor zone. You probably should rather be featuring as a talent judge here!"
+				
+			},
+			"cartographerLand" : {
+
+				"aiValue": 10000,
+				"rmg" : {
+					"zoneLimit" : 1,
+					"value" : 10000,
+					"rarity" : 2
+				},
+				"compatibilityIdentifiers" : [ "land" ],
+				"visitMode" : "unlimited",
+				"canRefuse" : true,
+				"rewards" : [
+					{
+						"limiter" : { "resources" : { "gold" : 1000 } },
+						"message" : 26,
+						"resources" : {
+							"gold" : -1000
+						},
+						"revealTiles" : {
+							"surface" : 1,
+							"water" : -1,
+							"rock" : -1
+						}
+					}
+				],
+				"onEmptyMessage" : "{Cartographer}\r\n\r\n28",
+				"onSelectMessage" : "{Cartographer}\r\n\r\nA big show is taking place at the Colosseum today. You enter the arena and hold the audience in awe with your magical prowess. Insatiable hunger for knowledge is what makes a true mage, so you gladly accept the first prize, which is one the newest academical handbooks",
+				"onVisitedMessage": "{Cartographer}\r\n\r\nModerator of the Colosseum instantly recognises you but respectfully denies entrance to the competitor zone. You probably should rather be featuring as a talent judge here!"
+				
+			},
+			"cartographerSubterranean" : {
+				
+				"aiValue" : 7500,
+				"rmg" : {
+					"zoneLimit" : 1,
+					"value" : 7500,
+					"rarity" : 20
+				},
+				"compatibilityIdentifiers" : [ "subterra" ],
+				"visitMode" : "unlimited",
+				"canRefuse" : true,
+				"rewards" : [
+					{
+						"limiter" : { "resources" : { "gold" : 10000 } },
+						"message" : 27,
+						"resources" : {
+							"gold" : -10000
+						},
+						"revealTiles" : {
+							"subterra" : 1,
+							"water" : -1,
+							"rock" : -1,
+							"surface" : -1
+						}
+					}
+				],
+				"onEmptyMessage" : "{Cartographer}\r\n\r\n28",
+				"onSelectMessage" : "{Cartographer}\r\n\r\nA big show is taking place at the Colosseum today. You enter the arena and hold the audience in awe with your magical prowess. Insatiable hunger for knowledge is what makes a true mage, so you gladly accept the first prize, which is one the newest academical handbooks",
+				"onVisitedMessage": "{Cartographer}\r\n\r\nModerator of the Colosseum instantly recognises you but respectfully denies entrance to the competitor zone. You probably should rather be featuring as a talent judge here!"
+				
+			}
+		}
+	}
+}

--- a/hota/Mods/gameBalance/content/config/hotaGameBalance/mapObjects.json
+++ b/hota/Mods/gameBalance/content/config/hotaGameBalance/mapObjects.json
@@ -21,7 +21,7 @@
 				"rewards" : [
 					{
 						"limiter" : { "resources" : { "gold" : 10000 } },
-						"message" : 25,
+						"message" : "You find an old fisherman who has the most detailed maps of the seas that you have ever seen. Would you like to purchase a set of maps for 10000 gold?",  // originally 25,
 						"resources" : {
 							"gold" : -10000
 						},
@@ -30,9 +30,8 @@
 						}
 					}
 				],
-				"onEmptyMessage" : "{Cartographer}\r\n\r\n28",
-				"onSelectMessage" : "{Cartographer}\r\n\r\nA big show is taking place at the Colosseum today. You enter the arena and hold the audience in awe with your magical prowess. Insatiable hunger for knowledge is what makes a true mage, so you gladly accept the first prize, which is one the newest academical handbooks",
-				"onVisitedMessage": "{Cartographer}\r\n\r\nModerator of the Colosseum instantly recognises you but respectfully denies entrance to the competitor zone. You probably should rather be featuring as a talent judge here!"
+				"onEmptyMessage" : "My maps cost 10000 gold, which you don't seem to have. Please stop wasting my time.",  // originally 28,
+				"onVisitedMessage": "You have already seen all my maps laddy, now run along."  // originally 24
 				
 			},
 			"cartographerLand" : {
@@ -48,10 +47,10 @@
 				"canRefuse" : true,
 				"rewards" : [
 					{
-						"limiter" : { "resources" : { "gold" : 1000 } },
-						"message" : 26,
+						"limiter" : { "resources" : { "gold" : 10000 } },
+						"message" : "You find a cartographer who sells maps of the land for 10000 gold. Would you like to buy a map?",  // originally 26,
 						"resources" : {
-							"gold" : -1000
+							"gold" : -10000
 						},
 						"revealTiles" : {
 							"surface" : 1,
@@ -60,10 +59,9 @@
 						}
 					}
 				],
-				"onEmptyMessage" : "{Cartographer}\r\n\r\n28",
-				"onSelectMessage" : "{Cartographer}\r\n\r\nA big show is taking place at the Colosseum today. You enter the arena and hold the audience in awe with your magical prowess. Insatiable hunger for knowledge is what makes a true mage, so you gladly accept the first prize, which is one the newest academical handbooks",
-				"onVisitedMessage": "{Cartographer}\r\n\r\nModerator of the Colosseum instantly recognises you but respectfully denies entrance to the competitor zone. You probably should rather be featuring as a talent judge here!"
-				
+				"onEmptyMessage" : "My maps cost 10000 gold, which you don't seem to have. Please stop wasting my time.",  // originally 28,
+				"onVisitedMessage": "You have already seen all my maps laddy, now run along."  // originally 24
+
 			},
 			"cartographerSubterranean" : {
 				
@@ -79,7 +77,7 @@
 				"rewards" : [
 					{
 						"limiter" : { "resources" : { "gold" : 10000 } },
-						"message" : 27,
+						"message" : "You discover an old dwarven miner who has kept several sets of maps from his working days. He is willing to sell you a map of the tunnels for 10000 gold. Do you agree?", // originally 27,
 						"resources" : {
 							"gold" : -10000
 						},
@@ -91,10 +89,8 @@
 						}
 					}
 				],
-				"onEmptyMessage" : "{Cartographer}\r\n\r\n28",
-				"onSelectMessage" : "{Cartographer}\r\n\r\nA big show is taking place at the Colosseum today. You enter the arena and hold the audience in awe with your magical prowess. Insatiable hunger for knowledge is what makes a true mage, so you gladly accept the first prize, which is one the newest academical handbooks",
-				"onVisitedMessage": "{Cartographer}\r\n\r\nModerator of the Colosseum instantly recognises you but respectfully denies entrance to the competitor zone. You probably should rather be featuring as a talent judge here!"
-				
+				"onEmptyMessage" : "My maps cost 10000 gold, which you don't seem to have. Please stop wasting my time.",  // originally 28,
+				"onVisitedMessage": "You have already seen all my maps laddy, now run along."  // originally 24
 			}
 		}
 	}

--- a/hota/Mods/gameBalance/mod.json
+++ b/hota/Mods/gameBalance/mod.json
@@ -1,10 +1,14 @@
 {
 	"name" : "Game balance",
-	"description" : "Balance improvements made by HotA Crew for Horn of The Abbys expansion.",
+	"description" : "Balance improvements made by HotA Crew for Horn of The Abyss expansion.",
 	"modType" : "Mechanics",
 	"author": "Kuririn & avatar",
 	"contact": "http://forum.df2.ru/index.php?showtopic=32286",
-	"version" : "1.3.6",
+	"version" : "1.3.7",
+	"changelog" : 
+	{
+		"1.3.7"   : [ "Changed the price for cartographer maps from 1000 to 10000 gold" ]
+	},
 	"depends" : [ "hota.mapobjects" ],
 	"settings" : {
 		"dwellings" : {
@@ -47,7 +51,8 @@
 	[
 		"config/hotaGameBalance/objectsRmgValues.json",
 		"config/hotaGameBalance/creatureBanks.json",
-		"config/hotaGameBalance/objectsRefusable.json"
+		"config/hotaGameBalance/objectsRefusable.json",
+		"config/hotaGameBalance/mapObjects.json"
 	],
 	"chinese" : {
 		"name" : "游戏平衡",


### PR DESCRIPTION
I saw [this on the Hota project board](https://github.com/orgs/vcmi/projects/3/views/1?pane=issue&itemId=24270615) and decided to use this to get familiar with the code base.
Steps that I took:

- Took the base config/objects/cartographer.json from the main repo;
- Removed the index parameters (for each type and the main one)
- renamed from "cartograhper" to "core:cartographer"
- changed the limiter and the resources { gold } from 1000 to 10000
- Saved the file under hota/Mods/MapObjects/content
- Added the file to the list hota/Mods/MapObjects/mod.json

I still haven't updated the text message, because I can't find the string in the repo. 
Could it be that it is hardcoded with the media files from the base (GOG) installation?
If somebody guides me how to update the text, I would extend this pull request

![cartographer](https://github.com/vcmi-mods/horn-of-the-abyss/assets/31136319/1ccbfd77-56de-49a0-9bb1-8da9cd671364)

