### PR TITLE
Remove 'hota.newgraphics' from mod.json

### DIFF
--- a/hota/Mods/mapSupport/mod.json
+++ b/hota/Mods/mapSupport/mod.json
@@ -20,7 +20,6 @@
 		"hota.mapobjects",
 		"hota.mapdecorations",
 		"hota.neutralcreatures",
-		"hota.newgraphics",
 		"hota.terrainoverlays",
 		"hota.highlandsterrain",
 		"hota.wastelandterrain"


### PR DESCRIPTION
Removed 'hota.newgraphics' from the mod dependencies.

To enable maps with `hd-edition`.

@misiokles 