### PR TITLE
RMG ban method change to reduce warnings

### DIFF
--- a/hota/Mods/gameBalance/mods/objects/mods/rmgBan/content/config/hotaGameBalance/objectsRmgValues.json
+++ b/hota/Mods/gameBalance/mods/objects/mods/rmgBan/content/config/hotaGameBalance/objectsRmgValues.json
@@ -5,9 +5,7 @@
 	"core:coverOfDarkness" : {
 		"types" : {
 			"coverOfDarkness" : {
-				"rmg" : {
-					"zoneLimit" : 0
-				}
+				"rmg" : null
 			}
 		}
 	},
@@ -15,9 +13,7 @@
 	"core:eyeOfTheMagi" : {
 		"types" : {
 			"object" : {
-				"rmg" : {
-					"zoneLimit" : 0
-				}
+				"rmg" : null
 			}
 		}
 	},
@@ -25,9 +21,7 @@
 	"core:hutOfTheMagi" : {
 		"types" : {
 			"object" : {
-				"rmg" : {
-					"zoneLimit" : 0
-				}
+				"rmg" : null
 			}
 		}
 	},
@@ -35,9 +29,7 @@
 	"core:sanctuary" : {
 		"types" : {
 			"object" : {
-				"rmg" : {
-					"zoneLimit" : 0
-				}
+				"rmg" : null
 			}
 		}
 	},
@@ -46,19 +38,13 @@
 	"core:cartographer" : {
 		"types" : {
 			"cartographerLand" : {
-				"rmg" : {
-					"zoneLimit" : 0
-				}
+				"rmg" : null
 			},
 			"cartographerWater" : {
-				"rmg" : {
-					"zoneLimit" : 0
-				}
+				"rmg" : null
 			},
 			"cartographerSubterranean" : {
-				"rmg" : {
-					"zoneLimit" : 0
-				}
+				"rmg" : null
 			}
 		}
 	},
@@ -66,9 +52,7 @@
 	"core:hillFort" : {
 		"types" : {
 			"object" : {
-				"rmg" : {
-					"zoneLimit" : 0
-				}
+				"rmg" : null
 			}
 		}
 	},
@@ -76,19 +60,13 @@
 	"core:creatureBank" : {
 		"types" : {
 			"pirateCavern" : {
-				"rmg" : {
-					"zoneLimit" : 0
-				}
+				"rmg" : null
 			},
 			"spit" : {
-				"rmg" : {
-					"zoneLimit" : 0
-				}
+				"rmg" : null
 			},
 			"ivoryTower" : {
-				"rmg" : {
-					"zoneLimit" : 0
-				}
+				"rmg" : null
 			}
 		}
 	},
@@ -96,9 +74,7 @@
 	"hota.mapobjects:ancientLamp" : {
 		"types" : {
 			"ancientLamp" : {
-				"rmg" : {
-					"zoneLimit" : 0
-				}
+				"rmg" : null
 			}
 		}
 	}


### PR DESCRIPTION
Setting `"maxPerZone" : 0` has the side effect of the RMG picking this object for placement, realizing it should not be placed and then logging a warning for that. Example:

```
[2026-Jan-15 17:14:51.372668] WARN [TBB worker 3] global - Attempt to add ObjectInfo with 0 maxPerZone! Value: 10000
[2026-Jan-15 17:14:51.376669] WARN [TBB worker 3] global - Attempt to add ObjectInfo with 0 maxPerZone! Value: 7000
[2026-Jan-15 17:14:51.376669] WARN [TBB worker 3] global - Attempt to add ObjectInfo with 0 maxPerZone! Value: 100
```

In order to make the objects not spawn, you can just null the `"rmg"` and then these objects will never be considered by the RMG.

I've sent this in an extra PR because technically, you are overwriting the rarity/value information, but you have to set them anyway in a template if you want to enable a banned object for a zone, so I don't see any side effects.