### PR TITLE
Factory submod bug fixes and polish

### DIFF
--- a/hota/Mods/factory/content/config/hota/factory/creatures/hotaDreadnought.json
+++ b/hota/Mods/factory/content/config/hota/factory/creatures/hotaDreadnought.json
@@ -12,7 +12,7 @@
 		"aiValue" : 3879,
 		"attack" : 18,
 		"cost" : {
-			"gold" : 2500,
+			"gold" : 2200,
 			"crystal" : 1
 		},
 		"damage" : {
@@ -76,8 +76,8 @@
 			"noRetaliation" : {
 				"type" : "BLOCKS_RETALIATION"
 			},
-			// Will be affected by Slayer with no expertise
-			"KING_1" : {
+			"KING_3" : // Will be affected by Expert Slayer only
+			{
 				"type" : "KING",
 				"val" : 3
 			}

--- a/hota/Mods/factory/content/config/hota/factory/creatures/hotaEngineer.json
+++ b/hota/Mods/factory/content/config/hota/factory/creatures/hotaEngineer.json
@@ -16,7 +16,7 @@
 		},
 		"damage" : {
 			"max" : 5,
-			"min" : 2
+			"min" : 3
 		},
 		"defense" : 5,
 		"fightValue" : 233,

--- a/hota/Mods/factory/content/config/hota/factory/creatures/hotaJuggernaut.json
+++ b/hota/Mods/factory/content/config/hota/factory/creatures/hotaJuggernaut.json
@@ -12,7 +12,7 @@
 		"aiValue" : 6433,
 		"attack" : 23,
 		"cost" : {
-			"gold" : 4000,
+			"gold" : 3500,
 			"crystal" : 2
 		},
 		"damage" : {
@@ -73,8 +73,8 @@
 			"noRetaliation" : {
 				"type" : "BLOCKS_RETALIATION"
 			},
-			// Will be affected by Slayer with no expertise
-			"KING_1" : {
+			"KING_3" : // Will be affected by Expert Slayer only
+			{
 				"type" : "KING",
 				"val" : 3
 			}

--- a/hota/Mods/factory/content/config/hota/factory/creatures/hotaMechanic.json
+++ b/hota/Mods/factory/content/config/hota/factory/creatures/hotaMechanic.json
@@ -16,7 +16,7 @@
 		},
 		"damage" : {
 			"max" : 4,
-			"min" : 2
+			"min" : 3
 		},
 		"defense" : 5,
 		"fightValue" : 198,

--- a/hota/Mods/factory/content/config/hota/factory/creatures/olgoiKhorkhoi.json
+++ b/hota/Mods/factory/content/config/hota/factory/creatures/olgoiKhorkhoi.json
@@ -1,7 +1,7 @@
 {
 	"olgoiKhorkhoi" : {
 		"name" : {
-			"plural" : "Olgoi-Khorkhois",
+			"plural" : "Olgoi-Khorkhoi",
 			"singular" : "Olgoi-Khorkhoi"
 		},
 		"advMapAmount" : {

--- a/hota/Mods/factory/content/config/hota/factory/heroes/agar.json
+++ b/hota/Mods/factory/content/config/hota/factory/heroes/agar.json
@@ -7,9 +7,9 @@
 			"name" : "Agar",
 			"biography" : "Many thought that the warlock Agar was a madman, and then a dead man. While the latter has been proven incorrect, there is still no unanimity in Enroth's scientific community on the former. Indeed, Agar's creations are undeniably viable and functional - but could a scientist in his right mind think of instilling such nasty inclinations and proclivities in a living being?",
 			"specialty" : {
-				"tooltip" : "No description",
+				"tooltip" : "Creature Bonus: Sandworms",
 				"name" : "Sandworms",
-				"description" : "Increases Speed of any Sandworms or Olgoi-Khorkhois by 1 and their Attack and Defense skills by 5% for every 5 levels (rounded up)."
+				"description" : "Increases the Speed of allied Sandworms and Olgoi-Khorkhoi by 1 and their Attack and Defense skills by 5% for every 5 levels (rounded up)."
 			}
 		},
 
@@ -28,8 +28,8 @@
 			},
 			{
 				"creature" : "hotaMechanic",
-				"max" : 8,
-				"min" : 6
+				"max" : 9,
+				"min" : 7
 			},
 			{
 				"creature" : "armadillo",

--- a/hota/Mods/factory/content/config/hota/factory/heroes/bertram.json
+++ b/hota/Mods/factory/content/config/hota/factory/heroes/bertram.json
@@ -7,7 +7,7 @@
 			"name" : "Bertram",
 			"biography" : "Few dwarves are capable of not just making a fortune, but also of making it work. Bertram left his father's house as soon as his beard grew two fingers long. Wandering around Antbertramich, he grew fabulously rich through investing in alchemical and magical ventures. His gold paid for the embodiment of many ideas that today underpin Burton's power.",
 			"specialty" : {
-				"tooltip" : "No description",
+				"tooltip" : "Resource Bonus: Gold",
 				"name" : "+350 Gold",
 				"description" : "Increases kingdom's income by 350 gold per day."
 			}
@@ -28,8 +28,8 @@
 			},
 			{
 				"creature" : "hotaMechanic",
-				"max" : 8,
-				"min" : 6
+				"max" : 9,
+				"min" : 7
 			},
 			{
 				"creature" : "armadillo",
@@ -53,7 +53,7 @@
 
 		"specialty" : {
 			"bonuses" : {
-				"gems" : {
+				"gold" : {
 					"subtype" : "gold",
 					"type" : "GENERATE_RESOURCE",
 					"val" : 350

--- a/hota/Mods/factory/content/config/hota/factory/heroes/celestine.json
+++ b/hota/Mods/factory/content/config/hota/factory/heroes/celestine.json
@@ -7,9 +7,9 @@
 			"name" : "Celestine",
 			"biography" : "The AvLeean druid who had lost his grove traversed the wold, imparting knowledge on anyone who sought it. He left the secrets of natural magic and his daughter Mirlanda in Tatalia, whilst in Eeofol, Celestine was born, inheriting another facet of his talent. Her father taught her how to tame the most violent beasts, offering them friendship, rather than the Tatalian beastmasters' trademark ruthless treatment.",
 			"specialty" : {
-				"tooltip" : "No description",
+				"tooltip" : "Creature Bonus: Armadillos",
 				"name" : "Armadillos",
-				"description" : "Increases Speed of any Armadillos or Bellwether Armadillos by 1 and their Attack and Defense skills by 5% for every 3 levels (rounded up)."
+				"description" : "Increases the Speed of allied Armadillos and Bellwether Armadillos by 1 and their Attack and Defense skills by 5% for every 3 levels (rounded up)."
 			}
 		},
 

--- a/hota/Mods/factory/content/config/hota/factory/heroes/dury.json
+++ b/hota/Mods/factory/content/config/hota/factory/heroes/dury.json
@@ -8,7 +8,7 @@
 			"biography" : "Dury spent the longest time in search for a magician who would not just promise to, but actually eliminate the repercussions of wounds she had sustained in dozens of clashes. One excellent blacksmith was able to forge a siertal plate to replace the part of her skull caved in by a wyvern's tail, and the mercenary now values fine armor far more than any magical malarkey.",
 			"specialty" : {
 				"description" : "Receives a 5% per level bonus to Armorer skill percentage.",
-				"tooltip" : "{Armorer}\r\n\r\nReceives a 5% per level bonus to Armorer skill percentage.",
+				"tooltip" : "Skill Bonus: Armorer",
 				"name" : "Armorer"
 			}
 		},
@@ -28,8 +28,8 @@
 			},
 			{
 				"creature" : "hotaMechanic",
-				"max" : 8,
-				"min" : 6
+				"max" : 9,
+				"min" : 7
 			},
 			{
 				"creature" : "armadillo",

--- a/hota/Mods/factory/content/config/hota/factory/heroes/eanswythe.json
+++ b/hota/Mods/factory/content/config/hota/factory/heroes/eanswythe.json
@@ -7,7 +7,7 @@
 			"name" : "Eanswythe",
 			"biography" : "According to hearsay, it was Eanswythe who concocted the potion that poisoned Regna's first emperor Hareck before fleeing for Jadame. If that is indeed the case, then she must be at least 6 centuries old. Ordinary people don't live that long, and whoever his enigmatic crone is, everyone knows: she merely has to raise an eyebrow to make even those most formidable solders drop their swords and spears.",
 			"specialty" : {
-				"tooltip" : "No description",
+				"tooltip" : "Spell Bonus: Weakness",
 				"name" : "Weakness",
 				"description" : "Casts Weakness with effect increased by 3 for 1-2 level creatures, by 2 for 3-4 level creatures, and by 1 for 5-6 level creatures."
 			}
@@ -28,8 +28,8 @@
 			},
 			{
 				"creature" : "hotaMechanic",
-				"max" : 8,
-				"min" : 6
+				"max" : 9,
+				"min" : 7
 			},
 			{
 				"creature" : "armadillo",

--- a/hota/Mods/factory/content/config/hota/factory/heroes/elderian.json
+++ b/hota/Mods/factory/content/config/hota/factory/heroes/elderian.json
@@ -8,9 +8,9 @@
 			"name" : "Elderian",
 			"biography" : "Elderian is a defender of Burton once Kastore took control.",
 			"specialty" : {
-				"tooltip" : "No description",
+				"tooltip" : "Creature Bonus: Automatons",
 				"name" : "Automatons",
-				"description" : "Increases Speed of any Automatons or Sentinel Automatons by 1 and their Attack and Defense skills by 5% for every 4 levels (rounded up)."
+				"description" : "Increases the Speed of allied Automatons and Sentinel Automatons by 1 and their Attack and Defense skills by 5% for every 4 levels (rounded up)."
 			}
 		},
 

--- a/hota/Mods/factory/content/config/hota/factory/heroes/floribert.json
+++ b/hota/Mods/factory/content/config/hota/factory/heroes/floribert.json
@@ -8,7 +8,7 @@
 			"biography" : "Floribert is regarded as one of Enroth's finest field surgeons, having introduced numerous new tools that speed up manipulations and therefore alleviate the suffering of the wounded. Floribert gets a steady supply of practicing material from his girlfriend Victoria's experiments.",
 			"specialty" : {
 				"description" : "Receives a 5% per level bonus to First Aid Tent healing efficiency.",
-				"tooltip" : "{First Aid}\r\n\r\nReceives a 5% per level bonus to First Aid Tent healing efficiency.",
+				"tooltip" : "Skill Bonus: First Aid",
 				"name" : "First Aid"
 			}
 		},

--- a/hota/Mods/factory/content/config/hota/factory/heroes/frederick.json
+++ b/hota/Mods/factory/content/config/hota/factory/heroes/frederick.json
@@ -8,9 +8,9 @@
 			"name" : "Frederick",
 			"biography" : "Frederick has been living the life of an ordinary Bracadian mage and alchemist, even if he has been a bit more curious than his fellows. Such curiosity made him experiment with mechanisms first, and then conduct forbidden research. As a result, Frederick had to flee from Bracada, and now he searches for a better place to devote himself to what he wants.",
 			"specialty" : {
-				"tooltip" : "No description",
+				"tooltip" : "Creature Bonus: Automatons",
 				"name" : "Automatons",
-				"description" : "Increases damage dealt by explosion of Automatons and Sentinel Automatons by 5% for every level (rounded up)."
+				"description" : "Increases the Speed of allied Automatons and Sentinel Automatons by 1 and their Attack and Defense skills by 5% for every 4 levels (rounded up)."
 			}
 		},
 

--- a/hota/Mods/factory/content/config/hota/factory/heroes/henrietta.json
+++ b/hota/Mods/factory/content/config/hota/factory/heroes/henrietta.json
@@ -7,8 +7,8 @@
 			"name" : "Henrietta",
 			"biography" : "Even a humble halfling from the Eeofol backwoods is capable of a feat when an unprecedented calamity knocks at the door. The new world, devoid of thatched roofs, carrot beds, or the incessant grumbling of geezers, has changed Henrietta, and she is now ready to change it herself. Kreegan fire reduces her homeland to ashes and scorched her heart, but she used it to forge herself a steel will.",
 			"specialty" : {
-				"description" : "Increases the Speed of any Halflings and Halfling Grenadiers by 1 and their Attack and Defense skills by 5% for every level (rounded up).",
-				"tooltip" : "Bonus: creature",
+				"description" : "Increases the Speed of allied Halflings and Halfling Grenadiers by 1 and their Attack and Defense skills by 5% for every level (rounded up).",
+				"tooltip" : "Creature Bonus: Halflings",
 				"name" : "Halflings"
 			}
 		},

--- a/hota/Mods/factory/content/config/hota/factory/heroes/jangaard.json
+++ b/hota/Mods/factory/content/config/hota/factory/heroes/jangaard.json
@@ -8,9 +8,9 @@
 			"name" : "Jangaard",
 			"biography" : "Jangaard is a defender of Burton once Kastore took control.",
 			"specialty" : {
-				"description" : "Increases the Speed of any Gunslingers and Bounty Hunters by 1 and their Attack and Defense skills by 5% for every 6 levels (rounded up).",
-				"tooltip" : "Bonus: creature",
-				"name" : "Gunslinger"
+				"description" : "Increases the Speed of allied Gunslingers and Bounty Hunters by 1 and their Attack and Defense skills by 5% for every 6 levels (rounded up).",
+				"tooltip" : "Creature Bonus: Gunslingers",
+				"name" : "Gunslingers"
 			}
 		},
 
@@ -29,8 +29,8 @@
 			},
 			{
 				"creature" : "hotaMechanic",
-				"max" : 8,
-				"min" : 6
+				"max" : 9
+				"min" : 7
 			},
 			{
 				"creature" : "armadillo",

--- a/hota/Mods/factory/content/config/hota/factory/heroes/jangaard.json
+++ b/hota/Mods/factory/content/config/hota/factory/heroes/jangaard.json
@@ -29,7 +29,7 @@
 			},
 			{
 				"creature" : "hotaMechanic",
-				"max" : 9
+				"max" : 9,
 				"min" : 7
 			},
 			{

--- a/hota/Mods/factory/content/config/hota/factory/heroes/melchior.json
+++ b/hota/Mods/factory/content/config/hota/factory/heroes/melchior.json
@@ -8,7 +8,7 @@
 			"biography" : "Melchior can see everything that is going on in the deepest recesses of someone else's mind. This secret talent provides a crucial advantage when assessing the foe's strength and intentions and convincing him to agree to terms. Any prince who enlists Melchior's services can be certain of never having to plead for a disgraceful peace.",
 			"specialty" : {
 				"description" : "Receives a 5% per level bonus to Diplomacy skill percentage when surrendering.",
-				"tooltip" : "Bonus: creature",
+				"tooltip" : "Skill Bonus: Diplomacy",
 				"name" : "Diplomacy"
 			}
 		},
