### PR TITLE
Added Learning submod

### DIFF
--- a/hota/Mods/gameBalance/mods/skills/mods/learning/content/config/hotaGameBalance/skills.json
+++ b/hota/Mods/gameBalance/mods/skills/mods/learning/content/config/hotaGameBalance/skills.json
@@ -1,0 +1,32 @@
+// 1.7.3:
+// [-] Learning experience bonus: 25/50/75% -> 20/40/60%.
+// 1.7.2:
+// [+] Learning increases the hero's experience gains by 25/50/75%.
+{
+	"core:learning" : {
+		"basic" : {
+			"description" : "{Basic Learning}\n\nBasic Learning increases the hero’s earned experience points by 20%.",
+			"effects" : {
+				"main" : {
+					"val" : 20
+				}
+			}
+		},
+		"advanced" : {
+			"description" : "{Advanced Learning}\n\nAdvanced Learning increases the hero’s earned experience points by 40%.",
+			"effects" : {
+				"main" : {
+					"val" : 40
+				}
+			}
+		},
+		"expert" : {
+			"description" : "{Expert Learning}\n\nExpert Learning increases the hero’s earned experience points by 60%.",
+			"effects" : {
+				"main" : {
+					"val" : 60
+				}
+			}
+		}
+	}
+}

--- a/hota/Mods/gameBalance/mods/skills/mods/learning/mod.json
+++ b/hota/Mods/gameBalance/mods/skills/mods/learning/mod.json
@@ -1,0 +1,12 @@
+{
+	"name" : "Learning",
+	"description" : "",
+	"modType" : "Mechanics",
+	"author" : "Kuririn, avatar, wnukos, Karyoplasma",
+	"contact" : "http://forum.df2.ru/index.php?showtopic=32286",
+	"version" : "1.0",
+
+	"skills" : [
+		"config/hotaGameBalance/skills.json"
+	]
+}


### PR DESCRIPTION
1.7.3:
[-] Learning experience bonus: 25/50/75% -> 20/40/60%.
1.7.2:
[+] Learning increases the hero's experience gains by 25/50/75%.

I used the 1.7.3 values. Feel free to change to 1.7.2

Edit: It does have the secondary effect to grant your hero a level-up on taking the skill. Dunno if this is possible in VCMI, but we can at least change the values.