### PR TITLE
1.7.2 faction changes

### DIFF
--- a/hota/Mods/gameBalance/mods/factions/content/config/hotaGameBalance/factions.json
+++ b/hota/Mods/gameBalance/mods/factions/content/config/hotaGameBalance/factions.json
@@ -182,5 +182,31 @@
 				}
 			}
 		}
+	},
+	"core:dungeon" : {
+		"town" : {
+			"buildings" : {
+				"dwellingLvl7": { 
+					"requires" : [ 
+						"allOf",
+						[ "mageGuild2" ],
+						[ "dwellingLvl4" ]
+					]
+				}
+			}
+		}
+	},
+	"core:rampart" : {
+		"town" : {
+			"buildings" : {
+				"dwellingLvl7": { 
+					"requires" : [ 
+						"allOf",
+						[ "mageGuild2" ],
+						[ "dwellingLvl5" ]
+					]
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
https://heroes.thelazy.net/index.php/Horn_of_the_Abyss_(Changelog)#Version_1.7.2_(31/DEC/2024)

[+] Building Dragon Cliffs and Upg. Dragon Cliffs no longer requires the Enchanted Spring and Unicorn Glade
[+] Building Dragon Cave and Upg. Dragon Cave no longer requires the Labyrinth and Manticore Lair