### PR TITLE
add war machine damage cap mechanics

### DIFF
--- a/hota/Mods/cannon/Content/config/hotaCannon/artillery.json
+++ b/hota/Mods/cannon/Content/config/hotaCannon/artillery.json
@@ -11,6 +11,15 @@
 					"subtype" : "creature.cannon",
 					"type" : "BONUS_DAMAGE_PERCENTAGE",
 					"valueType" : "BASE_NUMBER"
+				},
+				"damageCapCannon" : {
+					"type" : "DAMAGE_RECEIVED_CAP",
+					"propagator" : "ARMY",
+					"limiters" : [{
+					"type" : "CREATURE_TYPE_LIMITER",
+					"creature" : "cannon"
+				}],
+					"valueType" : "INDEPENDENT_MIN"
 				}
 			}
 		},
@@ -21,6 +30,9 @@
 				},
 				"damagePower" : {
 					"val" : 0
+				},
+				"damageCapCannon" : {
+					"val" : 40
 				}
 			}
 		},
@@ -31,6 +43,9 @@
 				},
 				"damagePower" : {
 					"val" : 100
+				},
+				"damageCapCannon" : {
+					"val" : 40
 				}
 			}
 		},
@@ -41,6 +56,9 @@
 				},
 				"damagePower" : {
 					"val" : 200
+				},
+				"damageCapCannon" : {
+					"val" : 40
 				}
 			}
 		}

--- a/hota/Mods/gameBalance/mods/skills/mod.json
+++ b/hota/Mods/gameBalance/mods/skills/mod.json
@@ -2,7 +2,7 @@
 	"name" : "Skills",
 	"description" : "",
 	"modType" : "Mechanics",
-	"author" : "Kuririn, avatar, wnukos",
+	"author" : "Kuririn, avatar, wnukos, mrhaandi",
 	"contact" : "http://forum.df2.ru/index.php?showtopic=32286",
 	"version" : "1.0",
 

--- a/hota/Mods/gameBalance/mods/skills/mods/artillery/Content/config/hotaGameBalance/skills.json
+++ b/hota/Mods/gameBalance/mods/skills/mods/artillery/Content/config/hotaGameBalance/skills.json
@@ -1,0 +1,32 @@
+{
+	"core:artillery" : {
+		"base" : {
+			"effects" : {
+				"damageCap" : {
+					"type" : "DAMAGE_RECEIVED_CAP",
+					"propagator" : "ARMY",
+					"limiters" : [{
+						"type" : "CREATURE_TYPE_LIMITER",
+						"creature" : "ballista"
+					}],
+					"valueType" : "INDEPENDENT_MIN"
+				}
+			}
+		},
+		"basic" : {
+			"effects" : {
+				"damageCap" : { "val" : 40 }
+			}
+		},
+		"advanced" : {
+			"effects" : {
+				"damageCap" : { "val" : 40 }
+			}
+		},
+		"expert" : {
+			"effects" : {
+				"damageCap" : { "val" : 40 }
+			}
+		}
+	}
+}

--- a/hota/Mods/gameBalance/mods/skills/mods/artillery/mod.json
+++ b/hota/Mods/gameBalance/mods/skills/mods/artillery/mod.json
@@ -1,0 +1,14 @@
+{
+	"name" : "Artillery",
+	"description" : "",
+	"modType" : "Mechanics",
+	"author" : "Hota Crew, ported by mrhaandi",
+	"contact" : "VCMI Discord: https://discord.gg/chBT42V",
+	"licenseName" : "Creative Commons Attribution-ShareAlike",
+	"licenseURL" : "http://creativecommons.org/licenses/by-sa/4.0/deed",
+	"version" : "1.0",
+
+	"skills" : [
+		"config/hotaGameBalance/skills.json"
+	]
+}

