### PR TITLE
Fix Hermit's Shack

### DIFF
--- a/hota/Mods/highlandsTerrain/content/config/hota/highlands/hotaInteractive/hermitsShack.json
+++ b/hota/Mods/highlandsTerrain/content/config/hota/highlands/hotaInteractive/hermitsShack.json
@@ -5,7 +5,7 @@
 		"types" : {
 			"hermitsShack" : {
 				"name" : "Hermit's Shack",
-				"description" : "(Improves a random secondary skill)",
+				"description" : "(Random secondary skill upgrade once per hero)\n",
 				"rmg" : {
 					"value" : 1500,
 					"rarity" : 80,
@@ -20,10 +20,9 @@
 						"GAZEBO"
 					]
 				},
-
-				"onSelectMessage" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace.",
-				"onVisitedMessage" : "{Hermit's Shack}\r\n\r\nOn entering the shack you notice the walls are lined with pages from scholarly books. However, there's nothing to be learned, and, on top of that, the hermit owner of the place shows up and sees you out quite rudely.",
-				"onEmptyMessage" : "{Hermit's Shack}\r\n\r\nOn entering the shack you notice the walls are lined with pages from scholarly books. However, there's nothing to be learned, and, on top of that, the hermit owner of the place shows up and sees you out quite rudely.",
+				
+				"onVisitedMessage" : "{Hermit's Shack}\n\nOn entering the shack you notice the walls are lined with pages from scholarly books. However, there's nothing to be learned, and, on top of that, the hermit owner of the place shows up and sees you out quite rudely.",
+				"onEmptyMessage" : "{Hermit's Shack}\n\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. There definitely is a lot to be learned here, but the material seems fairly advanced. You will have to get an introductory course elsewhere.",
 
 				"visitMode" : "hero",
 				"selectMode" : "selectRandom",
@@ -50,617 +49,589 @@
 				"rewards" : [
 					{
 						"limiter" : {
+							"noneOf" : [
+								{
+									"secondary" : [
+										{	
+											"type" : "pathfinding",
+											"amount" : 3
+										}
+									]
+								}
+							],
 							"secondary" : {
 								"pathfinding" : 1
 							}
 						},
 						"secondary" : {
-							"pathfinding" : 2
+							"pathfinding" : 1
 						},
 						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
-							"secondary" : {
-								"pathfinding" : 2
-							}
-						},
-						"secondary" : {
-							"pathfinding" : 3
-						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
-					},
-					{
-						"limiter" : {
+							"noneOf" : [
+								{
+									"secondary" : [
+										{	
+											"type" : "archery",
+											"amount" : 3
+										}
+									]
+								}
+							],
 							"secondary" : {
 								"archery" : 1
 							}
 						},
 						"secondary" : {
-							"archery" : 2
+							"archery" : 1
 						},
 						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
-							"secondary" : {
-								"archery" : 2
-							}
-						},
-						"secondary" : {
-							"archery" : 3
-						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
-					},
-					{
-						"limiter" : {
+							"noneOf" : [
+								{
+									"secondary" : [
+										{	
+											"type" : "logistics",
+											"amount" : 3
+										}
+									]
+								}
+							],
 							"secondary" : {
 								"logistics" : 1
 							}
 						},
 						"secondary" : {
-							"logistics" : 2
+							"logistics" : 1
 						},
 						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
-							"secondary" : {
-								"logistics" : 2
-							}
-						},
-						"secondary" : {
-							"logistics" : 3
-						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
-					},
-					{
-						"limiter" : {
+							"noneOf" : [
+								{
+									"secondary" : [
+										{	
+											"type" : "scouting",
+											"amount" : 3
+										}
+									]
+								}
+							],
 							"secondary" : {
 								"scouting" : 1
 							}
 						},
 						"secondary" : {
-							"scouting" : 2
+							"scouting" : 1
 						},
 						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
-							"secondary" : {
-								"scouting" : 2
-							}
-						},
-						"secondary" : {
-							"scouting" : 3
-						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
-					},
-					{
-						"limiter" : {
+							"noneOf" : [
+								{
+									"secondary" : [
+										{	
+											"type" : "diplomacy",
+											"amount" : 3
+										}
+									]
+								}
+							],
 							"secondary" : {
 								"diplomacy" : 1
 							}
 						},
 						"secondary" : {
-							"diplomacy" : 2
+							"diplomacy" : 1
 						},
 						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
-							"secondary" : {
-								"diplomacy" : 2
-							}
-						},
-						"secondary" : {
-							"diplomacy" : 3
-						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
-					},
-					{
-						"limiter" : {
+							"noneOf" : [
+								{
+									"secondary" : [
+										{	
+											"type" : "navigation",
+											"amount" : 3
+										}
+									]
+								}
+							],
 							"secondary" : {
 								"navigation" : 1
 							}
 						},
 						"secondary" : {
-							"navigation" : 2
+							"navigation" : 1
 						},
 						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
-							"secondary" : {
-								"navigation" : 2
-							}
-						},
-						"secondary" : {
-							"navigation" : 3
-						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
-					},
-					{
-						"limiter" : {
+							"noneOf" : [
+								{
+									"secondary" : [
+										{	
+											"type" : "leadership",
+											"amount" : 3
+										}
+									]
+								}
+							],
 							"secondary" : {
 								"leadership" : 1
 							}
 						},
 						"secondary" : {
-							"leadership" : 2
+							"leadership" : 1
 						},
 						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
-							"secondary" : {
-								"leadership" : 2
-							}
-						},
-						"secondary" : {
-							"leadership" : 3
-						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
-					},
-					{
-						"limiter" : {
+							"noneOf" : [
+								{
+									"secondary" : [
+										{	
+											"type" : "wisdom",
+											"amount" : 3
+										}
+									]
+								}
+							],
 							"secondary" : {
 								"wisdom" : 1
 							}
 						},
 						"secondary" : {
-							"wisdom" : 2
+							"wisdom" : 1
 						},
 						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
-							"secondary" : {
-								"wisdom" : 2
-							}
-						},
-						"secondary" : {
-							"wisdom" : 3
-						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
-					},
-					{
-						"limiter" : {
+							"noneOf" : [
+								{
+									"secondary" : [
+										{	
+											"type" : "mysticism",
+											"amount" : 3
+										}
+									]
+								}
+							],
 							"secondary" : {
 								"mysticism" : 1
 							}
 						},
 						"secondary" : {
-							"mysticism" : 2
+							"mysticism" : 1
 						},
 						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
-							"secondary" : {
-								"mysticism" : 2
-							}
-						},
-						"secondary" : {
-							"mysticism" : 3
-						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
-					},
-					{
-						"limiter" : {
+							"noneOf" : [
+								{
+									"secondary" : [
+										{	
+											"type" : "luck",
+											"amount" : 3
+										}
+									]
+								}
+							],
 							"secondary" : {
 								"luck" : 1
 							}
 						},
 						"secondary" : {
-							"luck" : 2
+							"luck" : 1
 						},
 						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
-							"secondary" : {
-								"luck" : 2
-							}
-						},
-						"secondary" : {
-							"luck" : 3
-						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
-					},
-					{
-						"limiter" : {
+							"noneOf" : [
+								{
+									"secondary" : [
+										{	
+											"type" : "ballistics",
+											"amount" : 3
+										}
+									]
+								}
+							],
 							"secondary" : {
 								"ballistics" : 1
 							}
 						},
 						"secondary" : {
-							"ballistics" : 2
+							"ballistics" : 1
 						},
 						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
-							"secondary" : {
-								"ballistics" : 2
-							}
-						},
-						"secondary" : {
-							"ballistics" : 3
-						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
-					},
-					{
-						"limiter" : {
+							"noneOf" : [
+								{
+									"secondary" : [
+										{	
+											"type" : "eagleEye",
+											"amount" : 3
+										}
+									]
+								}
+							],
 							"secondary" : {
 								"eagleEye" : 1
 							}
 						},
 						"secondary" : {
-							"eagleEye" : 2
+							"eagleEye" : 1
 						},
 						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
-							"secondary" : {
-								"eagleEye" : 2
-							}
-						},
-						"secondary" : {
-							"eagleEye" : 3
-						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
-					},
-					{
-						"limiter" : {
+							"noneOf" : [
+								{
+									"secondary" : [
+										{	
+											"type" : "necromancy",
+											"amount" : 3
+										}
+									]
+								}
+							],
 							"secondary" : {
 								"necromancy" : 1
 							}
 						},
 						"secondary" : {
-							"necromancy" : 2
+							"necromancy" : 1
 						},
 						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
-							"secondary" : {
-								"necromancy" : 2
-							}
-						},
-						"secondary" : {
-							"necromancy" : 3
-						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
-					},
-					{
-						"limiter" : {
+							"noneOf" : [
+								{
+									"secondary" : [
+										{	
+											"type" : "estates",
+											"amount" : 3
+										}
+									]
+								}
+							],
 							"secondary" : {
 								"estates" : 1
 							}
 						},
 						"secondary" : {
-							"estates" : 2
+							"estates" : 1
 						},
 						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
-							"secondary" : {
-								"estates" : 2
-							}
-						},
-						"secondary" : {
-							"estates" : 3
-						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
-					},
-					{
-						"limiter" : {
+							"noneOf" : [
+								{
+									"secondary" : [
+										{	
+											"type" : "fireMagic",
+											"amount" : 3
+										}
+									]
+								}
+							],
 							"secondary" : {
 								"fireMagic" : 1
 							}
 						},
 						"secondary" : {
-							"fireMagic" : 2
+							"fireMagic" : 1
 						},
 						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
-							"secondary" : {
-								"fireMagic" : 2
-							}
-						},
-						"secondary" : {
-							"fireMagic" : 3
-						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
-					},
-					{
-						"limiter" : {
+							"noneOf" : [
+								{
+									"secondary" : [
+										{	
+											"type" : "airMagic",
+											"amount" : 3
+										}
+									]
+								}
+							],
 							"secondary" : {
 								"airMagic" : 1
 							}
 						},
 						"secondary" : {
-							"airMagic" : 2
+							"airMagic" : 1
 						},
 						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
-							"secondary" : {
-								"airMagic" : 2
-							}
-						},
-						"secondary" : {
-							"airMagic" : 3
-						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
-					},
-					{
-						"limiter" : {
+							"noneOf" : [
+								{
+									"secondary" : [
+										{	
+											"type" : "waterMagic",
+											"amount" : 3
+										}
+									]
+								}
+							],
 							"secondary" : {
 								"waterMagic" : 1
 							}
 						},
 						"secondary" : {
-							"waterMagic" : 2
+							"waterMagic" : 1
 						},
 						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
-							"secondary" : {
-								"waterMagic" : 2
-							}
-						},
-						"secondary" : {
-							"waterMagic" : 3
-						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
-					},
-					{
-						"limiter" : {
+							"noneOf" : [
+								{
+									"secondary" : [
+										{	
+											"type" : "earthMagic",
+											"amount" : 3
+										}
+									]
+								}
+							],
 							"secondary" : {
 								"earthMagic" : 1
 							}
 						},
 						"secondary" : {
-							"earthMagic" : 2
+							"earthMagic" : 1
 						},
 						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
-							"secondary" : {
-								"earthMagic" : 2
-							}
-						},
-						"secondary" : {
-							"earthMagic" : 3
-						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
-					},
-					{
-						"limiter" : {
+							"noneOf" : [
+								{
+									"secondary" : [
+										{	
+											"type" : "scholar",
+											"amount" : 3
+										}
+									]
+								}
+							],
 							"secondary" : {
 								"scholar" : 1
 							}
 						},
 						"secondary" : {
-							"scholar" : 2
+							"scholar" : 1
 						},
 						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
-							"secondary" : {
-								"scholar" : 2
-							}
-						},
-						"secondary" : {
-							"scholar" : 3
-						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
-					},
-					{
-						"limiter" : {
+							"noneOf" : [
+								{
+									"secondary" : [
+										{	
+											"type" : "tactics",
+											"amount" : 3
+										}
+									]
+								}
+							],
 							"secondary" : {
 								"tactics" : 1
 							}
 						},
 						"secondary" : {
-							"tactics" : 2
+							"tactics" : 1
 						},
 						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
-							"secondary" : {
-								"tactics" : 2
-							}
-						},
-						"secondary" : {
-							"tactics" : 3
-						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
-					},
-					{
-						"limiter" : {
+							"noneOf" : [
+								{
+									"secondary" : [
+										{	
+											"type" : "artillery",
+											"amount" : 3
+										}
+									]
+								}
+							],
 							"secondary" : {
 								"artillery" : 1
 							}
 						},
 						"secondary" : {
-							"artillery" : 2
+							"artillery" : 1
 						},
 						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
-							"secondary" : {
-								"artillery" : 2
-							}
-						},
-						"secondary" : {
-							"artillery" : 3
-						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
-					},
-					{
-						"limiter" : {
+							"noneOf" : [
+								{
+									"secondary" : [
+										{	
+											"type" : "learning",
+											"amount" : 3
+										}
+									]
+								}
+							],
 							"secondary" : {
 								"learning" : 1
 							}
 						},
 						"secondary" : {
-							"learning" : 2
+							"learning" : 1
 						},
 						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
-							"secondary" : {
-								"learning" : 2
-							}
-						},
-						"secondary" : {
-							"learning" : 3
-						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
-					},
-					{
-						"limiter" : {
+							"noneOf" : [
+								{
+									"secondary" : [
+										{	
+											"type" : "offence",
+											"amount" : 3
+										}
+									]
+								}
+							],
 							"secondary" : {
 								"offence" : 1
 							}
 						},
 						"secondary" : {
-							"offence" : 2
+							"offence" : 1
 						},
 						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
-							"secondary" : {
-								"offence" : 2
-							}
-						},
-						"secondary" : {
-							"offence" : 3
-						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
-					},
-					{
-						"limiter" : {
+							"noneOf" : [
+								{
+									"secondary" : [
+										{	
+											"type" : "armorer",
+											"amount" : 3
+										}
+									]
+								}
+							],
 							"secondary" : {
 								"armorer" : 1
 							}
 						},
 						"secondary" : {
-							"armorer" : 2
+							"armorer" : 1
 						},
 						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
-							"secondary" : {
-								"armorer" : 2
-							}
-						},
-						"secondary" : {
-							"armorer" : 3
-						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
-					},
-					{
-						"limiter" : {
+							"noneOf" : [
+								{
+									"secondary" : [
+										{	
+											"type" : "intelligence",
+											"amount" : 3
+										}
+									]
+								}
+							],
 							"secondary" : {
 								"intelligence" : 1
 							}
 						},
 						"secondary" : {
-							"intelligence" : 2
+							"intelligence" : 1
 						},
 						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
-							"secondary" : {
-								"intelligence" : 2
-							}
-						},
-						"secondary" : {
-							"intelligence" : 3
-						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
-					},
-					{
-						"limiter" : {
+							"noneOf" : [
+								{
+									"secondary" : [
+										{	
+											"type" : "sorcery",
+											"amount" : 3
+										}
+									]
+								}
+							],
 							"secondary" : {
 								"sorcery" : 1
 							}
 						},
 						"secondary" : {
-							"sorcery" : 2
+							"sorcery" : 1
 						},
 						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
-							"secondary" : {
-								"sorcery" : 2
-							}
-						},
-						"secondary" : {
-							"sorcery" : 3
-						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
-					},
-					{
-						"limiter" : {
+							"noneOf" : [
+								{
+									"secondary" : [
+										{	
+											"type" : "resistance",
+											"amount" : 3
+										}
+									]
+								}
+							],
 							"secondary" : {
 								"resistance" : 1
 							}
 						},
 						"secondary" : {
-							"resistance" : 2
+							"resistance" : 1
 						},
 						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
-							"secondary" : {
-								"resistance" : 2
-							}
-						},
-						"secondary" : {
-							"resistance" : 3
-						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
-					},
-					{
-						"limiter" : {
+							"noneOf" : [
+								{
+									"secondary" : [
+										{	
+											"type" : "firstAid",
+											"amount" : 3
+										}
+									]
+								}
+							],
 							"secondary" : {
 								"firstAid" : 1
 							}
 						},
 						"secondary" : {
-							"firstAid" : 2
-						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
-					},
-					{
-						"limiter" : {
-							"secondary" : {
-								"firstAid" : 2
-							}
-						},
-						"secondary" : {
-							"firstAid" : 3
+							"firstAid" : 1
 						},
 						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					}


### PR DESCRIPTION
Noticed this issue in VCMI: https://github.com/vcmi/vcmi/issues/6722 and went to investigate and yes, Hermit's shack was fundamentally broken and potentially rewarded multiple levels for a secondary and could also pick an Expert secondary skill to upgrade (which did nothing and marked the object as visited).

Fixes in this PR:
+ better object description
+ removed `"onSelectMessage"` (unused - only used when object is set to `"playerSelect"`)
+ fixed `"onEmptyMessage"` (used to be the same as `"onVisitedMessage"`)
+ fixed limiters and bonuses for all rewards

Now it behaves as it should: It gives you a random secondary skill upgrade (1 level, never multiple) for either a Basic or an Advanced secondary skill. If your hero has no Basic or Advanced secondary skill, it will display the `"onEmptyMessage"`, telling you that you cannot learn anything here at the moment. This does not mark the object as visited, so you can return to it later.