@@ -28,8 +28,8 @@
 			},
 			{
 				"creature" : "hotaMechanic",
-				"max" : 8,
-				"min" : 6
+				"max" : 9,
+				"min" : 7
 			},
 			{
 				"creature" : "armadillo",

--- a/hota/Mods/factory/content/config/hota/factory/heroes/morton.json
+++ b/hota/Mods/factory/content/config/hota/factory/heroes/morton.json
@@ -7,8 +7,8 @@
 			"name" : "Morton",
 			"biography" : "Morton, a veteran of Goblin-Ogre Wars and one of the few who survived the assault on Gowdar Deep, vowed vengeance on the 'dirtskins' for the massacre that wiped his home off the face of Jadame. He gauges the quality of his ballistae by the number of ogres they can piece with a single shot.",
 			"specialty" : {
-				"description" : "Increases the Attack and Defense skills of any Ballista by 5% for every 5 levels (rounded up).",
-				"tooltip" : "Increases the Attack and Defense skills of any Ballista by 5% for every 5 levels (rounded up).",
+				"description" : "Increases the Ballista's Attack and Defense skills by 5% for every 5 levels (rounded up).",
+				"tooltip" : "Artillery Bonus: Ballista",
 				"name" : "Ballista"
 			}
 		},
@@ -49,7 +49,8 @@
 		],
 
 		"specialty" : {
-			"creature" : "ballista"
+			"creature" : "ballista",
+			"creatureLevel" : 5
 		}
 	}
 }

