### PR TITLE
Initial map support mapping

### DIFF
--- a/hota/Mods/bulwark/content/config/hota/bulwark/creatures/argali.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/creatures/argali.json
@@ -1,5 +1,5 @@
 {
-	"bulwarkArgali" : {
+	"argali" : {
 		"name" : {
 			"singular" : "Argali",
 			"plural" : "Argali"
@@ -51,7 +51,7 @@
 					"OPPOSITE_SIDE",
 					{
 						"type" : "UNIT_ADJACENT",
-						"creature" : "bulwarkArgali"
+						"creature" : "argali"
 					}
 				],
 				"icon" : "hota/bulwark/bonuses/spellDamageAura",

--- a/hota/Mods/bulwark/content/config/hota/bulwark/creatures/greatShaman.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/creatures/greatShaman.json
@@ -1,5 +1,5 @@
 {
-	"bulwarkGreatShaman" : {
+	"greatShaman" : {
 		"name" : {
 			"singular" : "Great Shaman",
 			"plural" : "Great Shamans"

--- a/hota/Mods/bulwark/content/config/hota/bulwark/creatures/jotunn.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/creatures/jotunn.json
@@ -1,5 +1,5 @@
 {
-	"bulwarkJotunn" : {
+	"jotunn" : {
 		"name" : {
 			"singular" : "Jotunn",
 			"plural" : "Jotunns"
@@ -7,7 +7,7 @@
 		"faction" : "bulwark",
 		"level" : 7,
 		"upgrades" : [
-			"bulwarkJotunnWarlord"
+			"jotunnWarlord"
 		],
 		"cost" : {
 			"gold" : 2000

--- a/hota/Mods/bulwark/content/config/hota/bulwark/creatures/jotunnWarlord.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/creatures/jotunnWarlord.json
@@ -1,5 +1,5 @@
 {
-	"bulwarkJotunnWarlord" : {
+	"jotunnWarlord" : {
 		"name" : {
 			"plural" : "Jotunn Warlord",
 			"singular" : "Jotunn Warlords"

--- a/hota/Mods/bulwark/content/config/hota/bulwark/creatures/kobold.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/creatures/kobold.json
@@ -1,5 +1,5 @@
 {
-	"bulwarkKobold" : {
+	"kobold" : {
 		"name" : {
 			"singular" : "Kobold",
 			"plural" : "Kobolds"
@@ -7,7 +7,7 @@
 		"faction" : "bulwark",
 		"level" : 1,
 		"upgrades" : [
-			"bulwarkKoboldForeman"
+			"koboldForeman"
 		],
 		"cost" : {
 			"gold" : 40
@@ -35,7 +35,7 @@
 				"valueType" : "BASE_NUMBER",
 				"updater" : {
 					"type" : "TIMES_ARMY_SIZE",
-					"filteredCreature" : "bulwarkKobold"
+					"filteredCreature" : "kobold"
 				},
 				"stacking" : "Kobolds",
 				"val" : 1,

--- a/hota/Mods/bulwark/content/config/hota/bulwark/creatures/koboldForeman.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/creatures/koboldForeman.json
@@ -1,5 +1,5 @@
 {
-	"bulwarkKoboldForeman" : {
+	"koboldForeman" : {
 		"name" : {
 			"singular" : "Kobold Foreman",
 			"plural" : "Kobold Foremen"
@@ -32,7 +32,7 @@
 				"valueType" : "BASE_NUMBER",
 				"updater" : {
 					"type" : "TIMES_ARMY_SIZE",
-					"filteredCreature" : "bulwarkKoboldForeman"
+					"filteredCreature" : "koboldForeman"
 				},
 				"stacking" : "KoboldForemen",
 				"val" : 1,

--- a/hota/Mods/bulwark/content/config/hota/bulwark/creatures/mammoth.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/creatures/mammoth.json
@@ -1,5 +1,5 @@
 {
-	"bulwarkMammoth" : {
+	"mammoth" : {
 		"name" : {
 			"singular" : "Mammoth",
 			"plural" : "Mammoths"
@@ -7,7 +7,7 @@
 		"faction" : "bulwark",
 		"level" : 6,
 		"upgrades" : [
-			"bulwarkWarMammoth"
+			"warMammoth"
 		],
 		"cost" : {
 			"gold" : 850

--- a/hota/Mods/bulwark/content/config/hota/bulwark/creatures/mountainRam.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/creatures/mountainRam.json
@@ -1,5 +1,5 @@
 {
-	"bulwarkMountainRam" : {
+	"mountainRam" : {
 		"name" : {
 			"singular" : "Mountain Ram",
 			"plural" : "Mountain Rams"
@@ -7,7 +7,7 @@
 		"faction" : "bulwark",
 		"level" : 2,
 		"upgrades" : [
-			"bulwarkArgali"
+			"argali"
 		],
 		"cost" : {
 			"gold" : 135

--- a/hota/Mods/bulwark/content/config/hota/bulwark/creatures/shaman.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/creatures/shaman.json
@@ -1,5 +1,5 @@
 {
-	"bulwarkShaman" : {
+	"shaman" : {
 		"name" : {
 			"singular" : "Shaman",
 			"plural" : "Shamans"
@@ -7,7 +7,7 @@
 		"faction" : "bulwark",
 		"level" : 5,
 		"upgrades" : [
-			"bulwarkGreatShaman"
+			"greatShaman"
 		],
 		"cost" : {
 			"gold" : 450

--- a/hota/Mods/bulwark/content/config/hota/bulwark/creatures/snowElf.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/creatures/snowElf.json
@@ -1,5 +1,5 @@
 {
-	"bulwarkSnowElf" : {
+	"snowElf" : {
 		"name" : {
 			"singular" : "Snow Elf",
 			"plural" : "Snow Elves"
@@ -7,7 +7,7 @@
 		"faction" : "bulwark",
 		"level" : 3,
 		"upgrades" : [
-			"bulwarkSteelElf"
+			"steelElf"
 		],
 		"cost" : {
 			"gold" : 230

--- a/hota/Mods/bulwark/content/config/hota/bulwark/creatures/steelElf.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/creatures/steelElf.json
@@ -1,5 +1,5 @@
 {
-	"bulwarkSteelElf" : {
+	"steelElf" : {
 		"name" : {
 			"singular" : "Steel Elf",
 			"plural" : "Steel Elves"

--- a/hota/Mods/bulwark/content/config/hota/bulwark/creatures/warMammoth.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/creatures/warMammoth.json
@@ -1,5 +1,5 @@
 {
-	"bulwarkWarMammoth" : {
+	"warMammoth" : {
 		"name" : {
 			"singular" : "War Mammoth",
 			"plural" : "War Mammoths"

--- a/hota/Mods/bulwark/content/config/hota/bulwark/creatures/yeti.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/creatures/yeti.json
@@ -1,5 +1,5 @@
 {
-	"bulwarkYeti" : {
+	"yeti" : {
 		"name" : {
 			"singular" : "Yeti",
 			"plural" : "Yeti"
@@ -7,7 +7,7 @@
 		"faction" : "bulwark",
 		"level" : 4,
 		"upgrades" : [
-			"bulwarkYetiRunemaster"
+			"yetiRunemaster"
 		],
 		"cost" : {
 			"gold" : 325

--- a/hota/Mods/bulwark/content/config/hota/bulwark/creatures/yetiRunemaster.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/creatures/yetiRunemaster.json
@@ -1,5 +1,5 @@
 {
-	"bulwarkYetiRunemaster" : {
+	"yetiRunemaster" : {
 		"name" : {
 			"singular" : "Yeti Runemaster",
 			"plural" : "Yeti Runemasters"

--- a/hota/Mods/bulwark/content/config/hota/bulwark/dwellings.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/dwellings.json
@@ -5,7 +5,7 @@
 				"name" : "Colliery",
 				"creatures" : [
 					[
-						"bulwarkKobold"
+						"kobold"
 					]
 				],
 				"sounds" : {
@@ -29,7 +29,7 @@
 				"name" : "Frigid Spur",
 				"creatures" : [
 					[
-						"bulwarkMountainRam"
+						"mountainRam"
 					]
 				],
 				"sounds" : {
@@ -53,7 +53,7 @@
 				"name" : "Hall of the Bold",
 				"creatures" : [
 					[
-						"bulwarkSnowElf"
+						"snowElf"
 					]
 				],
 				"sounds" : {
@@ -77,7 +77,7 @@
 				"name" : "Mountain Embassy",
 				"creatures" : [
 					[
-						"bulwarkYeti"
+						"yeti"
 					]
 				],
 				"sounds" : {
@@ -101,7 +101,7 @@
 				"name" : "Shaman Fane",
 				"creatures" : [
 					[
-						"bulwarkShaman"
+						"shaman"
 					]
 				],
 				"sounds" : {
@@ -126,7 +126,7 @@
 				"name" : "Mammoth Stalls",
 				"creatures" : [
 					[
-						"bulwarkMammoth"
+						"mammoth"
 					]
 				],
 				"sounds" : {
@@ -151,7 +151,7 @@
 				"name" : "Frosthome",
 				"creatures" : [
 					[
-						"bulwarkJotunn"
+						"jotunn"
 					]
 				],
 				"guards" : true,

--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroClasses/chieftain.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroClasses/chieftain.json
@@ -4,7 +4,7 @@
 		"faction" : "bulwark",
 		"affinity" : "might",
 		"defaultTavern" : 5,
-		"commander" : "bulwarkShaman", // placeholder
+		"commander" : "shaman", // placeholder
 		"animation" : {
 			"battle" : {
 				"female" : "hota/bulwark/heroClasses/chieftain/battle/CH22b_08.def",

--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroClasses/elder.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroClasses/elder.json
@@ -4,7 +4,7 @@
 		"faction" : "bulwark",
 		"affinity" : "magic",
 		"defaultTavern" : 5,
-		"commander" : "bulwarkShaman", // placeholder
+		"commander" : "shaman", // placeholder
 		"animation" : {
 			"battle" : {
 				"female" : "hota/bulwark/heroClasses/elder/battle/CH23b_08.DEF",

--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroes/akka.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroes/akka.json
@@ -1,5 +1,5 @@
 {
-	"15bulwarkAkka" : {
+	"15akka" : {
 		"class" : "elder",
 		"female" : true,
 		"images" : {
@@ -10,17 +10,17 @@
 		},
 		"army" : [
 			{
-				"creature" : "bulwarkKobold",
+				"creature" : "kobold",
 				"min" : 20,
 				"max" : 30
 			},
 			{
-				"creature" : "bulwarkMountainRam",
+				"creature" : "mountainRam",
 				"min" : 6,
 				"max" : 8
 			},
 			{
-				"creature" : "bulwarkSnowElf",
+				"creature" : "snowElf",
 				"min" : 3,
 				"max" : 5
 			}

--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroes/allora.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroes/allora.json
@@ -1,5 +1,5 @@
 {
-	"17bulwarkAllora" : {
+	"17allora" : {
 		"class" : "elder",
 		"female" : true,
 		"images" : {
@@ -10,17 +10,17 @@
 		},
 		"army" : [
 			{
-				"creature" : "bulwarkKobold",
+				"creature" : "kobold",
 				"min" : 20,
 				"max" : 30
 			},
 			{
-				"creature" : "bulwarkMountainRam",
+				"creature" : "mountainRam",
 				"min" : 6,
 				"max" : 8
 			},
 			{
-				"creature" : "bulwarkSnowElf",
+				"creature" : "snowElf",
 				"min" : 3,
 				"max" : 5
 			}

--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroes/biarma.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroes/biarma.json
@@ -1,5 +1,5 @@
 {
-	"13bulwarkBiarma" : {
+	"13biarma" : {
 		"class" : "elder",
 		"female" : true,
 		"onlyOnMapWithoutWater" : true,
@@ -11,7 +11,7 @@
 		},
 		"army" : [
 			{
-				"creature" : "bulwarkKobold",
+				"creature" : "kobold",
 				"min" : 20,
 				"max" : 30
 			},
@@ -21,7 +21,7 @@
 				"max" : 1
 			},
 			{
-				"creature" : "bulwarkSnowElf",
+				"creature" : "snowElf",
 				"min" : 3,
 				"max" : 5
 			}

--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroes/creyle.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroes/creyle.json
@@ -1,5 +1,5 @@
 {
-	"05bulwarkCreyle" : {
+	"05creyle" : {
 		"class" : "chieftain",
 		"female" : true,
 		"images" : {
@@ -10,17 +10,17 @@
 		},
 		"army" : [
 			{
-				"creature" : "bulwarkKobold",
+				"creature" : "kobold",
 				"min" : 20,
 				"max" : 30
 			},
 			{
-				"creature" : "bulwarkMountainRam",
+				"creature" : "mountainRam",
 				"min" : 6,
 				"max" : 8
 			},
 			{
-				"creature" : "bulwarkSnowElf",
+				"creature" : "snowElf",
 				"min" : 3,
 				"max" : 5
 			}
@@ -32,7 +32,7 @@
 			}
 		],
 		"specialty" : {
-			"creature" : "bulwarkMammoth"
+			"creature" : "mammoth"
 		},
 		"texts" : {
 			"name" : "Creyle",

--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroes/dalton.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroes/dalton.json
@@ -1,5 +1,5 @@
 {
-	"12bulwarkDalton" : {
+	"12dalton" : {
 		"class" : "elder",
 		"female" : false,
 		"images" : {
@@ -10,17 +10,17 @@
 		},
 		"army" : [
 			{
-				"creature" : "bulwarkKobold",
+				"creature" : "kobold",
 				"min" : 20,
 				"max" : 30
 			},
 			{
-				"creature" : "bulwarkMountainRam",
+				"creature" : "mountainRam",
 				"min" : 6,
 				"max" : 8
 			},
 			{
-				"creature" : "bulwarkSnowElf",
+				"creature" : "snowElf",
 				"min" : 3,
 				"max" : 5
 			}

--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroes/dhuin.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroes/dhuin.json
@@ -1,5 +1,5 @@
 {
-	"01bulwarkDhuin" : {
+	"01dhuin" : {
 		"class" : "chieftain",
 		"female" : false,
 		"images" : {
@@ -10,17 +10,17 @@
 		},
 		"army" : [
 			{
-				"creature" : "bulwarkKobold",
+				"creature" : "kobold",
 				"min" : 20,
 				"max" : 30
 			},
 			{
-				"creature" : "bulwarkSnowElf",
+				"creature" : "snowElf",
 				"min" : 3,
 				"max" : 5
 			},
 			{
-				"creature" : "bulwarkSnowElf",
+				"creature" : "snowElf",
 				"min" : 3,
 				"max" : 5
 			}
@@ -36,7 +36,7 @@
 			}
 		],
 		"specialty" : {
-			"creature" : "bulwarkSnowElf"
+			"creature" : "snowElf"
 		},
 		"texts" : {
 			"name" : "Dhuin",

--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroes/eikthurn.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroes/eikthurn.json
@@ -1,5 +1,5 @@
 {
-	"04bulwarkEikthurn" : {
+	"04eikthurn" : {
 		"class" : "chieftain",
 		"female" : false,
 		"images" : {
@@ -10,17 +10,17 @@
 		},
 		"army" : [
 			{
-				"creature" : "bulwarkMountainRam",
+				"creature" : "mountainRam",
 				"min" : 6,
 				"max" : 8
 			},
 			{
-				"creature" : "bulwarkMountainRam",
+				"creature" : "mountainRam",
 				"min" : 6,
 				"max" : 8
 			},
 			{
-				"creature" : "bulwarkMountainRam",
+				"creature" : "mountainRam",
 				"min" : 6,
 				"max" : 8
 			}
@@ -32,7 +32,7 @@
 			}
 		],
 		"specialty" : {
-			"creature" : "bulwarkMountainRam"
+			"creature" : "mountainRam"
 		},
 		"texts" : {
 			"name" : "Eikthurn",

--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroes/ergon.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroes/ergon.json
@@ -1,5 +1,5 @@
 {
-	"08bulwarkErgon" : {
+	"08ergon" : {
 		"class" : "chieftain",
 		"female" : false,
 		"images" : {
@@ -10,17 +10,17 @@
 		},
 		"army" : [
 			{
-				"creature" : "bulwarkKobold",
+				"creature" : "kobold",
 				"min" : 20,
 				"max" : 30
 			},
 			{
-				"creature" : "bulwarkMountainRam",
+				"creature" : "mountainRam",
 				"min" : 6,
 				"max" : 8
 			},
 			{
-				"creature" : "bulwarkSnowElf",
+				"creature" : "snowElf",
 				"min" : 3,
 				"max" : 5
 			}

--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroes/glacius.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroes/glacius.json
@@ -1,5 +1,5 @@
 {
-	"10bulwarkGlacius" : {
+	"10glacius" : {
 		"class" : "elder",
 		"female" : false,
 		"images" : {
@@ -10,17 +10,17 @@
 		},
 		"army" : [
 			{
-				"creature" : "bulwarkKobold",
+				"creature" : "kobold",
 				"min" : 20,
 				"max" : 30
 			},
 			{
-				"creature" : "bulwarkMountainRam",
+				"creature" : "mountainRam",
 				"min" : 6,
 				"max" : 8
 			},
 			{
-				"creature" : "bulwarkSnowElf",
+				"creature" : "snowElf",
 				"min" : 3,
 				"max" : 5
 			}

--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroes/haugir.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroes/haugir.json
@@ -1,5 +1,5 @@
 {
-	"14bulwarkHaugir" : {
+	"14haugir" : {
 		"class" : "elder",
 		"onlyOnWaterMap" : true,
 		"female" : false,
@@ -11,17 +11,17 @@
 		},
 		"army" : [
 			{
-				"creature" : "bulwarkKobold",
+				"creature" : "kobold",
 				"min" : 20,
 				"max" : 30
 			},
 			{
-				"creature" : "bulwarkMountainRam",
+				"creature" : "mountainRam",
 				"min" : 6,
 				"max" : 8
 			},
 			{
-				"creature" : "bulwarkSnowElf",
+				"creature" : "snowElf",
 				"min" : 3,
 				"max" : 5
 			}

--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroes/kriv.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroes/kriv.json
@@ -1,5 +1,5 @@
 {
-	"09bulwarkKriv" : {
+	"09kriv" : {
 		"class" : "elder",
 		"female" : false,
 		"images" : {
@@ -10,17 +10,17 @@
 		},
 		"army" : [
 			{
-				"creature" : "bulwarkKobold",
+				"creature" : "kobold",
 				"min" : 20,
 				"max" : 30
 			},
 			{
-				"creature" : "bulwarkMountainRam",
+				"creature" : "mountainRam",
 				"min" : 6,
 				"max" : 8
 			},
 			{
-				"creature" : "bulwarkSnowElf",
+				"creature" : "snowElf",
 				"min" : 3,
 				"max" : 5
 			}
@@ -32,7 +32,7 @@
 			}
 		],
 		"specialty" : {
-			"creature" : "bulwarkShaman"
+			"creature" : "shaman"
 		},
 		"spellbook" : [
 			"viewAir"

--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroes/kynr.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroes/kynr.json
@@ -1,5 +1,5 @@
 {
-	"07bulwarkKynr" : {
+	"07kynr" : {
 		"class" : "chieftain",
 		"female" : false,
 		"images" : {
@@ -10,17 +10,17 @@
 		},
 		"army" : [
 			{
-				"creature" : "bulwarkKobold",
+				"creature" : "kobold",
 				"min" : 20,
 				"max" : 30
 			},
 			{
-				"creature" : "bulwarkKobold",
+				"creature" : "kobold",
 				"min" : 20,
 				"max" : 30
 			},
 			{
-				"creature" : "bulwarkKobold",
+				"creature" : "kobold",
 				"min" : 20,
 				"max" : 30
 			}
@@ -36,7 +36,7 @@
 			}
 		],
 		"specialty" : {
-			"creature" : "bulwarkKobold",
+			"creature" : "kobold",
 			"stepSize" : 10
 		},
 		"texts" : {

--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroes/neia.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroes/neia.json
@@ -1,5 +1,5 @@
 {
-	"03bulwarkNeia" : {
+	"03neia" : {
 		"class" : "chieftain",
 		"female" : true,
 		"images" : {
@@ -10,17 +10,17 @@
 		},
 		"army" : [
 			{
-				"creature" : "bulwarkKobold",
+				"creature" : "kobold",
 				"min" : 20,
 				"max" : 30
 			},
 			{
-				"creature" : "bulwarkMountainRam",
+				"creature" : "mountainRam",
 				"min" : 6,
 				"max" : 8
 			},
 			{
-				"creature" : "bulwarkSnowElf",
+				"creature" : "snowElf",
 				"min" : 3,
 				"max" : 5
 			}

--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroes/oidana.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroes/oidana.json
@@ -1,5 +1,5 @@
 {
-	"02bulwarkOidana" : {
+	"02oidana" : {
 		"class" : "chieftain",
 		"female" : true,
 		"images" : {
@@ -10,17 +10,17 @@
 		},
 		"army" : [
 			{
-				"creature" : "bulwarkKobold",
+				"creature" : "kobold",
 				"min" : 20,
 				"max" : 30
 			},
 			{
-				"creature" : "bulwarkMountainRam",
+				"creature" : "mountainRam",
 				"min" : 6,
 				"max" : 8
 			},
 			{
-				"creature" : "bulwarkSnowElf",
+				"creature" : "snowElf",
 				"min" : 3,
 				"max" : 5
 			}

--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroes/sial.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroes/sial.json
@@ -1,5 +1,5 @@
 {
-	"11bulwarkSial" : {
+	"11sial" : {
 		"class" : "elder",
 		"female" : true,
 		"images" : {
@@ -10,17 +10,17 @@
 		},
 		"army" : [
 			{
-				"creature" : "bulwarkKobold",
+				"creature" : "kobold",
 				"min" : 20,
 				"max" : 30
 			},
 			{
-				"creature" : "bulwarkMountainRam",
+				"creature" : "mountainRam",
 				"min" : 6,
 				"max" : 8
 			},
 			{
-				"creature" : "bulwarkSnowElf",
+				"creature" : "snowElf",
 				"min" : 3,
 				"max" : 5
 			}

--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroes/spadum.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroes/spadum.json
@@ -1,5 +1,5 @@
 {
-	"06bulwarkSpadum" : {
+	"06spadum" : {
 		"class" : "chieftain",
 		"female" : false,
 		"images" : {
@@ -10,17 +10,17 @@
 		},
 		"army" : [
 			{
-				"creature" : "bulwarkKobold",
+				"creature" : "kobold",
 				"min" : 20,
 				"max" : 30
 			},
 			{
-				"creature" : "bulwarkMountainRam",
+				"creature" : "mountainRam",
 				"min" : 6,
 				"max" : 8
 			},
 			{
-				"creature" : "bulwarkSnowElf",
+				"creature" : "snowElf",
 				"min" : 3,
 				"max" : 5
 			}
@@ -36,7 +36,7 @@
 			}
 		],
 		"specialty" : {
-			"creature" : "bulwarkYeti"
+			"creature" : "yeti"
 		},
 		"texts" : {
 			"name" : "Spadum",

--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroes/vehr.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroes/vehr.json
@@ -1,5 +1,5 @@
 {
-	"16bulwarkVehr" : {
+	"16vehr" : {
 		"class" : "elder",
 		"female" : true,
 		"images" : {
@@ -10,17 +10,17 @@
 		},
 		"army" : [
 			{
-				"creature" : "bulwarkKobold",
+				"creature" : "kobold",
 				"min" : 20,
 				"max" : 30
 			},
 			{
-				"creature" : "bulwarkMountainRam",
+				"creature" : "mountainRam",
 				"min" : 6,
 				"max" : 8
 			},
 			{
-				"creature" : "bulwarkSnowElf",
+				"creature" : "snowElf",
 				"min" : 3,
 				"max" : 5
 			}

--- a/hota/Mods/bulwark/content/config/hota/bulwark/mapObjects/interactive/trapperLodge.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/mapObjects/interactive/trapperLodge.json
@@ -42,7 +42,7 @@
 							{
 								"anyOf" : [
 									"gremlin",
-									"bulwarkKobold"
+									"kobold"
 								],
 								"min" : 3,
 								"max" : 5

--- a/hota/Mods/bulwark/content/config/hota/bulwark/town/siege.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/town/siege.json
@@ -2,7 +2,7 @@
 	"bulwark" : {
 		"town" : {
 			"siege" : {
-				"shooter" : "bulwarkSnowElf",
+				"shooter" : "snowElf",
 				"imagePrefix" : "hota/bulwark/town/siege/sgbk",
 				"towerIconSmall" : "hota/bulwark/town/icons/arrowtowerssmall",
 				"towerIconLarge" : "hota/bulwark/town/icons/arrowtowerslarge",

--- a/hota/Mods/bulwark/content/config/hota/bulwark/town/town.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/town/town.json
@@ -16,32 +16,32 @@
 
 			"creatures" : [
 				[
-					"bulwarkKobold",
-					"bulwarkKoboldForeman"
+					"kobold",
+					"koboldForeman"
 				],
 				[
-					"bulwarkMountainRam",
-					"bulwarkArgali"
+					"mountainRam",
+					"argali"
 				],
 				[
-					"bulwarkSnowElf",
-					"bulwarkSteelElf"
+					"snowElf",
+					"steelElf"
 				],
 				[
-					"bulwarkYeti",
-					"bulwarkYetiRunemaster"
+					"yeti",
+					"yetiRunemaster"
 				],
 				[
-					"bulwarkShaman",
-					"bulwarkGreatShaman"
+					"shaman",
+					"greatShaman"
 				],
 				[
-					"bulwarkMammoth",
-					"bulwarkWarMammoth"
+					"mammoth",
+					"warMammoth"
 				],
 				[
-					"bulwarkJotunn",
-					"bulwarkJotunnWarlord"
+					"jotunn",
+					"jotunnWarlord"
 				]
 			],
 

--- a/hota/Mods/mapSupport/mod.json
+++ b/hota/Mods/mapSupport/mod.json
@@ -2,15 +2,16 @@
 	"name" : "Map format support (HotA)",
 	"description" : "This mod contains support files needed for loading maps in 'Horn of the Abyss' format in VCMI",
 	"modType" : "Other",
-	"author" : "Ivan",
+	"author" : "VCMI Team, Ivan",
 	"contact" : "https://forum.vcmi.eu/",
-	"version" : "1.2",
+	"version" : "1.8.0",
 	"compatibility" : {
-		"min" : "1.7"
+		"min" : "1.7.2"
 	},
 	"depends" : [
 		"hota.airship",
 		"hota.artifacts",
+		"hota.bulwark",
 		"hota.cannon",
 		"hota.confluxvaultofashes",
 		"hota.cove",
@@ -420,7 +421,8 @@
 
 				"factions" : {
 					"cove" : 9,
-					"factory" : 10
+					"factory" : 10,
+					"bulwark" : 11
 				},
 				"buildings" : {
 					"cove" : {
@@ -472,7 +474,22 @@
 					"hotaCouatl" : 182,
 					"crimsonCouatl" : 183,
 					"hotaDreadnought" : 184,
-					"hotaJuggernaut" : 185
+					"hotaJuggernaut" : 185,
+					//bulwark
+					"kobold" : 186,
+					"koboldForeman" : 187,
+					"mountainRam" : 188,
+					"argali" : 189,
+					"snowElf" : 190,
+					"steelElf" : 191,
+					"yeti" : 192,
+					"yetiRunemaster" : 193,
+					"shaman" : 194,
+					"greatShaman" : 195,
+					"mammoth" : 196,
+					"warMammoth" : 197,
+					"jotunn" : 198,
+					"jotunnWarlord" : 199
 				},
 
 				"heroes" : {
@@ -533,9 +550,27 @@
 					//					"athe" : 211,
 					//					"gruezak" : 212,
 					//					"zog" : 213,
-					"boyd" : 198
+					"boyd" : 198,
 					//					"hotaMaximus" : 215,
 					//					"balfour" : 216
+					//bulwark
+					"01dhuin" : 199,
+					"02oidana" : 200,
+					"03neia" : 201,
+					"04eikthurn" : 202,
+					"05creyle" : 203,
+					"06spadum" : 204,
+					"07kynr" : 205,
+					"08ergon" : 206,
+					"09kriv" : 207,
+					"10glacius" : 208,
+					"11sial" : 209,
+					"12dalton" : 210,
+					"13biarma" : 211,
+					"14haugir" : 212,
+					"15akka" : 213,
+					"16vehr" : 214,
+					"17allora" : 215
 				},
 
 				"portraits" : {
@@ -605,7 +640,25 @@
 					"portraitTarnumBeastmasterHotA" : 224,
 					"gruezak" : 225,
 					"hotaMaximus" : 226,
-					"balfour" : 227
+					"balfour" : 227,
+					//bulwark
+					"01dhuin" : 228,
+					"02oidana" : 229,
+					"03neia" : 230,
+					"04eikthurn" : 231,
+					"05creyle" : 232,
+					"06spadum" : 233,
+					"07kynr" : 234,
+					"08ergon" : 235,
+					"09kriv" : 236,
+					"10glacius" : 237,
+					"11sial" : 238,
+					"12dalton" : 239,
+					"13biarma" : 240,
+					"14haugir" : 241,
+					"15akka" : 242,
+					"16vehr" : 243,
+					"17allora" : 244		
 				},
 				"artifacts" : {
 					"diplomatsCloak" : 141,
@@ -638,10 +691,14 @@
 					"navigator" : 19,
 
 					"mercenary" : 20,
-					"artificer" : 21
+					"artificer" : 21,
+
+					"chieftain" : 22,
+					"elder" : 23
 				},
 				"skills" : {
-					"interference" : 28
+					"interference" : 28,
+					"runes" : 29
 				},
 				"terrains" : {
 					"highlands" : 10,
@@ -794,6 +851,7 @@
 							83,
 							5
 						]
+						// TODO snow seerhut
 					},
 					"questGuard" : {
 						"questGate" : [
@@ -941,6 +999,7 @@
 							17,
 							110
 						]
+						// bulwark TODO
 					},
 					"creatureGeneratorSpecial" : {
 						"whirpoolLarge" : [
@@ -1774,6 +1833,21 @@
 					"hota/factory/creatures/adventureMap/AVWalmd.def" : "AVWalmd.def",
 					"hota/factory/creatures/adventureMap/AVWalmb.def" : "AVWalmb.def",
 
+					"hota/bulwark/creatures/adventureMap/AVWKOBOL.def" : "AVWKOBOL.def",
+					"hota/bulwark/creatures/adventureMap/AVWFKOBL.def" : "AVWFKOBL.def",
+					"hota/bulwark/creatures/adventureMap/AVWMTRAM.def" : "AVWMTRAM.def",
+					"hota/bulwark/creatures/adventureMap/AVWARGAL.def" : "AVWARGAL.def",
+					"hota/bulwark/creatures/adventureMap/AVWSNELF.def" : "AVWSNELF.def",
+					"hota/bulwark/creatures/adventureMap/AVWSTELF.def" : "AVWSTELF.def",
+					"hota/bulwark/creatures/adventureMap/AVWYETI.def" : "AVWYETI.def",
+					"hota/bulwark/creatures/adventureMap/AVWMSPRT.def" : "AVWMSPRT.def",
+					"hota/bulwark/creatures/adventureMap/AVWSHAMN.def" : "AVWSHAMN.def",
+					"hota/bulwark/creatures/adventureMap/AVWGSHMN.def" : "AVWGSHMN.def",
+					"hota/bulwark/creatures/adventureMap/AVWMAMTH.def" : "AVWMAMTH.def",
+					"hota/bulwark/creatures/adventureMap/AVWWMAMT.def" : "AVWWMAMT.def",
+					"hota/bulwark/creatures/adventureMap/AVWJOTUN.def" : "AVWJOTUN.def",
+					"hota/bulwark/creatures/adventureMap/AVWJOTNW.def" : "AVWJOTNW.def",
+
 					"hota/cove/mapObjects/dwellings/nimphfo.def" : "nimphfo.def",
 					"hota/cove/mapObjects/dwellings/swshcamp.def" : "swshcamp.def",
 					"hota/cove/mapObjects/dwellings/fregat.def" : "fregat.def",
@@ -1792,6 +1866,14 @@
 					"hota/factory/mapObjects/dwellings/AVGauto.def" : "AVGauto.def",
 					"hota/factory/mapObjects/dwellings/AVGarma.def" : "AVGarma.def",
 					"hota/factory/mapObjects/dwellings/AVG2half.def" : "AVG2half.def",
+
+					"hota/bulwark/mapObjects/dwellings/AVGagrl0.def" : "AVGagrl0.def",
+					"hota/bulwark/mapObjects/dwellings/AVGjotn0.def" : "AVGjotn0.def",
+					"hota/bulwark/mapObjects/dwellings/AVGkbl01.def" : "AVGkbl01.def",
+					"hota/bulwark/mapObjects/dwellings/AVGmmth0.def" : "AVGmmth0.def",
+					"hota/bulwark/mapObjects/dwellings/AVGshmn0.def" : "AVGshmn0.def",
+					"hota/bulwark/mapObjects/dwellings/AVGvori0.def" : "AVGvori0.def",
+					"hota/bulwark/mapObjects/dwellings/AVGyeti0.def" : "AVGyeti0.def",
 
 					"hota/warehouses/avwrhscr.def" : "avwrhscr.def",
 					"hota/warehouses/avwrhsgl.def" : "avwrhsgl.def",
@@ -2153,7 +2235,7 @@
 					"HORN4.bik" : 115, // H3HORN Hota0304.h3m.prolog
 					"HORN5.bik" : 116, // H3HORN Hota0304.h3m.epilog
 
-					// unused?
+					// Custom maps - oh3 video with different mapping?
 					// "HotaVideo117" : 117,
 					// "HotaVideo118" : 118,
 					// "HotaVideo119" : 119,


### PR DESCRIPTION
Standardized heroes and creatures ids and added initial mapping

When https://github.com/vcmi/vcmi/pull/6608 merged we can also update maps to 1.8 version in repo

New objects must be placed in HotA editor and check against missing console warnings.