### PR TITLE
Made Elemental summon spells non-exclusive

### DIFF
--- a/hota/Mods/gameBalance/mods/spells/content/config/hotaGameBalance/spells.json
+++ b/hota/Mods/gameBalance/mods/spells/content/config/hotaGameBalance/spells.json
@@ -159,13 +159,18 @@
 	"core:fireElemental" : {
 		"levels" : {
 			"base" : {
-				"power" : 70,
 				"battleEffects" : {
 					"summon": {
 						"exclusive" : false,
 						"summonByHealth" : true
 					}
 				}
+			},
+			"none" : {
+				"power" : 70
+			},
+			"basic" : {
+				"power" : 70
 			},
 			"advanced" : {
 				"power" : 88
@@ -178,13 +183,18 @@
 	"core:earthElemental" : {
 		"levels" : {
 			"base" : {
-				"power" : 80,
 				"battleEffects" : {
 					"summon" : {
 						"exclusive" : false,
 						"summonByHealth" : true
 					}
 				}
+			},
+			"none" : {
+				"power" : 80
+			},
+			"basic" : {
+				"power" : 80
 			},
 			"advanced" : {
 				"power" : 100

--- a/hota/Mods/gameBalance/mods/spells/content/config/hotaGameBalance/spells.json
+++ b/hota/Mods/gameBalance/mods/spells/content/config/hotaGameBalance/spells.json
@@ -5,9 +5,6 @@
 			"base" : {
 				"effects" : {
 					"spellDamageReduction" : {
-						"type" : "SPELL_DAMAGE_REDUCTION",
-						"subtype" : "air",
-						"duration" : "N_TURNS",
 						"val" : 50
 					}
 				}
@@ -33,9 +30,6 @@
 			"base" : {
 				"effects" : {
 					"spellDamageReduction" : {
-						"type" : "SPELL_DAMAGE_REDUCTION",
-						"subtype" : "earth",
-						"duration" : "N_TURNS",
 						"val" : 50
 					}
 				}
@@ -61,9 +55,6 @@
 			"base" : {
 				"effects" : {
 					"spellDamageReduction" : {
-						"type" : "SPELL_DAMAGE_REDUCTION",
-						"subtype" : "fire",
-						"duration" : "N_TURNS",
 						"val" : 50
 					}
 				}
@@ -89,9 +80,6 @@
 			"base" : {
 				"effects" : {
 					"spellDamageReduction" : {
-						"type" : "SPELL_DAMAGE_REDUCTION",
-						"subtype" : "water",
-						"duration" : "N_TURNS",
 						"val" : 50
 					}
 				}
@@ -165,39 +153,64 @@
 			}
 		}
 	},
-
+	// 1.7.0
+	//[+] Lifted the ban on summoning different types of elementals in the same combat
+	//[+] Summoning Earth and Fire Elementals now has the power of [2/2/2.5/3] * SP
 	"core:fireElemental" : {
 		"levels" : {
+			"base" : {
+				"power" : 2,
+				"battleEffects" : {
+					"summon": {
+						"exclusive" : false
+					}
+				}
+			},
 			"advanced" : {
 				"power" : 3
 			},
-
-			"basic" : {
-				"power" : 2
-			},
 			"expert" : {
 				"power" : 3
-			},
-			"none" : {
-				"power" : 2
 			}
 		}
 	},
-
 	"core:earthElemental" : {
 		"levels" : {
+			"base" : {
+				"power" : 2,
+				"battleEffects" : {
+					"summon" : {
+						"exclusive" : false
+					}
+				}
+			},
 			"advanced" : {
 				"power" : 3
 			},
-
-			"basic" : {
-				"power" : 2
-			},
 			"expert" : {
 				"power" : 3
-			},
-			"none" : {
-				"power" : 2
+			}
+		}
+	},
+	"core:waterElemental" : {
+		"levels" : {
+			"base" : {
+				"battleEffects" : {
+					"summon" : {
+						"exclusive" : false
+					}
+				}
+			}
+		}
+	},
+	"core:airElemental" : {
+		"levels" : {
+			"base" : {
+				"battleEffects" : {
+					"summon" : {
+						"exclusive" : false
+					}
+				}
 			}
 		}
 	},

--- a/hota/Mods/gameBalance/mods/spells/content/config/hotaGameBalance/spells.json
+++ b/hota/Mods/gameBalance/mods/spells/content/config/hotaGameBalance/spells.json
@@ -159,36 +159,38 @@
 	"core:fireElemental" : {
 		"levels" : {
 			"base" : {
-				"power" : 2,
+				"power" : 70,
 				"battleEffects" : {
 					"summon": {
-						"exclusive" : false
+						"exclusive" : false,
+						"summonByHealth" : true
 					}
 				}
 			},
 			"advanced" : {
-				"power" : 3
+				"power" : 88
 			},
 			"expert" : {
-				"power" : 3
+				"power" : 105
 			}
 		}
 	},
 	"core:earthElemental" : {
 		"levels" : {
 			"base" : {
-				"power" : 2,
+				"power" : 80,
 				"battleEffects" : {
 					"summon" : {
-						"exclusive" : false
+						"exclusive" : false,
+						"summonByHealth" : true
 					}
 				}
 			},
 			"advanced" : {
-				"power" : 3
+				"power" : 100
 			},
 			"expert" : {
-				"power" : 3
+				"power" : 120
 			}
 		}
 	},


### PR DESCRIPTION
1.7.0
[+] Lifted the ban on summoning different types of elementals in the same combat

Also cleaned up the existing adjustments to make it easier to read. No functional change besides making Summoning X Elemental non-exclusive.