--- a/hota/Mods/gameBalance/mods/skills/mods/ballistics/Content/config/hotaCatapult/skills.json
+++ b/hota/Mods/gameBalance/mods/skills/mods/ballistics/Content/config/hotaCatapult/skills.json
@@ -1,0 +1,32 @@
+{
+	"core:ballistics" : {
+		"base" : {
+			"effects" : {
+				"damageCap" : {
+					"type" : "DAMAGE_RECEIVED_CAP",
+					"propagator" : "ARMY",
+					"limiters" : [{
+						"type" : "CREATURE_TYPE_LIMITER",
+						"creature" : "catapult"
+					}],
+					"valueType" : "INDEPENDENT_MIN"
+				}
+			}
+		},
+		"basic" : {
+			"effects" : {
+				"damageCap" : { "val" : 40 }
+			}
+		},
+		"advanced" : {
+			"effects" : {
+				"damageCap" : { "val" : 40 }
+			}
+		},
+		"expert" : {
+			"effects" : {
+				"damageCap" : { "val" : 40 }
+			}
+		}
+	}
+}

--- a/hota/Mods/gameBalance/mods/skills/mods/ballistics/mod.json
+++ b/hota/Mods/gameBalance/mods/skills/mods/ballistics/mod.json
@@ -23,5 +23,9 @@
 
 	"spells" : [
 		"config/hotaCatapult/catapultShot.json"
+	],
+
+	"skills" : [
+		"config/hotaCatapult/skills.json"
 	]
 }

--- a/hota/Mods/gameBalance/mods/skills/mods/firstAid/Content/config/hotaGameBalance/skills.json
+++ b/hota/Mods/gameBalance/mods/skills/mods/firstAid/Content/config/hotaGameBalance/skills.json
@@ -1,0 +1,32 @@
+{
+	"core:firstAid" : {
+		"base" : {
+			"effects" : {
+				"damageCap" : {
+					"type" : "DAMAGE_RECEIVED_CAP",
+					"propagator" : "ARMY",
+					"limiters" : [{
+						"type" : "CREATURE_TYPE_LIMITER",
+						"creature" : "firstAidTent"
+					}],
+					"valueType" : "INDEPENDENT_MIN"
+				}
+			}
+		},
+		"basic" : {
+			"effects" : {
+				"damageCap" : { "val" : 40 }
+			}
+		},
+		"advanced" : {
+			"effects" : {
+				"damageCap" : { "val" : 40 }
+			}
+		},
+		"expert" : {
+			"effects" : {
+				"damageCap" : { "val" : 40 }
+			}
+		}
+	}
+}

--- a/hota/Mods/gameBalance/mods/skills/mods/firstAid/mod.json
+++ b/hota/Mods/gameBalance/mods/skills/mods/firstAid/mod.json
@@ -1,0 +1,14 @@
+{
+	"name" : "First Aid",
+	"description" : "",
+	"modType" : "Mechanics",
+	"author" : "Hota Crew, ported by mrhaandi",
+	"contact" : "VCMI Discord: https://discord.gg/chBT42V",
+	"licenseName" : "Creative Commons Attribution-ShareAlike",
+	"licenseURL" : "http://creativecommons.org/licenses/by-sa/4.0/deed",
+	"version" : "1.0",
+
+	"skills" : [
+		"config/hotaGameBalance/skills.json"
+	]
+}

--- a/hota/mod.json
+++ b/hota/mod.json
@@ -5,8 +5,11 @@
 	"contact" : "http://forum.vcmi.eu/viewtopic.php?t=748",
 	"licenseName" : "Creative Commons Attribution-ShareAlike",
 	"licenseURL" : "http://creativecommons.org/licenses/by-sa/4.0/deed",
-	"version" : "1.7.727",
+	"version" : "1.7.728",
 	"changelog" : {
+		"1.7.728" : [
+			"Added damage cap for war machines when the corresponding secondary skill is present"
+		],
 		"1.7.727" : [
 			"Added additional creatures abilities icons by Kurek"
 		],


### PR DESCRIPTION
To be merged after https://github.com/vcmi/vcmi/pull/6436.

Given the corresponding secondary skill a war machine will not take more then 40% of max health damage.