### PR TITLE
Black tower guard layout fix

### DIFF
--- a/hota/Mods/mapObjects/content/config/hotaMapObjects/blackTower.json
+++ b/hota/Mods/mapObjects/content/config/hotaMapObjects/blackTower.json
@@ -9,13 +9,13 @@
 				"onVisitedMessage" : "A dragon once lived in this tower, however now it is empty and holds nothing of interest.",
 				"visitMode" : "once",
 				"selectMode" : "selectFirst",
-				"guardsLayout" : "creatureBankBlackTower",
+				"guardsLayout" : "default",
 				"templates" : {
 					"normal" : {
 						"animation" : "hota/banks/avblktwr.def",
 						"visitableFrom" : [
 							"---",
-							"-+-",
+							"+++",
 							"+++"
 						],
 						"mask" : [
@@ -29,7 +29,7 @@
 						"animation" : "hota/banks/avblktgr.def",
 						"visitableFrom" : [
 							"---",
-							"-+-",
+							"+++",
 							"+++"
 						],
 						"mask" : [
@@ -47,7 +47,7 @@
 						"animation" : "hota/banks/avblktsn.def",
 						"visitableFrom" : [
 							"---",
-							"-+-",
+							"+++",
 							"+++"
 						],
 						"mask" : [

--- a/hota/Mods/mapObjects/mod.json
+++ b/hota/Mods/mapObjects/mod.json
@@ -123,30 +123,6 @@
 						178,
 						99
 					]
-				},
-				"creatureBankBlackTower" : {
-					"tacticsAllowed" : true,
-					"obstaclesAllowed" : true,
-					"attackerCommander" : 54,
-					"defenderCommander" : 83,
-					"attackerUnits" : [
-						1,
-						35,
-						69,
-						86,
-						103,
-						137,
-						171
-					],
-					"defenderUnits" : [
-						99,
-						15,
-						49,
-						66,
-						134,
-						150,
-						184
-					]
 				}
 			}
 		}


### PR DESCRIPTION
Black Tower battle is a regular battle, no fancy shenanigans.
I've removed the `"creatureBankBlackTower"` layout definition from the mod.json as it unnecessary (and it was wrong if you showed up with less than 7 units anyway).

Also fixed the visitableFrom mask.