--- a/hota/Mods/factory/content/config/hota/factory/heroes/murdoch.json
+++ b/hota/Mods/factory/content/config/hota/factory/heroes/murdoch.json
@@ -8,7 +8,7 @@
 			"name" : "Murdoch",
 			"biography" : "Murdoch is a man to call a professional soldier of fortune. He barely likes anything more than money and fame. That is why Murdoch gathered a company of daredevils of his own kind and went to seek adventures on the landscapes of Jadame. Who knows where his fate will take him next time?",
 			"specialty" : {
-				"tooltip" : "No description",
+				"tooltip" : "Skill Bonus: Archery",
 				"name" : "Archery",
 				"description" : "Receives a 5% per level bonus to Archery skill percentage."
 			}
@@ -29,8 +29,8 @@
 			},
 			{
 				"creature" : "hotaMechanic",
-				"max" : 8,
-				"min" : 6
+				"max" : 9,
+				"min" : 7
 			},
 			{
 				"creature" : "armadillo",

--- a/hota/Mods/factory/content/config/hota/factory/heroes/sam.json
+++ b/hota/Mods/factory/content/config/hota/factory/heroes/sam.json
@@ -7,9 +7,9 @@
 			"name" : "Sam",
 			"biography" : "Since ancient times, earth oil has wreaked havoc on the farmers of Jadame, erupting in fountains and laying waste to their crops and pastures. Sam, the daughter and apprentice of a skilled blacksmith, was the first to tame this black beast by forcing it into a pipe and making it heat her forge. Her inventions made earth oil into Burton's blood, food, and arms.",
 			"specialty" : {
-				"description" : "Increases the Speed of any Mechanics and Engineers by 1 and their Attack and Defense skills by 5% for every 2 levels (rounded up).",
-				"tooltip" : "Bonus: creature",
-				"name" : "Mechanic"
+				"description" : "Increases the Speed of allied Mechanics and Engineers by 1 and their Attack and Defense skills by 5% for every 2 levels (rounded up).",
+				"tooltip" : "Creature Bonus: Mechanics",
+				"name" : "Mechanics"
 			}
 		},
 
