### PR TITLE
Fix highlands objects again and fix launcher warnings

### DIFF
--- a/hota/Mods/highlandsTerrain/content/config/hota/highlands/hotaInteractive/gazebo.json
+++ b/hota/Mods/highlandsTerrain/content/config/hota/highlands/hotaInteractive/gazebo.json
@@ -14,7 +14,7 @@
 				"sounds" : {
 					"visit" : [
 						"GAZEBO"
-					] //TODO: missing sound!
+					]
 				},
 				"rewards" : [
 					{

--- a/hota/Mods/highlandsTerrain/content/config/hota/highlands/hotaInteractive/hermitsShack.json
+++ b/hota/Mods/highlandsTerrain/content/config/hota/highlands/hotaInteractive/hermitsShack.json
@@ -37,7 +37,7 @@
 						],
 						"visitableFrom" : [
 							"---",
-							"-++",
+							"++-",
 							"+++"
 						],
 						"allowedTerrains" : [

--- a/hota/Mods/highlandsTerrain/content/config/hota/highlands/hotaInteractive/junkman.json
+++ b/hota/Mods/highlandsTerrain/content/config/hota/highlands/hotaInteractive/junkman.json
@@ -33,7 +33,7 @@
 						],
 						"visitableFrom" : [
 							"---",
-							"++-",
+							"-++",
 							"+++"
 						],
 						"allowedTerrains" : [

--- a/hota/Mods/highlandsTerrain/content/config/hota/highlands/hotaInteractive/mineralSpring.json
+++ b/hota/Mods/highlandsTerrain/content/config/hota/highlands/hotaInteractive/mineralSpring.json
@@ -34,12 +34,12 @@
 						"animation" : "hota/highlands/hotaInteractive/mineralSpring/AVXmspr0",
 						"mask" : [
 							"VVV",
-							"VBV",
+							"VVV",
 							"VBA"
 						],
 						"visitableFrom" : [
 							"---",
-							"--+",
+							"-++",
 							"+++"
 						],
 						"allowedTerrains" : [

--- a/hota/Mods/highlandsTerrain/content/config/hota/highlands/hotaStatic/hotaHighlandsStaticBiomes.json
+++ b/hota/Mods/highlandsTerrain/content/config/hota/highlands/hotaStatic/hotaHighlandsStaticBiomes.json
@@ -2,7 +2,7 @@
 	"waterfalls" : {
 		"biome" : {
 			"terrain" : "highlands",
-			"objectType" : "mountain"
+			"objectType" : "other"
 		},
 		"templates" : [
 			"hotaAVLwtf00",
@@ -30,22 +30,6 @@
 			"avlhpn11",
 			"avlhpn12",
 			"avlhpn13"
-		]
-	},
-	"puddles" : {
-		"biome" : {
-			"terrain" : "highlands",
-			"objectType" : "other"
-		},
-		"templates" : [
-			"avlhml00",
-			"avlhml01",
-			"avlhml02",
-			"avlhml03",
-			"avlhml04",
-			"avlhml05",
-			"avlhml06",
-			"avlhml07"
 		]
 	}
 }

--- a/hota/Mods/highlandsTerrain/content/config/hota/highlands/hotaStatic/spruces.json
+++ b/hota/Mods/highlandsTerrain/content/config/hota/highlands/hotaStatic/spruces.json
@@ -138,7 +138,7 @@
 						"mask" : [
 							"VVVV",
 							"VVBB",
-							"VVBB",
+							"VBBB",
 							"VBBV"
 						],
 						"allowedTerrains" : [

--- a/hota/Mods/highlandsTerrain/content/config/hota/highlands/hotaStatic/waterfalls.json
+++ b/hota/Mods/highlandsTerrain/content/config/hota/highlands/hotaStatic/waterfalls.json
@@ -1,6 +1,6 @@
 {
 	"highlandsWaterfalls" : {
-		"name" : "Mountain",
+		"name" : "Waterfall",
 		"handler" : "static",
 		"types" : {
 			"waterfalls" : {

--- a/hota/Mods/highlandsTerrain/content/config/hota/highlands/vanillaInteractive/abandonedMine.json
+++ b/hota/Mods/highlandsTerrain/content/config/hota/highlands/vanillaInteractive/abandonedMine.json
@@ -7,7 +7,7 @@
 						"animation" : "hota/highlands/vanillaInteractive/mines/AVXamH1",
 						"mask" : [
 							"VVVV",
-							"VBBB",
+							"VVBV",
 							"VBAB"
 						],
 						"visitableFrom" : [

--- a/hota/Mods/highlandsTerrain/content/config/hota/highlands/vanillaInteractive/obelisk.json
+++ b/hota/Mods/highlandsTerrain/content/config/hota/highlands/vanillaInteractive/obelisk.json
@@ -7,7 +7,7 @@
 						"animation" : "hota/highlands/vanillaInteractive/obelisk/AvXOblOr",
 						"visitableFrom" : [
 							"---",
-							"+-+",
+							"+++",
 							"+++"
 						],
 						"mask" : [

--- a/hota/Mods/highlandsTerrain/content/config/hota/highlands/vanillaInteractive/tradingPost.json
+++ b/hota/Mods/highlandsTerrain/content/config/hota/highlands/vanillaInteractive/tradingPost.json
@@ -1,0 +1,26 @@
+{
+	"core:tradingPost" : {
+		"types" : {
+			"object" : {
+				"templates" : {
+					"highlandsTradingPost" : {
+						"animation" : "AVXpost0.def",
+						"mask" : [
+							"VVV",
+							"VVV",
+							"VBA"
+						],
+						"visitableFrom" : [
+							"---",
+							"-++",
+							"+++"
+						],
+						"allowedTerrains" : [
+							"highlands"
+						]
+					}
+				}
+			}
+		}
+	}
+}

--- a/hota/Mods/highlandsTerrain/content/config/hota/highlands/vanillaStatic/vanillaHighlandsStaticBiomes.json
+++ b/hota/Mods/highlandsTerrain/content/config/hota/highlands/vanillaStatic/vanillaHighlandsStaticBiomes.json
@@ -53,15 +53,6 @@
 			"avlhll03"
 		]
 	},
-	"highlandsHole" : {
-		"biome" : {
-			"terrain" : "highlands",
-			"objectType" : "crater"
-		},
-		"templates" : [
-			"avlhlhl"
-		]
-	},
 	"highlandsFlower" : {
 		"biome" : {
 			"terrain" : "highlands",

--- a/hota/Mods/highlandsTerrain/mod.json
+++ b/hota/Mods/highlandsTerrain/mod.json
@@ -57,6 +57,7 @@
 		"config/hota/highlands/vanillaInteractive/mines.json",
 		"config/hota/highlands/vanillaInteractive/obelisk.json",
 		"config/hota/highlands/vanillaInteractive/signs.json",
+		"config/hota/highlands/vanillaInteractive/tradingPost.json",
 		"config/hota/highlands/hotaInteractive/churchyard.json",
 		"config/hota/highlands/hotaInteractive/gazebo.json",
 		"config/hota/highlands/hotaInteractive/hermitsShack.json",

--- a/hota/Mods/mapDecorations/content/config/hotaMapDecorations/vanillaStatic/vanillaStaticBiomes.json
+++ b/hota/Mods/mapDecorations/content/config/hotaMapDecorations/vanillaStatic/vanillaStaticBiomes.json
@@ -211,20 +211,6 @@
 			"ZREEF5"
 		]
 	},
-	"kelp" : {
-		"biome" : {
-			"terrain" : "water",
-			"objectType" : "plant"
-		},
-		"templates" : [
-			"AVLklp30",
-			"AVLklp40",
-			"AVLswd1",
-			"AVLswd2",
-			"AVLswd3",
-			"AVLswd4"
-		]
-	},
 	"waterRock" : {
 		"biome" : {
 			"terrain" : "water",

--- a/hota/Mods/wastelandTerrain/content/config/hota/wasteland/hotaStatic/hotaWastelandStaticBiomes.json
+++ b/hota/Mods/wastelandTerrain/content/config/hota/wasteland/hotaStatic/hotaWastelandStaticBiomes.json
@@ -24,15 +24,6 @@
 			"AVLwll02"
 		]
 	},
-	"limestonePuddles" : {
-		"biome" : {
-			"terrain" : "wasteland",
-			"objectType" : "other"
-		},
-		"templates" : [
-			"AVLwml00"
-		]
-	},
 	"wastelandSkulls" : {
 		"biome" : {
 			"terrain" : "wasteland",


### PR DESCRIPTION
This PR fixes overlooked issues in the hota.highlandsTerrain submod. It also fixes the launcher warnings about removing empty object sets.

hota.highlandsTerrain:
Objects:
+ fixed `"visitableFrom"` field of Junkman, Hermit's Shack, Mineral Spring and Obelisk
+ fixed mask of Mineral Spring, a spruce (avlhpn12) and Highlands Abandoned Mine 
+ added a Trading Post for highlands terrain (for some reason, RMG wouldn't spawn it otherwise, now it does)
+ Renamed the waterfalls from "Mountain" to "Waterfall"
+ removed Gazebo missing sound comment. There is no sound missing, Gazebo doesn't have an ambient sound and the interact sound was correct.

Biomes:
+ made Waterfalls "other" instead of "mountain", they look weird as mountains
+ removed "puddles" and "highlandHole" biomes since they had no objects with blocking tiles, so they were removed by the launcher with a warning
    + They shouldn't be defined as statics because statics are assumed to have blocking tiles, but I have no better idea for them
    + I do not know how to make RMG spawn non-blocking decorations :(

What is still missing is that the highland version of the churchyard is picked for highlands terrain by the RMG. It never is for me, it only ever spawns the normal version. The definition files are correct, so I have no idea what is wrong, it works for other terrains and objects.

hota.wastelandTerrain:
+ removed the "limestonePuddles" biome, empty set, no blocking objects

hota.mapDecorations:
+ removed the "kelp" biome, empty set, no blocking objects

This fixes all launcher warnings about empty object sets. The one remaining is a mistake in core's biomes.json.