### PR TITLE
Grave reward/sound/refusable, manual Mana Vortex and small Ancient Altar fix

### DIFF
--- a/hota/Mods/gameBalance/mods/factions/content/config/hotaGameBalance/factions.json
+++ b/hota/Mods/gameBalance/mods/factions/content/config/hotaGameBalance/factions.json
@@ -196,6 +196,20 @@
 							"dwellingLvl4"
 						]
 					]
+				},
+				"special2" : {
+					"description" : "The Mana Vortex doubles the spell points for one visiting hero, once per week.",
+					"manualHeroVisit" : true,
+					"configuration" : {
+						"canRefuse" : true,
+						"onEmptyMessage" : "Your hero has enough spell points and cannot get more from the Mana Vortex.",
+						"onVisitedMessage" : "The Mana Vortex has been already used this week.",
+						"rewards" : {
+							"modify@1" : {
+								"message" : "As you near the Mana Vortex, you sense that it could fill your body with new energy.\n\nDo you want to use the Mana Vortex to double your hero's normal spell points?"
+							}
+						}
+					}
 				}
 			}
 		}

--- a/hota/Mods/neutralCreatures/Mods/ancientAltar/content/config/hotaBanks/ancientAltar.json
+++ b/hota/Mods/neutralCreatures/Mods/ancientAltar/content/config/hotaBanks/ancientAltar.json
@@ -34,7 +34,7 @@
 				//					"value" :  20000,
 				//					"rarity" : 20
 				//				},
-				"blockedVisitable" : false,
+				"blockedVisitable" : true,
 				"onGuardedMessage" : "{Ancient Altar}\r\n\r\nDeep under the ground you find an ancient temple, where Haspids guard an artifact of great power.\r\nDo you want to fight them?",
 				"onVisitedMessage" : "{Ancient Altar}\r\n\r\nDeep under the ground you find an ancient temple. An artifact of great power used to be kept here, but now the temple is empty.",
 				"visitMode" : "once",

--- a/hota/Mods/wastelandTerrain/content/config/hota/wasteland/hotaInteractive/grave.json
+++ b/hota/Mods/wastelandTerrain/content/config/hota/wasteland/hotaInteractive/grave.json
@@ -4,6 +4,11 @@
 	"grave" : {
 		"handler" : "configurable",
 		"name" : "Grave",
+		"base" : {
+			"sounds" : {
+				"removal" : [ "DIGSOUND" ]
+			}
+		},
 		"types" : {
 			"grave" : {
 				"name" : "Grave",
@@ -12,9 +17,13 @@
 					"value" : 500,
 					"rarity" : 30
 				},
+				"removable" : true,
+				"blockedVisitable" : false,
+				"showScoutedPreview" : false,
+				"canRefuse" : true,
 				"rewards" : [
 					{
-						"message" : "{Grave}\r\n\r\nThis tomb is fresh, and even the shovel someone dug it with hasn't been stolen yet. You take up the latter, cover your nose with a handkerchief, and manage to extract something valuable from the ground.",
+						"message" : "{Grave}\n\nThis tomb is fresh, and even the shovel someone dug it with hasn't been stolen yet.\nDo you want to take up the latter, cover your nose with a handkerchief, and extract something valuable from the ground and call it a day?",
 						"appearChance" : {
 							"max" : 50
 						},
@@ -44,7 +53,7 @@
 						"removeObject" : true
 					},
 					{
-						"message" : "{Grave}\r\n\r\nThis tomb is fresh, and even the shovel someone dug it with hasn't been stolen yet. You take up the latter, cover your nose with a handkerchief, and manage to extract something valuable from the ground.",
+						"message" : "{Grave}\n\nThis tomb is fresh, and even the shovel someone dug it with hasn't been stolen yet.\nDo you want to take up the latter, cover your nose with a handkerchief, and extract something valuable from the ground and call it a day?",
 						"appearChance" : {
 							"min" : 50
 						},
@@ -75,7 +84,7 @@
 					}
 				],
 
-				"visitMode" : "hero",
+				"visitMode" : "once",
 				"templates" : {
 					"avxgravw" : {
 						"animation" : "hota/wasteland/hotaInteractive/grave/avxgravw",

--- a/hota/Mods/wastelandTerrain/content/config/hota/wasteland/hotaInteractive/grave.json
+++ b/hota/Mods/wastelandTerrain/content/config/hota/wasteland/hotaInteractive/grave.json
@@ -1,11 +1,13 @@
 {
+	// 1.7.0:
+	// [+] Changed the Tomb (note: they mean Grave) reward from 500-5000 to 1500-4000 Gold
 	"grave" : {
 		"handler" : "configurable",
 		"name" : "Grave",
 		"types" : {
 			"grave" : {
 				"name" : "Grave",
-				"description" : "(Takes all movement points, and gives 500-5000 gold, a random Treasure of Minor artifact, and -3 morale until the next battle.)",
+				"description" : "(Takes all movement points, and gives 1500-4000 gold, a random Treasure or Minor artifact, and -3 morale until the next battle.)",
 				"rmg" : {
 					"value" : 500,
 					"rarity" : 30
@@ -18,16 +20,12 @@
 						},
 						"resources" : {
 							"gold" : [
-								500,
-								1000,
 								1500,
 								2000,
 								2500,
 								3000,
 								3500,
-								4000,
-								4500,
-								5000
+								4000
 							]
 						},
 						"bonuses" : [
@@ -52,16 +50,12 @@
 						},
 						"resources" : {
 							"gold" : [
-								500,
-								1000,
 								1500,
 								2000,
 								2500,
 								3000,
 								3500,
-								4000,
-								4500,
-								5000
+								4000
 							]
 						},
 						"bonuses" : [


### PR DESCRIPTION
This PR is kinda all over the place. Small annoyances that bugged me for a while. Changes:

gameBalance:
+ Added the manual selection for the Mana Vortex. I've adjusted the reward message a bit because in HotA, you get 2 message pop-ups, once when you click and once when you accept. This is one message that covers both. Changed the building description to reflect that.

wastelandTerrain:
1.7.0:
[+] Changed the Tomb reward from 500-5000 to 1500-4000 Gold
I've seen this change earlier but was confused what they meant with "Tomb". They meant the Grave.

Also corrected a typo in the description (of -> or)

Edit:
After reading @misiokles thoughts in #363, I made Grave refusable and also gave it the shovel sound when it disappears to make it just a bit more true to original.

neutralCreatures -> ancientAltar:
The activator tile is now blocked like in HotA