### PR TITLE
objectsRefusable messages

### DIFF
--- a/hota/Mods/gameBalance/mods/objects/content/config/hotaGameBalance/objectsRefusable.json
+++ b/hota/Mods/gameBalance/mods/objects/content/config/hotaGameBalance/objectsRefusable.json
@@ -6,11 +6,24 @@
 			}
 		}
 	},
-
+	
+	"hota.mapobjects:colosseumOfTheMagi" : {
+		"types" : {
+			"colosseumOfTheMagi" : {
+				"canRefuse" : true
+			}
+		}
+	},
+	
 	"core:witchHut" : {
 		"types" : {
 			"witchHut" : {
-				"canRefuse" : true
+				"canRefuse" : true,
+				"rewards" : {
+					"modify@1" : {
+						"message" : "An ancient witch living in a strange hut welcomes you, offering to teach you %s for her own inscrutable purposes."
+					}
+				}
 			}
 		}
 	},
@@ -18,7 +31,18 @@
 	"core:scholar" : {
 		"types" : {
 			"scholar" : {
-				"canRefuse" : true
+				"canRefuse" : true,
+				"rewards" : {
+					"modify@1" : {
+						"message" : "As you ride into a clearing, you notice a university scholar resting his horse. He offers to teach you some of what he knows before setting off."
+					},
+					"modify@2" : {
+						"message" : "As you ride into a clearing, you notice a university scholar resting his horse. He offers to teach you some of what he knows before setting off."
+					},
+					"modify@3" : {
+						"message" : "As you ride into a clearing, you notice a university scholar resting his horse. He offers to teach you some of what he knows before setting off."
+					}
+				}
 			}
 		}
 	}

--- a/hota/Mods/gameBalance/mods/objects/content/config/hotaGameBalance/objectsRefusable.json
+++ b/hota/Mods/gameBalance/mods/objects/content/config/hotaGameBalance/objectsRefusable.json
@@ -8,7 +8,7 @@
 			}
 		}
 	},
-	
+
 	"core:witchHut" : {
 		"types" : {
 			"witchHut" : {
@@ -39,7 +39,7 @@
 				}
 			}
 		}
-	}
+	},
   
  	"hota.mapobjects:colosseumOfTheMagi" : {
 		"types" : {

--- a/hota/Mods/mapObjects/content/config/hotaMapObjects/colosseum.json
+++ b/hota/Mods/mapObjects/content/config/hotaMapObjects/colosseum.json
@@ -5,7 +5,7 @@
 		"types" : {
 			"colosseumOfTheMagi" : {
 				"name" : "Colosseum Of The Magi",
-				"description" : "(+2 spellpower or knowledge once per hero)",
+				"description" : "(+2 spellpower or knowledge\nonce per hero)",
 				"rmg" : {
 					"value" : 3000,
 					"rarity" : 50,
@@ -31,7 +31,7 @@
 						}
 					}
 				],
-				"onSelectMessage" : "{Colosseum Of The Magi}\r\n\r\nA big show is taking place at the Colosseum today. You enter the arena and hold the audience in awe with your magical prowess. Insatiable hunger for knowledge is what makes a true mage, so you gladly accept the first prize, which is one the newest academical handbooks",
+				"onSelectMessage" : "{Colosseum Of The Magi}\r\n\r\nA big show is taking place at the Colosseum today. You enter the arena and hold the audience in awe with your magical prowess. Insatiable hunger for knowledge is what makes a true mage, so you gladly accept the first prize, which is one the newest academical handbooks.",
 				"onVisitedMessage" : "{Colosseum Of The Magi}\r\n\r\nModerator of the Colosseum instantly recognises you but respectfully denies entrance to the competitor zone. You probably should rather be featuring as a talent judge here!",
 				"visitMode" : "hero",
 				"selectMode" : "selectPlayer",


### PR DESCRIPTION
+ Added Colosseum of the Magi to refusables
+ Fixed messages in objectsRefusable (Arena and Colosseum don't need this, they display their normal message)
+ Fixed a missing period in Colosseum of the Magi's message and added a line break in the description (looks better)