### PR TITLE
Fixed cannon overriding ballista's extra damage

### DIFF
--- a/hota/Mods/cannon/Content/config/hotaCannon/artillery.json
+++ b/hota/Mods/cannon/Content/config/hotaCannon/artillery.json
@@ -3,12 +3,12 @@
 		"base" : {
 			"effects" : {
 				"cannonExtra" : {
-					"subtype" : "creature.cannon",
+					"subtype" : "hota.cannon:creature.cannon",
 					"type" : "BONUS_DAMAGE_CHANCE",
 					"valueType" : "BASE_NUMBER"
 				},
-				"damagePower" : {
-					"subtype" : "creature.cannon",
+				"damagePowerCannon" : {
+					"subtype" : "hota.cannon:creature.cannon",
 					"type" : "BONUS_DAMAGE_PERCENTAGE",
 					"valueType" : "BASE_NUMBER"
 				},
@@ -18,10 +18,11 @@
 					"limiters" : [
 						{
 							"type" : "CREATURE_TYPE_LIMITER",
-							"creature" : "cannon"
+							"creature" : "hota.cannon:creature.cannon"
 						}
 					],
-					"valueType" : "INDEPENDENT_MIN"
+					"valueType" : "INDEPENDENT_MIN",
+					"val" : 40
 				}
 			}
 		},
@@ -30,24 +31,18 @@
 				"cannonExtra" : {
 					"val" : 0
 				},
-				"damagePower" : {
+				"damagePowerCannon" : {
 					"val" : 0
-				},
-				"damageCapCannon" : {
-					"val" : 40
 				}
 			}
 		},
 		"advanced" : {
 			"effects" : {
 				"cannonExtra" : {
-					"val" : 75
-				},
-				"damagePower" : {
 					"val" : 100
 				},
-				"damageCapCannon" : {
-					"val" : 40
+				"damagePowerCannon" : {
+					"val" : 100
 				}
 			}
 		},
@@ -56,11 +51,8 @@
 				"cannonExtra" : {
 					"val" : 100
 				},
-				"damagePower" : {
+				"damagePowerCannon" : {
 					"val" : 200
-				},
-				"damageCapCannon" : {
-					"val" : 40
 				}
 			}
 		}


### PR DESCRIPTION
While investigating #97, I realized that there is an issue with how Artillery from the cannon submod adds the extra damage. It used core's `"damagePower"` field and changed the subtype there to the cannon. Thus, the Ballista was unable to do any 
bonus damage since its subtype was gone from the bonus. This PR fixes that by just making a separate field for the cannon damage. I also corrected the value for the chance on Advanced level, it should be guaranteed instead of 75%.

I couldn't find out why there is manual control without Artillery tho, everything seems fine in that regard...