### PR TITLE
Add Faerie Ring to Highlands

### DIFF
--- a/hota/Mods/highlandsTerrain/content/config/hota/highlands/vanillaInteractive/faerieRing.json
+++ b/hota/Mods/highlandsTerrain/content/config/hota/highlands/vanillaInteractive/faerieRing.json
@@ -1,0 +1,25 @@
+{
+	"core:faerieRing" : {
+		"types" : {
+			"faerieRing" : {
+				"templates" : {
+					"highlandsFaerieRing" : {
+						"animation" : "AVSRING0.def",
+						"mask" : [
+							"VVV",
+							"VAB"
+						],
+						"visitableFrom" : [
+							"---",
+							"++-",
+							"+++"
+						],
+						"allowedTerrains" : [
+							"highlands"
+						]
+					}
+				}
+			}
+		}
+	}
+}

--- a/hota/Mods/highlandsTerrain/mod.json
+++ b/hota/Mods/highlandsTerrain/mod.json
@@ -58,6 +58,7 @@
 		"config/hota/highlands/vanillaInteractive/obelisk.json",
 		"config/hota/highlands/vanillaInteractive/signs.json",
 		"config/hota/highlands/vanillaInteractive/tradingPost.json",
+		"config/hota/highlands/vanillaInteractive/faerieRing.json",
 		"config/hota/highlands/hotaInteractive/churchyard.json",
 		"config/hota/highlands/hotaInteractive/gazebo.json",
 		"config/hota/highlands/hotaInteractive/hermitsShack.json",


### PR DESCRIPTION
Highlands is one of the few terrains that can actually spawn a Faerie Ring. This PR adds the missing template.

There are still vanilla objects missing, but I feel that these are issues in core, not in the terrain, so I didn't add them. Made an issue for that (https://github.com/vcmi/vcmi/issues/6737), but to recap, the following objects cannot spawn on some terrains even if they should:

+ Garden of Revelation (not on snow (why lol) and mod terrains)
+ Magic Well (not on mod terrains)
+ Redwood Observatory (not on mod terrains)
+ Campfire (not on mod terrains)

If you feel that any of those should be added on per mod basis, I can add them, but those should really spawn everywhere, no?