@@ -23,18 +23,18 @@
 		"army" : [
 			{
 				"creature" : "hotaMechanic",
-				"max" : 6,
-				"min" : 4
+				"max" : 9,
+				"min" : 7
 			},
 			{
 				"creature" : "hotaMechanic",
-				"max" : 6,
-				"min" : 4
+				"max" : 9,
+				"min" : 7
 			},
 			{
 				"creature" : "hotaMechanic",
-				"max" : 6,
-				"min" : 4
+				"max" : 9,
+				"min" : 7
 			}
 		],
 		"skills" : [

--- a/hota/Mods/factory/content/config/hota/factory/heroes/stina.json
+++ b/hota/Mods/factory/content/config/hota/factory/heroes/stina.json
@@ -8,9 +8,9 @@
 			"name" : "Stina",
 			"biography" : "Stina is a defender of Burton once Kastore took control.",
 			"specialty" : {
-				"description" : "Increases the Speed of any Mechanics and Engineers by 1 and their Attack and Defense skills by 5% for every 2 levels (rounded up).",
-				"tooltip" : "Bonus: creature",
-				"name" : "Mechanic"
+				"description" : "Increases the Speed of allied Mechanics and Engineers by 1 and their Attack and Defense skills by 5% for every 2 levels (rounded up).",
+				"tooltip" : "Creature Bonus: Mechanics",
+				"name" : "Mechanics"
 			}
 		},
 
