### PR TITLE
Creature fight/ai values to 1.7.2

### DIFF
--- a/hota/Mods/gameBalance/mods/creatures/content/config/hotaGameBalance/creatures.json
+++ b/hota/Mods/gameBalance/mods/creatures/content/config/hotaGameBalance/creatures.json
@@ -73,8 +73,22 @@
 	"core:redDragon" : {
 		"aiValue" : 5003
 	},
+	"core:boneDragon" : {
+		"abilities" : {
+			"boneDragonSkeleton" : {
+				"type" : "SKELETON_TRANSFORMER_TARGET",
+				"subtype" : "creature.boneDragon"
+			}
+		}
+	},
 	"core:ghostDragon" : {
-		"aiValue" : 4919
+		"aiValue" : 4919,
+		"abilities" : {
+			"boneDragonSkeleton" : {
+				"type" : "SKELETON_TRANSFORMER_TARGET",
+				"subtype" : "creature.boneDragon"
+			}
+		}
 	},
 	"core:cyclopKing" : {
 		"aiValue" : 1544

--- a/hota/Mods/gameBalance/mods/creatures/content/config/hotaGameBalance/creatures.json
+++ b/hota/Mods/gameBalance/mods/creatures/content/config/hotaGameBalance/creatures.json
@@ -18,7 +18,8 @@
 		}
 	},
 	"core:efreetSultan" : {
-		"aiValue" : 2343
+		"aiValue" : 2343,
+		"fightValue" : 1802
 	},
 	"core:psychicElemental" : {
 		"cost" : {
@@ -48,6 +49,8 @@
 		}
 	},
 	"core:phoenix" : {
+		"horde" : 1,
+		"growth" : 1,
 		"cost" : {
 			"gold" : 3000
 		}
@@ -63,5 +66,32 @@
 	"core:lizardWarrior" : {
 		"fightValue" : 174,
 		"aiValue" : 209
+	},
+	"core:scorpicore" : {
+		"aiValue" : 1685
+	},
+	"core:redDragon" : {
+		"aiValue" : 5003
+	},
+	"core:ghostDragon" : {
+		"aiValue" : 4919
+	},
+	"core:cyclopKing" : {
+		"aiValue" : 1544
+	},
+	"core:naga" : {
+		"aiValue" : 1814
+	},
+	"core:sharpshooter" : {
+		"advMapAmount" : {
+			"min" : 10,
+			"max" : 16
+		}
+	},
+	"core:ballista" : {
+		// maybe ai decisions factor in gold cost, idk
+		"cost" : {
+			"gold" : 1500
+		}
 	}
 }

--- a/hota/Mods/gameBalance/mods/creatures/content/config/hotaGameBalance/creaturesCove.json
+++ b/hota/Mods/gameBalance/mods/creatures/content/config/hotaGameBalance/creaturesCove.json
@@ -1,0 +1,30 @@
+{
+	"hota.cove:pirate" : {
+		"fightValue" : 208,
+		"aiValue" : 312
+	},
+	"hota.cove:corsair" : {
+		"fightValue" : 311,
+		"aiValue" : 407
+	},
+	"hota.cove:seadog" : {
+		"fightValue" : 376,
+		"aiValue" : 602,
+		"advMapAmount" : {
+			"min" : 12,
+			"max" : 20
+		}
+	},
+	"hota.cove:nixWarrior" : {
+		"fightValue" : 1763,
+		"aiValue" : 2116
+	},
+	"hota.cannon:cannon" : {
+		// maybe ai decisions factor in gold cost, idk
+		"cost" : {
+			"gold" : 3000
+		},
+		"fightValue" : 900,
+		"aiValue" : 825
+	}
+}

