### PR TITLE
Pre-configure support for Sea Barrel and Grave (I think)

### DIFF
--- a/hota/Mods/mapObjects/content/config/hotaMapObjects/seaBarrel.json
+++ b/hota/Mods/mapObjects/content/config/hotaMapObjects/seaBarrel.json
@@ -25,11 +25,25 @@
 				},
 				"blockedVisitable" : true,
 				"removable" : true,
+				"variables" : {
+					"resource" : {
+						"gainedResource" : { 
+							"anyOf" : [ "mercury", "gems", "sulfur", "crystal" ]
+						}
+					},
+					"number" : {
+						"gainedAmount" : {
+							"min" : 3,
+							"max" : 6
+						}
+					}
+				},
 				"rewards" : [
 					{
 						"appearChance" : {
 							"max" : 20
 						},
+						"mapDice" : 1,
 						"message" : "{Sea Barrel}\r\n\r\nThis barrel is full of sea water. You have no idea why it is still afloat.",
 						"removeObject" : true
 					},
@@ -37,18 +51,13 @@
 						"appearChance" : {
 							"min" : 20
 						},
-						"resources" : {
-							"list" : [
-								"mercury",
-								"sulfur",
-								"crystal",
-								"gems"
-							],
-							"amount" : {
-								"min" : 3,
-								"max" : 6
+						"mapDice" : 0,
+						"resources" : [
+							{
+								"type" : "@gainedResource",
+								"amount" : "@gainedAmount"
 							}
-						},
+						],
 						"message" : "{Sea Barrel}\r\n\r\nThis barrel is holding neither water nor wine, but rather some smuggled goods.",
 						"removeObject" : true
 					}

--- a/hota/Mods/wastelandTerrain/content/config/hota/wasteland/hotaInteractive/grave.json
+++ b/hota/Mods/wastelandTerrain/content/config/hota/wasteland/hotaInteractive/grave.json
@@ -17,6 +17,25 @@
 					"value" : 500,
 					"rarity" : 30
 				},
+				"variables" : {
+					"artifact" : {
+						"gainedArtifact" : { 
+							"anyOf" : [
+								{
+									"class" : "TREASURE"
+								},
+								{
+									"class" : "MINOR"
+								}
+							]
+						}
+					},
+					"number" : {
+						"gainedAmount" : {
+							"amount" : [ 1500, 2000, 2500, 3000, 3500, 4000 ]
+						}
+					}
+				},
 				"removable" : true,
 				"blockedVisitable" : false,
 				"showScoutedPreview" : false,
@@ -24,59 +43,20 @@
 				"rewards" : [
 					{
 						"message" : "{Grave}\n\nThis tomb is fresh, and even the shovel someone dug it with hasn't been stolen yet.\nDo you want to take up the latter, cover your nose with a handkerchief, and extract something valuable from the ground and call it a day?",
-						"appearChance" : {
-							"max" : 50
-						},
-						"resources" : {
-							"gold" : [
-								1500,
-								2000,
-								2500,
-								3000,
-								3500,
-								4000
-							]
-						},
+						"resources" : [
+							{
+								"type" : "gold",
+								"amount" : "@gainedAmount"
+							}
+						],
+						"artifacts" : [
+							"@gainedArtifact"
+						],
 						"bonuses" : [
 							{
 								"type" : "MORALE",
 								"val" : -3,
 								"duration" : "ONE_BATTLE"
-							}
-						],
-						"artifacts" : [
-							{
-								"class" : "TREASURE"
-							}
-						],
-						"movePercentage" : 0,
-						"removeObject" : true
-					},
-					{
-						"message" : "{Grave}\n\nThis tomb is fresh, and even the shovel someone dug it with hasn't been stolen yet.\nDo you want to take up the latter, cover your nose with a handkerchief, and extract something valuable from the ground and call it a day?",
-						"appearChance" : {
-							"min" : 50
-						},
-						"resources" : {
-							"gold" : [
-								1500,
-								2000,
-								2500,
-								3000,
-								3500,
-								4000
-							]
-						},
-						"bonuses" : [
-							{
-								"type" : "MORALE",
-								"val" : -3,
-								"duration" : "ONE_BATTLE"
-							}
-						],
-						"artifacts" : [
-							{
-								"class" : "MINOR"
 							}
 						],
 						"movePercentage" : 0,


### PR DESCRIPTION
I gotta be honest here, I have no clue what a "mapDice" is and it also isn't explained anywhere, so I randomly plopped in some numbers until it seemed to work. Left it out of Grave entirely (not sure if that is a mistake either), but my testing said it's fine.

How I tested:
[bullshit.zip](https://github.com/user-attachments/files/24696806/bullshit.zip)
This map is called "zzzzzzgraveTest" ingame and contains a preconfigured Grave (upper one always gives 15 Gold and Boots of Speed) and a normal one. It also contains several sea barrels: top-left always gives some 50ish sulfur, bottom-left is always empty, others are random.

I restarted this map several times and the fixed rewards seem fixed and the random rewards seem random, so I guess that worked? Sea Barrel also logs the same warning as Wagon and Campfire, so that is reassuring.

About Ancient Lamp... yeah, that building doesn't even properly function, so I have not the slightest idea how to do this.