@@ -24,18 +24,18 @@
 		"army" : [
 			{
 				"creature" : "hotaMechanic",
-				"max" : 6,
-				"min" : 4
+				"max" : 9,
+				"min" : 7
 			},
 			{
 				"creature" : "hotaMechanic",
-				"max" : 6,
-				"min" : 4
+				"max" : 9,
+				"min" : 7
 			},
 			{
 				"creature" : "hotaMechanic",
-				"max" : 6,
-				"min" : 4
+				"max" : 9,
+				"min" : 7
 			}
 		],
 		"skills" : [

--- a/hota/Mods/factory/content/config/hota/factory/heroes/tancred.json
+++ b/hota/Mods/factory/content/config/hota/factory/heroes/tancred.json
@@ -7,9 +7,9 @@
 			"name" : "Tancred",
 			"biography" : "Back in his alchemist days, Tancred discovered an ancient recipe for a concoction that exploded without the use of magic. To his great dismay, the crucial component - saltpeter - was nearly entirely absent from Antagarich. Only in Jadame did Tancred discover vast caves full of this rare element and perfect the design of the arquebus that hurls tiny bullets with this awesome power.",
 			"specialty" : {
-				"description" : "Increases the Speed of any Gunslingers and Bounty Hunters by 1 and their Attack and Defense skills by 5% for every 6 levels (rounded up).",
-				"tooltip" : "Bonus: creature",
-				"name" : "Gunslinger"
+				"description" : "Increases the Speed of allied Gunslingers and Bounty Hunters by 1 and their Attack and Defense skills by 5% for every 6 levels (rounded up).",
+				"tooltip" : "Creature Bonus: Gunslingers",
+				"name" : "Gunslingers"
 			}
 		},
 
@@ -28,8 +28,8 @@
 			},
 			{
 				"creature" : "hotaMechanic",
-				"max" : 8,
-				"min" : 6
+				"max" : 9,
+				"min" : 7
 			},
 			{
 				"creature" : "armadillo",

--- a/hota/Mods/factory/content/config/hota/factory/heroes/tavin.json
+++ b/hota/Mods/factory/content/config/hota/factory/heroes/tavin.json
@@ -8,9 +8,9 @@
 			"name" : "Tavin",
 			"biography" : "Tavin is barely the only halflings who joined the army of Erathia. Other halflings disapprove his way of living as these creatures do not like adventures. However, his folks respect him, even if they fear a bit and tend to avoid him. When Kreegans invaded Eeofol, Tavin quickly became a leader of local resistances, and is still ready to defend his homeland.",
 			"specialty" : {
-				"description" : "Receives a 5% per level bonus to Offence skill percentage.",
-				"tooltip" : "Receives a 5% per level bonus to Offence skill.",
-				"name" : "Offence"
+				"description" : "Receives a 5% per level bonus to Offense skill percentage.",
+				"tooltip" : "Skill Bonus: Offense",
+				"name" : "Offense"
 			}
 		},
 
@@ -29,8 +29,8 @@
 			},
 			{
 				"creature" : "hotaMechanic",
-				"max" : 8,
-				"min" : 6
+				"max" : 9,
+				"min" : 7
 			},
 			{
 				"creature" : "armadillo",

--- a/hota/Mods/factory/content/config/hota/factory/heroes/todd.json
+++ b/hota/Mods/factory/content/config/hota/factory/heroes/todd.json
@@ -7,9 +7,9 @@
 			"name" : "Todd",
 			"biography" : "Few Bracadan scientists have actually seen, let alone handled, a hammer or a furnace. Todd, however, had to learn how to use them, unable to convey his esoteric ideas to blacksmiths and coppersmiths. There was also a scarcity of instruments and materials vital to his research in Bracada; Todd journeyed halfway around the world in search of them before finding what he sought in Burton.",
 			"specialty" : {
-				"tooltip" : "No description",
+				"tooltip" : "Creature Bonus: Automatons",
 				"name" : "Automatons",
-				"description" : "Increases Speed of any Automatons or Sentinel Automatons by 1 and their Attack and Defense skills by 5% for every 4 levels (rounded up)."
+				"description" : "Increases the Speed of allied Automatons and Sentinel Automatons by 1 and their Attack and Defense skills by 5% for every 4 levels (rounded up)."
 			}
 		},
 

