### PR TITLE
fix wasteland absolute obstacle graphics

### DIFF
--- a/hota/Mods/wastelandTerrain/content/config/hota/wasteland/obstacles.json
+++ b/hota/Mods/wastelandTerrain/content/config/hota/wasteland/obstacles.json
@@ -233,7 +233,7 @@
 			149,
 			150
 		],
-		"animation" : "hota/wasteland/obstacles/ObWLD13",
+		"animation" : "hota/wasteland/obstacles/ObWLD13/ObWLD13.png",
 		"absolute" : true
 	},
 	"hotaWLD14" : {
@@ -257,7 +257,7 @@
 			77,
 			78
 		],
-		"animation" : "hota/wasteland/obstacles/ObWLD14",
+		"animation" : "hota/wasteland/obstacles/ObWLD14/ObWLD14.png",
 		"absolute" : true
 	}
 }

--- a/hota/mod.json
+++ b/hota/mod.json
@@ -5,8 +5,11 @@
 	"contact" : "http://forum.vcmi.eu/viewtopic.php?t=748",
 	"licenseName" : "Creative Commons Attribution-ShareAlike",
 	"licenseURL" : "http://creativecommons.org/licenses/by-sa/4.0/deed",
-	"version" : "1.7.725",
+	"version" : "1.7.726",
 	"changelog" : {
+		"1.7.726" : [
+			"Fixed Wasteland absolute obstacles"
+		],
 		"1.7.725" : [
 			"Fixed Couatl adventure map graphics"
 		],


### PR DESCRIPTION
In vcmi absolute obstacles are associated with images, not animations:
https://github.com/vcmi/vcmi/blob/a9ecef9ec714606aff43c65ed7e681858dece7c9/client/battle/BattleObstacleController.cpp#L45-L59

This is misconfigured for wasteland. Btw. it is done correctly for fieldsOfGlory:
https://github.com/vcmi-mods/horn-of-the-abyss/blob/ab98e4b8060626a1056f4bb7edbf1f0c41c75465/hota/Mods/terrainOverlays/content/config/fieldsOfGlory/obstacles.json#L7-L8