### PR TITLE
Wasteland biomes retouch

### DIFF
--- a/hota/Mods/wastelandTerrain/content/config/hota/wasteland/hotaStatic/hotaWastelandStaticBiomes.json
+++ b/hota/Mods/wastelandTerrain/content/config/hota/wasteland/hotaStatic/hotaWastelandStaticBiomes.json
@@ -18,6 +18,7 @@
 			"objectType" : "lake"
 		},
 		"templates" : [
+			"avlhlws0",
 			"AVLwll00",
 			"AVLwll01",
 			"AVLwll02"
@@ -32,17 +33,22 @@
 			"AVLwml00"
 		]
 	},
-	"core:skull" : {
+	"wastelandSkulls" : {
 		"biome" : {
 			"terrain" : "wasteland",
-			"objectType" : "other"
+			"objectType" : "animal"
 		},
 		"templates" : [
-			"jaws",
-			"AVLbon00",
-			"AVLbon01",
-			"AVLbon02",
-			"AVLbon03"
+				"AVLskul0Hota",
+				"AVLskul1",
+				"AVLskul2",
+				"AVLskul3",
+				"AVLwcsk0",
+				"AVLbon00",
+				"AVLbon01",
+				"AVLbon02",
+				"AVLbon03",
+				"jaws"
 		]
 	}
 }

--- a/hota/Mods/wastelandTerrain/content/config/hota/wasteland/vanillaStatic/bones.json
+++ b/hota/Mods/wastelandTerrain/content/config/hota/wasteland/vanillaStatic/bones.json
@@ -4,7 +4,7 @@
 			"hotaSkulls" : {
 				"name" : "Skull",
 				"templates" : {
-					"AVLskul0" : {
+					"AVLskul0Hota" : {
 						"animation" : "hota/wasteland/vanillaStatic/bones/AVLskul0",
 						"mask" : [
 							"B"

--- a/hota/Mods/wastelandTerrain/content/config/hota/wasteland/vanillaStatic/vanillaWastelandStaticBiomes.json
+++ b/hota/Mods/wastelandTerrain/content/config/hota/wasteland/vanillaStatic/vanillaWastelandStaticBiomes.json
@@ -72,15 +72,6 @@
 			"AVLsh9xw"
 		]
 	},
-	"wastelandHole" : {
-		"biome" : {
-			"terrain" : "wasteland",
-			"objectType" : "crater"
-		},
-		"templates" : [
-			"AVLsh9xw"
-		]
-	},
 	"wastelandMountains" : {
 		"biome" : {
 			"terrain" : "wasteland",
@@ -149,17 +140,19 @@
 			"AVLca130"
 		]
 	},
-	"core:skull" : {
-		"biome" : {
-			"terrain" : "wasteland",
-			"objectType" : "other"
-		},
-		"templates" : [
-			"AVLskul0",
-			"AVLskul1",
-			"AVLskul2",
-			"AVLskul3",
-			"AVLwcsk0"
-		]
+	"core:templateSet36" : {
+		"templates" : {
+			"appendItems" : [
+				"AVLskul1",
+				"AVLskul2",
+				"AVLskul3",
+				"AVLwcsk0",
+				"AVLbon00",
+				"AVLbon01",
+				"AVLbon02",
+				"AVLbon03",
+				"jaws"
+			]
+		}
 	}
 }


### PR DESCRIPTION
+ The "wastelandHole" crater-biome was not the template that used sprites/hole, instead it was some shrub, so I figured that was a mistake. I've put the sprites/hole object (small watering hole) in the lakes biome where it fits thematically
+ added the hota skulls to the core sand skull biome
+ made a new wasteland skull biome with the same skulls for wastelandTerrain (couldn't add the terrain to core's biome - just didn't want to work)

There are 2 very small wasteland-rock biomes in [vanillaWastelandStaticBiomes](hota/Mods/wastelandTerrain/content/config/hota/wasteland/vanillaStatic/vanillaWastelandStaticBiomes.json) that could be merged imo, but I think that was done to have more than a single rock biome, so I left it how it is.

@misiokles I renamed the skull that looks identical to the vanilla one to [%name%Hota](hota/Mods/wastelandTerrain/content/config/hota/wasteland/vanillaStatic/bones.json), I dunno if that is problematic, but it makes for easier conflict resolution.