### PR TITLE
Object fixes/updates, wasteland biome retouch

### DIFF
--- a/hota/Mods/gameBalance/mods/objects/mods/rmgTweak/content/config/hotaGameBalance/objectsRmgValues.json
+++ b/hota/Mods/gameBalance/mods/objects/mods/rmgTweak/content/config/hotaGameBalance/objectsRmgValues.json
@@ -90,5 +90,15 @@
 				}
 			}
 		}
+	},
+	
+	"core:leanTo" : {
+		"types" : {
+			"leanTo" : {
+				"rmg" : {
+					"rarity" : 50
+				}
+			}
+		}
 	}
 }

--- a/hota/Mods/mapDecorations/content/config/hotaMapDecorations/vanillaInteractive/wagon.json
+++ b/hota/Mods/mapDecorations/content/config/hotaMapDecorations/vanillaInteractive/wagon.json
@@ -13,6 +13,9 @@
 							"---",
 							"-++",
 							"+++"
+						],
+						"allowedTerrains" : [
+							"rough"
 						]
 					}
 				}

--- a/hota/Mods/mapObjects/content/config/hotaMapObjects/blackTower.json
+++ b/hota/Mods/mapObjects/content/config/hotaMapObjects/blackTower.json
@@ -12,7 +12,7 @@
 				"guardsLayout" : "creatureBankBlackTower",
 				"templates" : {
 					"normal" : {
-						"animation" : "hota/banks/avblktgr.def",
+						"animation" : "hota/banks/avblktwr.def",
 						"visitableFrom" : [
 							"---",
 							"-+-",

--- a/hota/Mods/mapObjects/content/config/hotaMapObjects/ivoryTower.json
+++ b/hota/Mods/mapObjects/content/config/hotaMapObjects/ivoryTower.json
@@ -16,6 +16,9 @@
 							"VVV",
 							"VVV",
 							"VBA"
+						],
+						"allowedTerrains" : [
+							"sand"
 						]
 					},
 					"snow" : {
@@ -46,7 +49,7 @@
 				},
 				"rmg" : {
 					"value" : 7000,
-					"rarity" : 10
+					"rarity" : 100
 				},
 				"blockedVisitable" : false,
 				"onGuardedMessage" : 32,

--- a/hota/Mods/wastelandTerrain/content/config/hota/wasteland/hotaStatic/hotaWastelandStaticBiomes.json
+++ b/hota/Mods/wastelandTerrain/content/config/hota/wasteland/hotaStatic/hotaWastelandStaticBiomes.json
@@ -24,6 +24,22 @@
 			"AVLwll02"
 		]
 	},
+	"wastingBones" : {
+		"biome" : {
+			"terrain" : [
+				"wasteland",
+				"sand"
+			],
+			"objectType" : "other"
+		},
+		"templates" : [
+			"AVLbon00",
+			"AVLbon01",
+			"AVLbon02",
+			"AVLbon03",
+			"jaws"
+		]
+	},
 	"wastelandSkulls" : {
 		"biome" : {
 			"terrain" : "wasteland",
@@ -34,12 +50,7 @@
 			"AVLskul1",
 			"AVLskul2",
 			"AVLskul3",
-			"AVLwcsk0",
-			"AVLbon00",
-			"AVLbon01",
-			"AVLbon02",
-			"AVLbon03",
-			"jaws"
+			"AVLwcsk0"
 		]
 	}
 }

--- a/hota/Mods/wastelandTerrain/content/config/hota/wasteland/vanillaStatic/vanillaWastelandStaticBiomes.json
+++ b/hota/Mods/wastelandTerrain/content/config/hota/wasteland/vanillaStatic/vanillaWastelandStaticBiomes.json
@@ -146,12 +146,7 @@
 				"AVLskul1",
 				"AVLskul2",
 				"AVLskul3",
-				"AVLwcsk0",
-				"AVLbon00",
-				"AVLbon01",
-				"AVLbon02",
-				"AVLbon03",
-				"jaws"
+				"AVLwcsk0"
 			]
 		}
 	}


### PR DESCRIPTION
+ Fixed Black Tower normal sprite to be the actual normal version instead of the grass version
+ Fixed the HotA Wagon spawning on all terrains
+ Fixed Ivory Tower spawning on all terrains and its rarity
+ Added 1.8.0 leanTo rarity update to rmgTweaks

biomes:
+ added only the skulls (small blockers) to the core template for sand, likewise made the equivalent wasteland biome also only have skulls
+ made a new dedicated sand/wasteland biome of type "other" for the larger bones.

The result of the biome changes is that the RMG doesn't spam the large bones that much anymore, so zones look better imo