### PR TITLE
Fair market rate bonus

### DIFF
--- a/hota/Mods/bulwark/content/config/hota/bulwark/town/buildings.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/town/buildings.json
@@ -125,6 +125,13 @@
 					"marketModes" : [
 						"resource-resource",
 						"resource-player"
+					],
+					"bonuses": [
+						{
+							"propagator": "PLAYER",
+							"type": "MARKETPLACE_ACCESS",
+							"val": 2
+						}
 					]
 				},
 				"special2" : {


### PR DESCRIPTION
+ Adds the bonus for Bulwark's Fair building (counts as 2 additional marketplaces).

See: https://github.com/vcmi/vcmi/pull/6728

Requires at minimum VCMI-branch-beta-e4ab14a (2026-Jan-16 23:23)