### PR TITLE
Fix paths in polish translations for gameBalance and mapObjects

### DIFF
--- a/hota/Mods/gameBalance/mod.json
+++ b/hota/Mods/gameBalance/mod.json
@@ -69,7 +69,7 @@
 		"name" : "Balans gry",
 		"description" : "Balans gry stworzony przez HotA Crew dla dodatku Horn of The Abyss",
 		"translations" : [
-			"config/translation/polish.json"
+			"translation/polish.json"
 		]
 	},
 	"swedish" : {

--- a/hota/Mods/mapObjects/mod.json
+++ b/hota/Mods/mapObjects/mod.json
@@ -33,7 +33,7 @@
 	"name" : "Nowe obiekty",
 	"description" : "Mod dodaje wiele nowych obiektów stworzonych przez HotA Crew do VCMI, które pojawiają się na mapach losowych",
 		"translations" : [
-		"config/translation/mapObjects/polish.json"
+		"translation/mapObjects/polish.json"
 		]
 	},
 	"ukrainian" : {


### PR DESCRIPTION
In log i found that those files are marked as failed to fetch.
This patch seems fix it.
Failed to find file config/translation/mapObjects/polish.json
Failed to find file config/translation/polish.json