--- a/hota/Mods/factory/content/config/hota/factory/heroes/umender.json
+++ b/hota/Mods/factory/content/config/hota/factory/heroes/umender.json
@@ -8,9 +8,9 @@
 			"name" : "Umender",
 			"biography" : "Umender is a defender of Burton once Kastore took control.",
 			"specialty" : {
-				"tooltip" : "No description",
+				"tooltip" : "Creature Bonus: Automatons",
 				"name" : "Automatons",
-				"description" : "Increases damage dealt by explosion of Automatons and Sentinel Automatons by 5% for every level (rounded up)."
+				"description" : "Increases the Speed of allied Automatons and Sentinel Automatons by 1 and their Attack and Defense skills by 5% for every 4 levels (rounded up)."
 			}
 		},
 

--- a/hota/Mods/factory/content/config/hota/factory/heroes/valquest.json
+++ b/hota/Mods/factory/content/config/hota/factory/heroes/valquest.json
@@ -9,7 +9,7 @@
 			"biography" : "Valquest is a defender of Burton once Kastore took control.",
 			"specialty" : {
 				"description" : "Receives a 5% per level bonus to First Aid Tent healing efficiency.",
-				"tooltip" : "Receives a 5% per level bonus to First Aid Tent healing efficiency.",
+				"tooltip" : "Skill Bonus: First Aid",
 				"name" : "First Aid"
 			}
 		},

--- a/hota/Mods/factory/content/config/hota/factory/heroes/victoria.json
+++ b/hota/Mods/factory/content/config/hota/factory/heroes/victoria.json
@@ -7,9 +7,9 @@
 			"name" : "Victoria",
 			"biography" : "Higher magic can restore the dead, but can a simple infantryman who stepped on a landmine count on having someone work it on him? Victoria's fascination with such an insidious weapon did not earn her colleagues' respect, yet she committed her life to perfecting it. After meeting Floribert, the inventor found another use for her engineering knowledge, designing mechanical limbs for crippled warriors.",
 			"specialty" : {
-				"tooltip" : "No description",
+				"tooltip" : "Spell Bonus: Land Mine",
 				"name" : "Land Mine",
-				"description" : "Casts Land Mine with damage increased by 3% for every n hero levels, where n is the level of the targeted creature."
+				"description" : "Casts Land Mine with damage increased by 3% for every N hero levels, where N is the level of the creature stepping into the mine."
 			}
 		},
 
@@ -28,8 +28,8 @@
 			},
 			{
 				"creature" : "hotaMechanic",
-				"max" : 8,
-				"min" : 6
+				"max" : 9,
+				"min" : 7
 			},
 			{
 				"creature" : "armadillo",
@@ -53,10 +53,10 @@
 
 		"specialty" : {
 			"bonuses" : {
-				"frostRing" : {
-					"subtype" : "spell.landMine",
+				"landMine" : {
+					"subtype" : "spell.landMineTrigger",
 					"type" : "SPECIAL_SPELL_LEV",
-					"updater" : "TIMES_HERO_LEVEL",
+					"updater" : "TIMES_HERO_LEVEL_DIVIDE_STACK_LEVEL",
 					"val" : 3
 				}
 			}

--- a/hota/Mods/factory/content/config/hota/factory/heroes/winzells.json
+++ b/hota/Mods/factory/content/config/hota/factory/heroes/winzells.json
@@ -8,9 +8,9 @@
 			"name" : "Winzells",
 			"biography" : "Winzells is a defender of Burton once Kastore took control.",
 			"specialty" : {
-				"description" : "Receives a 5% per level bonus to Offence skill percentage.",
-				"tooltip" : "Receives a 5% per level bonus to Offence skill.",
-				"name" : "Offence"
+				"description" : "Receives a 5% per level bonus to Offense skill percentage.",
+				"tooltip" : "Skill Bonus: Offense",
+				"name" : "Offense"
 			}
 		},
 
@@ -29,8 +29,8 @@
 			},
 			{
 				"creature" : "hotaMechanic",
-				"max" : 8,
-				"min" : 6
+				"max" : 9,
+				"min" : 7
 			},
 			{
 				"creature" : "armadillo",

--- a/hota/Mods/factory/content/config/hota/factory/heroes/wrathmont.json
+++ b/hota/Mods/factory/content/config/hota/factory/heroes/wrathmont.json
@@ -7,9 +7,9 @@
 			"name" : "Wrathmont",
 			"biography" : "Wrathmont's volatile temper got him into countless problems in his life, most notably during the carve-up of Archibald Ironfist's estate, when former colleagues banded together against the warlock, weary of his tantrums. Barely escaping them, Wrathmont fled Enroth. He spent years searching for and studying old stone tablets, learning to control his fury and stoke it in others instead.",
 			"specialty" : {
-				"tooltip" : "No description",
+				"tooltip" : "Spell Bonus: Frenzy",
 				"name" : "Frenzy",
-				"description" : "Casts Frenzy with Attack bonus increased by 3% for ever n hero levels, where n is the level of the targeted creature."
+				"description" : "Casts Frenzy with effect increased by 3% for every N hero levels, where N is the level of the target creature."
 			}
 		},
 
@@ -28,8 +28,8 @@
 			},
 			{
 				"creature" : "hotaMechanic",
-				"max" : 8,
-				"min" : 6
+				"max" : 9,
+				"min" : 7
 			},
 			{
 				"creature" : "armadillo",
@@ -56,7 +56,7 @@
 				"frenzy" : {
 					"subtype" : "spell.frenzy",
 					"type" : "SPECIAL_SPELL_LEV",
-					"updater" : "TIMES_HERO_LEVEL",
+					"updater" : "TIMES_HERO_LEVEL_DIVIDE_STACK_LEVEL",
 					"val" : 3
 				}
 			}

