### PR TITLE
Interference hotfix

### DIFF
--- a/hota/Mods/cove/Content/config/hota/cove/heroes/balfour.json
+++ b/hota/Mods/cove/Content/config/hota/cove/heroes/balfour.json
@@ -31,7 +31,7 @@
 				"level": "basic"
 			},
 			{
-				"skill": "interference",
+				"skill": "resistance",
 				"level": "basic"
 			}
 		],

--- a/hota/Mods/interference/content/config/hotaInterference/heroStartingSkillChanges.json
+++ b/hota/Mods/interference/content/config/hotaInterference/heroStartingSkillChanges.json
@@ -124,5 +124,33 @@
 				"level": "basic"
 			}
 		]
+	},
+	"hota.cove:17zilare":
+	{
+		"skills":
+		[
+			{
+				"skill": "wisdom",
+				"level": "basic"
+			},
+			{
+				"skill": "interference",
+				"level": "basic"
+			}
+		]
+	},
+	"hota.cove:balfour":
+	{
+		"skills":
+		[
+			{
+				"skill": "wisdom",
+				"level": "basic"
+			},
+			{
+				"skill": "interference",
+				"level": "basic"
+			}
+		]
 	}
 }

--- a/hota/mod.json
+++ b/hota/mod.json
@@ -5,9 +5,10 @@
 	"contact" : "http://forum.vcmi.eu/viewtopic.php?t=748",
 	"licenseName" : "Creative Commons Attribution-ShareAlike",
 	"licenseURL" : "http://creativecommons.org/licenses/by-sa/4.0/deed",
-	"version" : "1.7.57",
+	"version" : "1.7.58",
 	"changelog" : 
 	{
+		"1.7.58"  : [ "Balfour Interference hotfix and add Zilare to the heroes who have a second secondary skill replaced with Interference" ],
 		"1.7.57"  : [ "Improve HotA Heroes submod, add balfour bio by Ben Yan, Fix Kydomios nad Maximus specialty" ],
 		"1.7.56"  : [ "Update HotA formatting and factory file structure, fix cove hero ordering and add submods disabling special flag for factory and cove campaign heroes" ],
 		"1.7.55"  : [ "Fix for columns in biome" ],


### PR DESCRIPTION
This PR:
- Fixes Balfour's Secondary Skill
- Adds Zilare and Balfour to the group of the heroes whose second Secondary Skills get replaced by Interference