--- a/hota/Mods/gameBalance/mods/creatures/content/config/hotaGameBalance/creaturesFactory.json
+++ b/hota/Mods/gameBalance/mods/creatures/content/config/hotaGameBalance/creaturesFactory.json
@@ -1,0 +1,49 @@
+{
+	"hota.factory:halflingGrenadier" : {
+		"fightValue" : 75
+	},
+	"hota.factory:hotaMechanic" : {
+		"fightValue" : 186
+	},
+	"hota.factory:hotaEngineer" : {
+		"fightValue" : 232
+	},
+	"hota.factory:armadillo" : {
+		"fightValue" : 248
+	},
+	"hota.factory:bellwetherArmadillo" : {
+		"fightValue" : 256
+	},
+	"hota.factory:automaton" : {
+		"aiValue" : 669,
+		"fightValue" : 398
+	},
+	"hota.factory:sentinelAutomaton" : {
+		"aiValue" : 947,
+		"fightValue" : 631
+	},
+	"hota.factory:sandworm" : {
+		"fightValue" : 793
+	},
+	"hota.factory:olgoiKhorkhoi" : {
+		"fightValue" : 894
+	},
+	"hota.factory:gunslinger" : {
+		"fightValue" : 904
+	},
+	"hota.factory:bountyHunter" : {
+		"fightValue" : 932
+	},
+	"hota.factory:hotaCouatl" : {
+		"fightValue" : 2521
+	},
+	"hota.factory:crimsonCouatl" : {
+		"fightValue" : 3815
+	},
+	"hota.factory:hotaDreadnought" : {
+		"fightValue" : 3879
+	},
+	"hota.factory:hotaJuggernaut" : {
+		"fightValue" : 5361
+	}
+}

--- a/hota/Mods/gameBalance/mods/creatures/mod.json
+++ b/hota/Mods/gameBalance/mods/creatures/mod.json
@@ -2,12 +2,18 @@
 	"name" : "Creatures",
 	"description" : "",
 	"modType" : "Mechanics",
-	"author" : "Kuririn, avatar, wnukos",
+	"author" : "Kuririn, avatar, wnukos, Karyoplasma",
 	"contact" : "http://forum.df2.ru/index.php?showtopic=32286",
 	"version" : "1.3.11",
-
+	"softDepends" : [
+		"hota.cove",
+		"hota.cannon",
+		"hota.factory"
+	],
 	"creatures" : [
-		"config/hotaGameBalance/creatures.json"
+		"config/hotaGameBalance/creatures.json",
+		"config/hotaGameBalance/creaturesCove.json",
+		"config/hotaGameBalance/creaturesFactory.json"
 	],
 
 	"chinese" : {

--- a/hota/Mods/neutralCreatures/content/config/hotaNeutralCreatures/fangarm.json
+++ b/hota/Mods/neutralCreatures/content/config/hotaNeutralCreatures/fangarm.json
@@ -17,8 +17,8 @@
 			"min" : 8,
 			"max" : 12
 		},
-		"fightValue" : 850,
-		"aiValue" : 900,
+		"fightValue" : 929,
+		"aiValue" : 929,
 		"advMapAmount" : {
 			"min" : 8,
 			"max" : 12

--- a/hota/Mods/neutralCreatures/content/config/hotaNeutralCreatures/satyr.json
+++ b/hota/Mods/neutralCreatures/content/config/hotaNeutralCreatures/satyr.json
@@ -17,8 +17,8 @@
 			"min" : 6,
 			"max" : 10
 		},
-		"fightValue" : 500,
-		"aiValue" : 550,
+		"fightValue" : 471,
+		"aiValue" : 518,
 		"advMapAmount" : {
 			"min" : 10,
 			"max" : 16


### PR DESCRIPTION
Everything I could find relating to creatures in the HotA changes.

+ Sharpshooter adventure map amount
    + cross-referenced from CRTRAITS.txt (HotA 1.7.2)
+ Satyr and Fangarm changes were so old (1.3.5 and 1.5.0 respectively) that I updated the neutralCreatures submod with them
    + values from HotA.dat (1.7.2) because I didn't trust the wiki because of mild (okay, maybe severe) paranoia (wiki was correct)
+ for the rest of the changes, I just referenced the wiki pages of the respective creatures

I kept the Cove and Factory creatures in separate files because I didn't know whether I should update that in the respective submod or in gameBalance.creatures.

Edit: Also incorporates this change from 1.7.0
[+] Bone and Ghost Dragons now transform into Bone Dragons in the Skeleton Converter