### PR TITLE
New Pathfinding submod

### DIFF
--- a/hota/Mods/gameBalance/mods/skills/mods/pathfinding/content/config/hotaGameBalance/skills.json
+++ b/hota/Mods/gameBalance/mods/skills/mods/pathfinding/content/config/hotaGameBalance/skills.json
@@ -1,0 +1,33 @@
+{
+	"core:pathfinding" : {
+		"base" : {
+			"effects" : {
+				"minCost" : {
+					"type" : "BASE_TILE_MOVEMENT_COST",
+					"valueType" : "BASE_VALUE"
+				}
+			}
+		},
+		"basic" : {
+			"description" : "{Basic Pathfinding}\n\nBasic Pathfinding reduces the movement penalty for rough terrain by 25 points, down to a minimum cost of 95.",
+			"effects" : {
+				"main" : { "val" : 25 },
+				"minCost" : { "val" : -5 }
+			}
+		},
+		"advanced" : {
+			"description" : "{Advanced Pathfinding}\n\nAdvanced Pathfinding reduces the movement penalty for rough terrain by 50 points, down to a minimum cost of 90.",
+			"effects" : {
+				"main" : { "val" : 50 },
+				"minCost" : { "val" : -10 }
+			}
+		},
+		"expert" : {
+			"description" : "{Expert Pathfinding}\n\nExpert Pathfinding reduces the movement penalty for rough terrain by 75 points, down to a minimum cost of 85.",
+			"effects" : {
+				"main" : { "val" : 75 },
+				"minCost" : { "val" : -15 }
+			}
+		}
+	}
+}

--- a/hota/Mods/gameBalance/mods/skills/mods/pathfinding/mod.json
+++ b/hota/Mods/gameBalance/mods/skills/mods/pathfinding/mod.json
@@ -1,0 +1,12 @@
+{
+	"name" : "Pathfinding",
+	"description" : "",
+	"modType" : "Mechanics",
+	"author" : "Kuririn, avatar, wnukos",
+	"contact" : "http://forum.df2.ru/index.php?showtopic=32286",
+	"version" : "1.0",
+
+	"skills" : [
+		"config/hotaGameBalance/skills.json"
+	]
+}


### PR DESCRIPTION
HotA changed pathfinding to also reduce base tile movement cost for off-road tiles to 95/90/85, so that Pathfinding has an effect on neutral terrains. This submod reflects this change.