--- a/hota/Mods/factory/content/config/hota/factory/heroes/wynona.json
+++ b/hota/Mods/factory/content/config/hota/factory/heroes/wynona.json
@@ -8,7 +8,7 @@
 			"biography" : "Jadamean dark elves' natural element is the towns and deserts they cross with their caravans. Wynona, however, had always preferred exploring the wilderness outside Alvar and the Murmurwoods, tracking animals and taking notes of their habits. She eventually became the foremost authority on Jadamean fauna, having learned a great deal from her flying, crawling, and hopping friends.",
 			"specialty" : {
 				"description" : "Increases Scouting radius by 1 for every 6 levels.",
-				"tooltip" : "Increases Scouting radius by 1 for every 6 levels.",
+				"tooltip" : "Skill Bonus: Scouting",
 				"name" : "Scouting"
 			}
 		},
@@ -28,8 +28,8 @@
 			},
 			{
 				"creature" : "hotaMechanic",
-				"max" : 8,
-				"min" : 6
+				"max" : 9,
+				"min" : 7
 			},
 			{
 				"creature" : "armadillo",

--- a/hota/Mods/factory/content/config/hota/factory/heroes/ziph.json
+++ b/hota/Mods/factory/content/config/hota/factory/heroes/ziph.json
@@ -7,9 +7,9 @@
 			"name" : "Ziph",
 			"biography" : "Ziph had long served as a maid to an old mage who looked down on her and her kin. The wizard had no idea that 'ziph' meant 'freedom' in Gremlish, much less did he suspect that she was listening in on his lectures. One day, Ziph crammed half of her master's lab into a magic bag, hid in a ship's hold, and fled Bracada for good.",
 			"specialty" : {
-				"tooltip" : "No description",
+				"tooltip" : "Spell Bonus: Lightning Bolt",
 				"name" : "Lightning Bolt",
-				"description" : "Casts Lightning with damage increased by 3% for every n hero levels, where n is the level of the targeted creature."
+				"description" : "Casts Lightning Bolt with damage increased by 3% for every N hero levels, where N is the level of the target creature."
 			}
 		},
 
