### PR TITLE
Fix terrain exclusive templates

### DIFF
--- a/hota/Mods/mapDecorations/content/config/hotaMapDecorations/vanillaInteractive/wagon.json
+++ b/hota/Mods/mapDecorations/content/config/hotaMapDecorations/vanillaInteractive/wagon.json
@@ -13,6 +13,9 @@
 							"---",
 							"-++",
 							"+++"
+						],
+						"allowedTerrains" : [
+							"rough"
 						]
 					}
 				}

--- a/hota/Mods/mapObjects/content/config/hotaMapObjects/blackTower.json
+++ b/hota/Mods/mapObjects/content/config/hotaMapObjects/blackTower.json
@@ -12,7 +12,7 @@
 				"guardsLayout" : "creatureBankBlackTower",
 				"templates" : {
 					"normal" : {
-						"animation" : "hota/banks/avblktgr.def",
+						"animation" : "hota/banks/avblktwr.def",
 						"visitableFrom" : [
 							"---",
 							"-+-",
@@ -23,6 +23,15 @@
 							"VVVV",
 							"VVVV",
 							"VVAV"
+						],
+						"allowedTerrains" : [
+							"dirt",
+							"sand",
+							"rough",
+							"subterra",
+							"lava",
+							"hota.wastelandTerrain:wasteland",
+							"hota.highlandsTerrain:highlands"
 						]
 					},
 					"grass" : {

--- a/hota/Mods/mapObjects/content/config/hotaMapObjects/churchyard.json
+++ b/hota/Mods/mapObjects/content/config/hotaMapObjects/churchyard.json
@@ -15,6 +15,16 @@
 							"VVVV",
 							"VVVV",
 							"VBAB"
+						],
+						"allowedTerrains" : [
+							"dirt",
+							"sand",
+							"grass",
+							"swamp",
+							"rough",
+							"subterra",
+							"lava",
+							"hota.wastelandTerrain:wasteland"
 						]
 					},
 					"snow" : {

--- a/hota/Mods/mapObjects/content/config/hotaMapObjects/experimentalShop.json
+++ b/hota/Mods/mapObjects/content/config/hotaMapObjects/experimentalShop.json
@@ -15,6 +15,17 @@
 							"VVV",
 							"VVV",
 							"VBA"
+						],
+						"allowedTerrains" : [
+							"dirt",
+							"sand",
+							"grass",
+							"swamp",
+							"rough",
+							"subterra",
+							"lava",
+							"hota.wastelandTerrain:wasteland",
+							"hota.highlandsTerrain:highlands"
 						]
 					},
 					"snow" : {

--- a/hota/Mods/mapObjects/content/config/hotaMapObjects/ivoryTower.json
+++ b/hota/Mods/mapObjects/content/config/hotaMapObjects/ivoryTower.json
@@ -47,10 +47,10 @@
 						"hota/IVORYTOW.wav"
 					]
 				},
-				//"rmg" : {
-				//	"value" : 7000,
-				//	"rarity" : 100
-				//},
+				"rmg" : {
+					"value" : 7000,
+					"rarity" : 100
+				},
 				"blockedVisitable" : false,
 				"onGuardedMessage" : 32,
 				"onVisitedMessage" : 33,

--- a/hota/Mods/mapObjects/content/config/hotaMapObjects/ivoryTower.json
+++ b/hota/Mods/mapObjects/content/config/hotaMapObjects/ivoryTower.json
@@ -16,6 +16,9 @@
 							"VVV",
 							"VVV",
 							"VBA"
+						],
+						"allowedTerrains" : [
+							"sand"
 						]
 					},
 					"snow" : {
@@ -44,10 +47,10 @@
 						"hota/IVORYTOW.wav"
 					]
 				},
-				"rmg" : {
-					"value" : 7000,
-					"rarity" : 10
-				},
+				//"rmg" : {
+				//	"value" : 7000,
+				//	"rarity" : 100
+				//},
 				"blockedVisitable" : false,
 				"onGuardedMessage" : 32,
 				"onVisitedMessage" : 33,

--- a/hota/Mods/wastelandTerrain/content/config/hota/wasteland/hotaStatic/hotaWastelandStaticBiomes.json
+++ b/hota/Mods/wastelandTerrain/content/config/hota/wasteland/hotaStatic/hotaWastelandStaticBiomes.json
@@ -24,6 +24,22 @@
 			"AVLwll02"
 		]
 	},
+	"wastingBones" : {
+		"biome" : {
+			"terrain" : [
+				"wasteland",
+				"sand"
+			],
+			"objectType" : "other"
+		},
+		"templates" : [
+			"AVLbon00",
+			"AVLbon01",
+			"AVLbon02",
+			"AVLbon03",
+			"jaws"
+		]
+	},
 	"wastelandSkulls" : {
 		"biome" : {
 			"terrain" : "wasteland",
@@ -34,12 +50,7 @@
 			"AVLskul1",
 			"AVLskul2",
 			"AVLskul3",
-			"AVLwcsk0",
-			"AVLbon00",
-			"AVLbon01",
-			"AVLbon02",
-			"AVLbon03",
-			"jaws"
+			"AVLwcsk0"
 		]
 	}
 }

--- a/hota/Mods/wastelandTerrain/content/config/hota/wasteland/vanillaStatic/vanillaWastelandStaticBiomes.json
+++ b/hota/Mods/wastelandTerrain/content/config/hota/wasteland/vanillaStatic/vanillaWastelandStaticBiomes.json
@@ -146,12 +146,7 @@
 				"AVLskul1",
 				"AVLskul2",
 				"AVLskul3",
-				"AVLwcsk0",
-				"AVLbon00",
-				"AVLbon01",
-				"AVLbon02",
-				"AVLbon03",
-				"jaws"
+				"AVLwcsk0"
 			]
 		}
 	}


### PR DESCRIPTION
This PR fixes objects or object types introduced in HotA that have terrain variations in their templates, for example Churchyard, Black Tower or Experimental Shop. RMG would never spawn the terrain variation because the default version was allowed on all terrains. I don't know why that is a problem for newly introduced types as with core object types, you can just add the template (see learningStone in mapDecorations for example) and it'll work...

Going by object:
+ Black Tower
    + fixed a typo in the animation that made the normal variation spawn with the grass/swamp sprite
    + fixed grass, swamp and snow versions of it never spawning
+ Churchyard
    + fixed highlands and snow versions never spawning
+ Experimental Shop
    + fixed snow version never spawning
+ Ivory Tower
    + fixed sand variation spawning everywhere and snow version never spawning
    + corrected the rarity
    + made it default banned like in HotA
+ Wagon
   + Fixed the HotA version spawning everywhere (should only spawn on rough terrain)

Changes semi-related to map objects:
I didn't like how the wasteland and sand zones looked biome-wise, so I changed it a bit. I made only the skulls (small blockers) spawn as "animal" in wasteland and sand and made a new biome with type "other" for both wasteland and sand for the bigger skeletons.