### PR TITLE
grail building, better placeholder for sieidi

### DIFF
--- a/hota/Mods/bulwark/content/config/hota/bulwark/town/buildings.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/town/buildings.json
@@ -82,13 +82,14 @@
 				},
 				"resourceSilo" : {
 					"name" : "Resource Silo",
-					"description" : "The Resource Silo provides you with an additional +1 gems each day.",
+					"description" : "The Resource Silo provides you with an additional +1 wood and +1 ore each day.",
 					"cost" : {
 						"gold" : 5000,
 						"ore" : 5
 					},
 					"produce" : {
-						"gems" : 1
+						"wood" : 1,
+						"ore" : 1
 					}
 				},
 				"shipyard" : {
@@ -113,8 +114,15 @@
 						"wood" : 5
 					},
 					"requires" : [
-						"marketplace"
-					]
+						"allOf",
+						[
+							"townHall"
+						],
+						[
+							"marketplace"
+						]
+					],
+					"marketModes" : ["resource-resource", "resource-player"]
 				},
 				"special2" : {
 					"name" : "Sieidi of Runes",
@@ -124,7 +132,15 @@
 						"ore" : 5,
 						"crystal" : 2,
 						"gems" : 2
-					}
+					},
+					// placeholder
+					"marketModes" : ["resource-skill"],
+					"marketOffer" : [
+						"runes",
+						"runes",
+						"runes",
+						"runes"
+					]
 				},
 				"special3" : {
 					"name" : "Altar of the Runes",
@@ -133,7 +149,8 @@
 						"gold" : 1000,
 						"crystal" : 2,
 						"gems" : 2
-					}
+					},
+					"upgrades" : "special2"
 				},
 				"horde1" : {
 					"name" : "Hay Bins",
@@ -155,8 +172,15 @@
 					]
 				},
 				"grail" : {
-					"name" : "Spirit of the Forebears",
-					"description" : "Grail Structure. +5000 Gold/day. +50% creature growth. Gives a garrisoned hero +20 Defense while defending in siege combat."
+					"name" : "Spirits of the Forebears",
+					"description" : "The Spirits of the Forebears increase weekly creature generation by 50%, provide your kingdom with an additional 5000 gold each day, and increase the Defence strength of a garrison hero by +20 when defending against a siege.",
+					"bonuses": [
+						{ 
+							"type": "PRIMARY_SKILL",
+							"subtype": "primarySkill.defence", 
+							"val": 20
+						} 
+					]
 				},
 
 				"mageGuild1" : {

--- a/hota/Mods/bulwark/content/config/hota/bulwark/town/town.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/town/town.json
@@ -1,7 +1,6 @@
 {
 	"bulwark" : {
 		"town" : {
-			"primaryResource" : "gems",
 			"moatAbility" : "bulwarkMoat",
 			"defaultTavern" : 5,
 			"townBackground" : "hota/bulwark/town/background",
@@ -296,6 +295,6 @@
 				"Ellesmere"
 			]
 		},
-		"description" : "{Bulwark}\n\nAdded later."
+		"description" : "{Bulwark}\n\nThe Bulwark's inhabitants represent the peoples living on the frozen over island of Vori: Snow Elves, Jotunns, Yeti, and Kobolds. They are joined by their staunch allies, Argali and Mammoths. Their courage and unusual abilities, which they owe to the mysterious forces lurking in the eternal snows, are the stuff of legends and songs."
 	}
 }


### PR DESCRIPTION
town.json:
+ Corrected resource starting bonus to Wood/Ore instead of Gems.
+ Added lore description for Bulwark

buildings.json:
+ corrected production and description of Resource Silo
+ corrected Fair's requirements and added marketMode for it
+ added University mode for Sieidi of Runes. It should be a rewardable, but I couldn't get it to wait and ask when clicked, it would always just grant the skill which sucks
    + made Altar of Runes inherit Sieidi's properties
+ better Grail building description and added its bonus