@@ -28,8 +28,8 @@
 			},
 			{
 				"creature" : "hotaMechanic",
-				"max" : 8,
-				"min" : 6
+				"max" : 9,
+				"min" : 7
 			},
 			{
 				"creature" : "armadillo",
@@ -53,10 +53,10 @@
 
 		"specialty" : {
 			"bonuses" : {
-				"frostRing" : {
+				"lightningBolt" : {
 					"subtype" : "spell.lightningBolt",
 					"type" : "SPECIAL_SPELL_LEV",
-					"updater" : "TIMES_HERO_LEVEL",
+					"updater" : "TIMES_HERO_LEVEL_DIVIDE_STACK_LEVEL",
 					"val" : 3
 				}
 			}

--- a/hota/Mods/factory/content/config/hota/factory/town/town.json
+++ b/hota/Mods/factory/content/config/hota/factory/town/town.json
@@ -426,13 +426,7 @@
 					},
 					"upgrades" : "dwellingLvl3",
 					"requires" : [
-						"allOf",
-						[
-							"fort"
-						],
-						[
-							"dwellingLvl3"
-						]
+						"dwellingLvl3"
 					]
 				},
 				"horde1Upgr" : {
@@ -474,7 +468,10 @@
 					"cost" : {
 						"gold" : 1000,
 						"ore" : 5
-					}
+					},
+					"requires" : [
+						"fort"
+					]
 				},
 				"grail" : {
 					"description" : "The presence of the Lightning Rod increases weekly creature generation by 50%, provides your empire with an additional 5000 gold each day.Strikes all enemy stacks with lightning at the beginning of every battle the player participates in, anywhere on the map.",
@@ -492,7 +489,7 @@
 					"description" : "The Halfling Adobe allows you to recruit Halflings.",
 					"name" : "Halfling Adobe",
 					"cost" : {
-						"gold" : 400,
+						"gold" : 500,
 						"wood" : 5,
 						"ore" : 5
 					},
@@ -509,13 +506,7 @@
 						"ore" : 5
 					},
 					"requires" : [
-						"allOf",
-						[
-							"fort"
-						],
-						[
-							"blacksmith"
-						]
+						"dwellingLvl1"
 					]
 				},
 				"dwellingLvl3" : {
@@ -558,11 +549,11 @@
 						"crystal" : 2
 					},
 					"requires" : [
-						"dwellingLvl2"
+						"dwellingLvl3"
 					]
 				},
 				"dwellingLvl6" : {
-					"description" : "The Watchtower allows you to recruit Gunslinger.",
+					"description" : "The Watchtower allows you to recruit Gunslingers.",
 					"name" : "Watchtower",
 					"cost" : {
 						"gold" : 4000,
@@ -572,13 +563,7 @@
 						"mercury" : 5
 					},
 					"requires" : [
-						"allOf",
-						[
-							"blacksmith"
-						],
-						[
-							"dwellingLvl4"
-						]
+						"dwellingLvl4"
 					]
 				},
 				"dwellingLvl7" : {
@@ -591,31 +576,25 @@
 						"crystal" : 10
 					},
 					"requires" : [
-						"dwellingLvl5"
+						"allOf",
+						[
+							"dwellingLvl5"
+						],
+						[
+							"mageGuild1"
+						]
 					]
 				},
 				"dwellingLvl8" : {
 					"description" : "The Gantry allows you to recruit Dreadnoughts.",
 					"name" : "Gantry",
 					"cost" : {
-						"gold" : 15000,
+						"gold" : 10000,
 						"ore" : 20,
 						"crystal" : 20
 					},
 					"requires" : [
-						"allOf",
-						[
-							"marketplace"
-						],
-						[
-							"blacksmith"
-						],
-						[
-							"dwellingLvl4"
-						],
-						[
-							"dwellingLvl6"
-						]
+						"dwellingLvl6"
 					]
 				},
 				"dwellingUpLvl1" : {
@@ -623,11 +602,11 @@
 					"name" : "Upg. Halfling Adobe",
 					"cost" : {
 						"gold" : 1000,
-						"mercury" : 2,
-						"sulfur" : 2
+						"mercury" : 5,
+						"sulfur" : 5
 					},
 					"requires" : [
-						"tavern"
+						"blacksmith"
 					],
 					"upgrades" : "dwellingLvl1"
 				},
@@ -635,10 +614,13 @@
 					"description" : "The Foundry allows you to recruit Engineers.",
 					"name" : "Upg. Foundry",
 					"cost" : {
-						"gold" : 1500,
+						"gold" : 1000,
 						"wood" : 5,
 						"ore" : 5
 					},
+					"requires" : [
+						"blacksmith"
+					],
 					"upgrades" : "dwellingLvl2"
 				},
 				"dwellingUpLvl3" : {
@@ -661,12 +643,15 @@
 					"upgrades" : "dwellingLvl4"
 				},
 				"dwellingUpLvl5" : {
-					"description" : "The Catacombs allows you to recruit Olgoi-Khorkhois.",
+					"description" : "The Catacombs allows you to recruit Olgoi-Khorkhoi.",
 					"name" : "Upg. Catacombs",
 					"cost" : {
 						"gold" : 2000,
 						"gems" : 5
 					},
+					"requires" : [
+						"mageGuild1"
+					],
 					"upgrades" : "dwellingLvl5"
 				},
 				"dwellingUpLvl6" : {
@@ -678,6 +663,9 @@
 						"mercury" : 5,
 						"wood" : 10
 					},
+					"requires" : [
+						"marketplace"
+					],
 					"upgrades" : "dwellingLvl6"
 				},
 				"dwellingUpLvl7" : {
@@ -703,7 +691,7 @@
 						"crystal" : 20
 					},
 					"requires" : [
-						"resourceSilo"
+						"marketplace"
 					],
 					"upgrades" : "dwellingLvl8"
 				}


### PR DESCRIPTION
Alright, this is a general look over the Factory submod. The most apparent issues were Victoria's specialty and the building tree in the town. I mainly tried to make wording more consistent and nice.

Creatures:

+ Fixed Mechanic/Engineer minimum damage
+ Fixed Juggernaut cost and renamed field name of the KING_3 ability to make it more clear
    + Left the placeholder no-retaliation in
+ Plural of Olgoi-Khorkhoi has no "s"

Heroes:

+ Fixed Victoria's ability to affect the correct part of the spell
+ Fixed bonus updater for Ziph, Victoria and Wrathmont
+ Made specialty descriptions, names and tooltips consistent in wording
+ Adjusted the stack size of Mechanics in starting armies

Town:

+ Fixed incorrect or missing building requirements
+ Corrected some prices
+ Fixed typos where I found them