### PR TITLE
Fix Jotunn/Skeleton Transformer interaction

### DIFF
--- a/hota/Mods/bulwark/content/config/hota/bulwark/creatures/jotunn.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/creatures/jotunn.json
@@ -68,10 +68,6 @@
 			"KING_3" : {
 				"type" : "KING",
 				"val" : 3
-			},
-			"dragonSkeleton" : {
-				"type" : "SKELETON_TRANSFORMER_TARGET",
-				"subtype" : "boneDragon"
 			}
 		},
 		"graphics" : {

--- a/hota/Mods/bulwark/content/config/hota/bulwark/creatures/jotunnWarlord.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/creatures/jotunnWarlord.json
@@ -87,10 +87,6 @@
 			"KING_3" : {
 				"type" : "KING",
 				"val" : 3
-			},
-			"dragonSkeleton" : {
-				"type" : "SKELETON_TRANSFORMER_TARGET",
-				"subtype" : "boneDragon"
 			}
 		},
 		"graphics" : {


### PR DESCRIPTION
Jotunns and Warlords don't transform into Bone Dragons.

Thanks @misiokles 