### PR TITLE
Some small creature fixes

### DIFF
--- a/hota/Mods/gameBalance/mods/creatures/content/config/hotaGameBalance/creatures.json
+++ b/hota/Mods/gameBalance/mods/creatures/content/config/hotaGameBalance/creatures.json
@@ -2,9 +2,17 @@
 	"core:monk" : {
 		"aiValue" : 582
 	},
+	"core:devil" : {
+		"abilities" : {
+			"decreaseLuck" : {
+				"description" : "{Reduces enemy luck}\nDevils reduce enemy luck by one"
+			}
+		}
+	}
 	"core:archDevil" : {
 		"abilities" : {
 			"decreaseLuck" : {
+				"description" : "{Reduces enemy luck}\nArch Devils reduce enemy luck by two"
 				"val" : -2
 			}
 		}

--- a/hota/Mods/gameBalance/mods/creatures/content/config/hotaGameBalance/creatures.json
+++ b/hota/Mods/gameBalance/mods/creatures/content/config/hotaGameBalance/creatures.json
@@ -8,11 +8,11 @@
 				"description" : "{Reduces enemy luck}\nDevils reduce enemy luck by one"
 			}
 		}
-	}
+	},
 	"core:archDevil" : {
 		"abilities" : {
 			"decreaseLuck" : {
-				"description" : "{Reduces enemy luck}\nArch Devils reduce enemy luck by two"
+				"description" : "{Reduces enemy luck}\nArch Devils reduce enemy luck by two",
 				"val" : -2
 			}
 		}

--- a/hota/Mods/neutralCreatures/Mods/Bonuses icons/content/config/leprechaun.json
+++ b/hota/Mods/neutralCreatures/Mods/Bonuses icons/content/config/leprechaun.json
@@ -4,7 +4,8 @@
 			"castsFortune" : {
 				"icon" : "bonuses/fortune2.png"
 			},
-			"unbelievalbeLuck" : {
+			"unbelievableLuck" : {
+				"description" : "Doubles the Luck of allied units in battle.",
 				"icon" : "bonuses/doubleluck.png"
 			}
 		}

--- a/hota/Mods/neutralCreatures/content/config/hotaNeutralCreatures/leprechaun.json
+++ b/hota/Mods/neutralCreatures/content/config/hotaNeutralCreatures/leprechaun.json
@@ -39,17 +39,32 @@
 				"type" : "CREATURE_ENCHANT_POWER",
 				"val" : 6
 			},
-			"unbelievalbeLuck" : {
+			// FIXME: "unbelievableLuck" should only affect positive luck.
+			"unbelievableLuck" : {
 				"type" : "LUCK",
 				"val" : 100,
 				"valueType" : "PERCENT_TO_ALL",
+				"propagator" : "ARMY",
 				"limiters" : [
 					{
 						"type" : "HAS_ANOTHER_BONUS_LIMITER",
 						"bonusType" : "LUCK"
 					}
 				]
-			}
+			}//,
+			// my proposition of a workaround - disable negative luck; uncomment if okay
+		//	"noNegativeLuck" : {
+		//		"type" : "LUCK",
+		//		"val" : 0,
+		//		"valueType" : "INDEPENDENT_MAX",
+		//		"propagator" : "ARMY",
+		//		"limiters" : [
+		//			{
+		//				"type" : "HAS_ANOTHER_BONUS_LIMITER",
+		//				"bonusType" : "LUCK"
+		//			}
+		//		]
+		//	}
 		},
 		"graphics" : {
 			"iconSmall" : "hota/creatures/iconsSmall/CPrSm171",

--- a/hota/Mods/neutralCreatures/content/config/hotaNeutralCreatures/satyr.json
+++ b/hota/Mods/neutralCreatures/content/config/hotaNeutralCreatures/satyr.json
@@ -32,8 +32,8 @@
 				"val" : 2
 			},
 			"spellpower" : {
-				"type" : "CREATURE_SPELL_POWER",
-				"val" : 600
+				"type" : "CREATURE_ENCHANT_POWER",
+				"val" : 6
 			},
 			"spellpoints" : {
 				"type" : "CASTS",


### PR DESCRIPTION
submod gameBalance:
+ corrected the description of Devils' and Arch Devils' effects

submod neutralCreatures:
+ fixed Leprechaun's luck doubling ability
+ corrected Satyr's spell power

Leprechaun's ability also doubles negative luck chance as well. I believe this is incorrect and proposed a workaround for it in the leprechaun.json. It is commented out because I wasn't sure if that would be too big of a change.