### PR TITLE
Preconfigure support for HotA mapObjects

### DIFF
--- a/hota/Mods/highlandsTerrain/content/config/hota/highlands/hotaInteractive/ruins.json
+++ b/hota/Mods/highlandsTerrain/content/config/hota/highlands/hotaInteractive/ruins.json
@@ -57,6 +57,7 @@
 							"min" : 0,
 							"max" : 30
 						},
+						"mapDice" : 0,
 						"guards" : [
 							{
 								"amount" : 20,
@@ -96,6 +97,7 @@
 							"min" : 30,
 							"max" : 60
 						},
+						"mapDice" : 1,
 						"guards" : [
 							{
 								"amount" : 30,
@@ -135,6 +137,7 @@
 							"min" : 60,
 							"max" : 90
 						},
+						"mapDice" : 2,
 						"guards" : [
 							{
 								"amount" : 40,
@@ -174,6 +177,7 @@
 							"min" : 90,
 							"max" : 100
 						},
+						"mapDice" : 3,
 						"guards" : [
 							{
 								"amount" : 50,

--- a/hota/Mods/mapObjects/content/config/hotaMapObjects/beholderSanctuary.json
+++ b/hota/Mods/mapObjects/content/config/hotaMapObjects/beholderSanctuary.json
@@ -26,6 +26,17 @@
 						"hota/LOOPBEHD.wav"
 					]
 				},
+				"variables" : {
+					"artifact" : {
+						"gainedArtifact" : { 
+							"anyOf" : [
+								{
+									"class" : "MINOR"
+								}
+							]
+						}
+					}
+				},
 				"rmg" : {
 					"value" : 2500,
 					"rarity" : 100
@@ -43,6 +54,7 @@
 							"min" : 0,
 							"max" : 30
 						},
+						"mapDice" : 0,
 						"guards" : [
 							{
 								"amount" : 10,
@@ -70,9 +82,7 @@
 							"gold" : 3000
 						},
 						"artifacts" : [
-							{
-								"class" : "MINOR"
-							}
+							"@gainedArtifact"
 						]
 					},
 					{
@@ -81,6 +91,7 @@
 							"min" : 30,
 							"max" : 60
 						},
+						"mapDice" : 1,
 						"guards" : [
 							{
 								"amount" : 15,
@@ -108,9 +119,7 @@
 							"gold" : 4500
 						},
 						"artifacts" : [
-							{
-								"class" : "MINOR"
-							}
+							"@gainedArtifact"
 						]
 					},
 					{
@@ -119,6 +128,7 @@
 							"min" : 60,
 							"max" : 90
 						},
+						"mapDice" : 2,
 						"guards" : [
 							{
 								"amount" : 20,
@@ -146,9 +156,7 @@
 							"gold" : 6000
 						},
 						"artifacts" : [
-							{
-								"class" : "MINOR"
-							}
+							"@gainedArtifact"
 						]
 					},
 					{
@@ -157,6 +165,7 @@
 							"min" : 90,
 							"max" : 100
 						},
+						"mapDice" : 3,
 						"guards" : [
 							{
 								"amount" : 30,
@@ -184,9 +193,7 @@
 							"gold" : 9000
 						},
 						"artifacts" : [
-							{
-								"class" : "MINOR"
-							}
+							"@gainedArtifact"
 						]
 					}
 				]

--- a/hota/Mods/mapObjects/content/config/hotaMapObjects/blackTower.json
+++ b/hota/Mods/mapObjects/content/config/hotaMapObjects/blackTower.json
@@ -8,6 +8,17 @@
 				"onGuardedMessage" : "You stand in front of a dragon's dwelling. The vicious creature is terrorising the surrounding lands. Would you like to battle it?",
 				"onVisitedMessage" : "A dragon once lived in this tower, however now it is empty and holds nothing of interest.",
 				"visitMode" : "once",
+				"variables" : {
+					"artifact" : {
+						"gainedArtifact" : { 
+							"anyOf" : [
+								{
+									"class" : "MINOR"
+								}
+							]
+						}
+					}
+				},
 				"selectMode" : "selectFirst",
 				"guardsLayout" : "default",
 				"templates" : {
@@ -80,6 +91,7 @@
 							"min" : 0,
 							"max" : 30
 						},
+						"mapDice" : 0,
 						"guards" : [
 							{
 								"amount" : 1,
@@ -90,9 +102,7 @@
 							"gold" : 2000
 						},
 						"artifacts" : [
-							{
-								"class" : "MINOR"
-							}
+							"@gainedArtifact"
 						]
 					},
 					{
@@ -101,6 +111,7 @@
 							"min" : 30,
 							"max" : 60
 						},
+						"mapDice" : 1,
 						"guards" : [
 							{
 								"amount" : 1,
@@ -111,9 +122,7 @@
 							"gold" : 2250
 						},
 						"artifacts" : [
-							{
-								"class" : "MINOR"
-							}
+							"@gainedArtifact"
 						]
 					},
 					{
@@ -122,6 +131,7 @@
 							"min" : 60,
 							"max" : 90
 						},
+						"mapDice" : 2,
 						"guards" : [
 							{
 								"amount" : 1,
@@ -132,9 +142,7 @@
 							"gold" : 3500
 						},
 						"artifacts" : [
-							{
-								"class" : "MINOR"
-							}
+							"@gainedArtifact"
 						]
 					},
 					{
@@ -143,6 +151,7 @@
 							"min" : 90,
 							"max" : 100
 						},
+						"mapDice" : 3,
 						"guards" : [
 							{
 								"amount" : 1,
@@ -153,9 +162,7 @@
 							"gold" : 3750
 						},
 						"artifacts" : [
-							{
-								"class" : "MINOR"
-							}
+							"@gainedArtifact"
 						]
 					}
 				]

--- a/hota/Mods/mapObjects/content/config/hotaMapObjects/churchyard.json
+++ b/hota/Mods/mapObjects/content/config/hotaMapObjects/churchyard.json
@@ -63,6 +63,17 @@
 				"visitMode" : "once",
 				"selectMode" : "selectFirst",
 				"guardsLayout" : "creatureBankChurchyard",
+				"variables" : {
+					"artifact" : {
+						"gainedArtifact" : { 
+							"anyOf" : [
+								{
+									"class" : "MINOR"
+								}
+							]
+						}
+					}
+				},
 				"rewards" : [
 					{
 						"message" : "After defeating the undead you search the graveyard and find something useful!",
@@ -100,9 +111,7 @@
 							"gold" : 2500
 						},
 						"artifacts" : [
-							{
-								"class" : "MINOR"
-							}
+							"@gainedArtifact"
 						]
 					}
 				]

--- a/hota/Mods/mapObjects/content/config/hotaMapObjects/experimentalShop.json
+++ b/hota/Mods/mapObjects/content/config/hotaMapObjects/experimentalShop.json
@@ -56,6 +56,7 @@
 							"min" : 0,
 							"max" : 30
 						},
+						"mapDice" : 0,
 						"guards" : [
 							{
 								"amount" : 4,
@@ -91,6 +92,7 @@
 							"min" : 30,
 							"max" : 60
 						},
+						"mapDice" : 1,
 						"guards" : [
 							{
 								"amount" : 8,
@@ -126,6 +128,7 @@
 							"min" : 60,
 							"max" : 90
 						},
+						"mapDice" : 2,
 						"guards" : [
 							{
 								"amount" : 12,
@@ -161,6 +164,7 @@
 							"min" : 90,
 							"max" : 100
 						},
+						"mapDice" : 3,
 						"guards" : [
 							{
 								"amount" : 16,

--- a/hota/Mods/mapObjects/content/config/hotaMapObjects/ivoryTower.json
+++ b/hota/Mods/mapObjects/content/config/hotaMapObjects/ivoryTower.json
@@ -64,6 +64,7 @@
 							"min" : 0,
 							"max" : 30
 						},
+						"mapDice" : 0,
 						"guards" : [
 							{
 								"amount" : 7,
@@ -99,6 +100,7 @@
 							"min" : 30,
 							"max" : 60
 						},
+						"mapDice" : 1,
 						"guards" : [
 							{
 								"amount" : 10,
@@ -134,6 +136,7 @@
 							"min" : 60,
 							"max" : 90
 						},
+						"mapDice" : 2,
 						"guards" : [
 							{
 								"amount" : 13,
@@ -169,6 +172,7 @@
 							"min" : 90,
 							"max" : 100
 						},
+						"mapDice" : 3,
 						"guards" : [
 							{
 								"amount" : 16,

--- a/hota/Mods/mapObjects/content/config/hotaMapObjects/jetsam.json
+++ b/hota/Mods/mapObjects/content/config/hotaMapObjects/jetsam.json
@@ -30,6 +30,7 @@
 						"appearChance" : {
 							"max" : 25
 						},
+						"mapDice" : 0,
 						"message" : "{Jetsam}\r\n\r\nYou inspect the jettisoned cargo. Nothing of value can be found.",
 						"removeObject" : true
 					},
@@ -38,6 +39,7 @@
 							"min" : 25,
 							"max" : 50
 						},
+						"mapDice" : 1,
 						"resources" : {
 							"ore" : 5
 						},
@@ -53,6 +55,7 @@
 							"ore" : 5,
 							"gold" : 200
 						},
+						"mapDice" : 2,
 						"message" : "{Jetsam}\r\n\r\nYou inspect the jettisoned cargo. Some ore and gold go into your coffers.",
 						"removeObject" : true
 					},
@@ -65,6 +68,7 @@
 							"ore" : 10,
 							"gold" : 500
 						},
+						"mapDice" : 3,
 						"message" : "{Jetsam}\r\n\r\nYou inspect the jettisoned cargo. Some ore and gold go into your coffers.",
 						"removeObject" : true
 					}

--- a/hota/Mods/mapObjects/content/config/hotaMapObjects/mansion.json
+++ b/hota/Mods/mapObjects/content/config/hotaMapObjects/mansion.json
@@ -18,6 +18,17 @@
 						]
 					}
 				},
+				"variables" : {
+					"artifact" : {
+						"gainedArtifact" : { 
+							"anyOf" : [
+								{
+									"class" : "MAJOR"
+								}
+							]
+						}
+					}
+				},
 				"sounds" : {
 					"ambient" : [
 						"hota/LOOPMANS.wav"
@@ -43,6 +54,7 @@
 							"min" : 0,
 							"max" : 30
 						},
+						"mapDice" : 0,
 						"guards" : [
 							{
 								"amount" : 8,
@@ -73,9 +85,7 @@
 							"crystal" : 2
 						},
 						"artifacts" : [
-							{
-								"class" : "MAJOR"
-							}
+							"@gainedArtifact"
 						]
 					},
 					{
@@ -84,6 +94,7 @@
 							"min" : 30,
 							"max" : 60
 						},
+						"mapDice" : 1,
 						"guards" : [
 							{
 								"amount" : 12,
@@ -114,9 +125,7 @@
 							"crystal" : 3
 						},
 						"artifacts" : [
-							{
-								"class" : "MAJOR"
-							}
+							"@gainedArtifact"
 						]
 					},
 					{
@@ -125,6 +134,7 @@
 							"min" : 60,
 							"max" : 90
 						},
+						"mapDice" : 2,
 						"guards" : [
 							{
 								"amount" : 16,
@@ -155,9 +165,7 @@
 							"crystal" : 4
 						},
 						"artifacts" : [
-							{
-								"class" : "MAJOR"
-							}
+							"@gainedArtifact"
 						]
 					},
 					{
@@ -166,6 +174,7 @@
 							"min" : 90,
 							"max" : 100
 						},
+						"mapDice" : 3,
 						"guards" : [
 							{
 								"amount" : 20,
@@ -196,9 +205,7 @@
 							"crystal" : 5
 						},
 						"artifacts" : [
-							{
-								"class" : "MAJOR"
-							}
+							"@gainedArtifact"
 						]
 					}
 				]

--- a/hota/Mods/mapObjects/content/config/hotaMapObjects/pirateCavern.json
+++ b/hota/Mods/mapObjects/content/config/hotaMapObjects/pirateCavern.json
@@ -43,6 +43,7 @@
 							"min" : 0,
 							"max" : 30
 						},
+						"mapDice" : 0,
 						"guards" : [
 							{
 								"amount" : 10,
@@ -75,6 +76,7 @@
 							"min" : 30,
 							"max" : 60
 						},
+						"mapDice" : 1,
 						"guards" : [
 							{
 								"amount" : 20,
@@ -107,6 +109,7 @@
 							"min" : 60,
 							"max" : 90
 						},
+						"mapDice" : 2,
 						"guards" : [
 							{
 								"amount" : 30,
@@ -139,6 +142,7 @@
 							"min" : 90,
 							"max" : 100
 						},
+						"mapDice" : 3,
 						"guards" : [
 							{
 								"amount" : 40,

--- a/hota/Mods/mapObjects/content/config/hotaMapObjects/redTower.json
+++ b/hota/Mods/mapObjects/content/config/hotaMapObjects/redTower.json
@@ -46,6 +46,7 @@
 							"min" : 0,
 							"max" : 30
 						},
+						"mapDice" : 0,
 						"guards" : [
 							{
 								"amount" : 7,
@@ -82,6 +83,7 @@
 							"min" : 30,
 							"max" : 60
 						},
+						"mapDice" : 1,
 						"guards" : [
 							{
 								"amount" : 14,
@@ -118,6 +120,7 @@
 							"min" : 30,
 							"max" : 90
 						},
+						"mapDice" : 2,
 						"guards" : [
 							{
 								"amount" : 21,
@@ -154,6 +157,7 @@
 							"min" : 90,
 							"max" : 100
 						},
+						"mapDice" : 3,
 						"guards" : [
 							{
 								"amount" : 28,

--- a/hota/Mods/mapObjects/content/config/hotaMapObjects/spit.json
+++ b/hota/Mods/mapObjects/content/config/hotaMapObjects/spit.json
@@ -43,6 +43,7 @@
 							"min" : 0,
 							"max" : 30
 						},
+						"mapDice" : 0,
 						"guards" : [
 							{
 								"amount" : 4,
@@ -71,6 +72,7 @@
 							"min" : 30,
 							"max" : 60
 						},
+						"mapDice" : 1,
 						"guards" : [
 							{
 								"amount" : 6,
@@ -99,6 +101,7 @@
 							"min" : 60,
 							"max" : 90
 						},
+						"mapDice" : 2,
 						"guards" : [
 							{
 								"amount" : 8,
@@ -127,6 +130,7 @@
 							"min" : 90,
 							"max" : 100
 						},
+						"mapDice" : 3,
 						"guards" : [
 							{
 								"amount" : 12,

--- a/hota/Mods/mapObjects/content/config/hotaMapObjects/templeOfTheSea.json
+++ b/hota/Mods/mapObjects/content/config/hotaMapObjects/templeOfTheSea.json
@@ -48,6 +48,7 @@
 							"min" : 0,
 							"max" : 30
 						},
+						"mapDice" : 0,
 						"guards" : [
 							{
 								"amount" : 8,
@@ -90,6 +91,7 @@
 							"min" : 30,
 							"max" : 60
 						},
+						"mapDice" : 1,
 						"guards" : [
 							{
 								"amount" : 8,
@@ -132,6 +134,7 @@
 							"min" : 60,
 							"max" : 90
 						},
+						"mapDice" : 2,
 						"guards" : [
 							{
 								"amount" : 8,
@@ -174,6 +177,7 @@
 							"min" : 90,
 							"max" : 100
 						},
+						"mapDice" : 3,
 						"guards" : [
 							{
 								"amount" : 10,

--- a/hota/Mods/mapObjects/content/config/hotaMapObjects/vialOfMana.json
+++ b/hota/Mods/mapObjects/content/config/hotaMapObjects/vialOfMana.json
@@ -22,6 +22,7 @@
 						"appearChance" : {
 							"max" : 30
 						},
+						"mapDice" : 0,
 						"manaPoints" : 30,
 						"manaOverflowFactor" : 50,
 						"message" : "{Vial of Mana}\r\n\r\nYou get hold of the vial, but are disappointed to see it lacking any messsage. There's only water inside, suprisingly fresh though.",
@@ -32,6 +33,7 @@
 							"min" : 30,
 							"max" : 60
 						},
+						"mapDice" : 1,
 						"manaPoints" : 40,
 						"manaOverflowFactor" : 50,
 						"message" : "{Vial of Mana}\r\n\r\nYou get hold of the vial, but are disappointed to see it lacking any messsage. There's only water inside, suprisingly fresh though.",
@@ -42,6 +44,7 @@
 							"min" : 60,
 							"max" : 90
 						},
+						"mapDice" : 2,
 						"manaPoints" : 50,
 						"manaOverflowFactor" : 50,
 						"message" : "{Vial of Mana}\r\n\r\nYou get hold of the vial, but are disappointed to see it lacking any messsage. There's only water inside, suprisingly fresh though.",
@@ -52,6 +55,7 @@
 							"min" : 90,
 							"max" : 100
 						},
+						"mapDice" : 3,
 						"manaPoints" : 60,
 						"manaOverflowFactor" : 50,
 						"message" : "{Vial of Mana}\r\n\r\nYou get hold of the vial, but are disappointed to see it lacking any messsage. There's only water inside, suprisingly fresh though.",

--- a/hota/Mods/mapObjects/content/config/hotaMapObjects/wolfRaiderPicket.json
+++ b/hota/Mods/mapObjects/content/config/hotaMapObjects/wolfRaiderPicket.json
@@ -40,6 +40,7 @@
 							"min" : 0,
 							"max" : 30
 						},
+						"mapDice" : 0,
 						"guards" : [
 							{
 								"amount" : 10,
@@ -75,6 +76,7 @@
 							"min" : 30,
 							"max" : 60
 						},
+						"mapDice" : 1,
 						"guards" : [
 							{
 								"amount" : 15,
@@ -110,6 +112,7 @@
 							"min" : 60,
 							"max" : 90
 						},
+						"mapDice" : 2,
 						"guards" : [
 							{
 								"amount" : 20,
@@ -145,6 +148,7 @@
 							"min" : 90,
 							"max" : 100
 						},
+						"mapDice" : 3,
 						"guards" : [
 							{
 								"amount" : 30,


### PR DESCRIPTION
Added preconfigure support for Vial of Mana, Jetsam and all banks I could find (12 banks I think). Preconfiguring the artifact in the banks does not work yet, but it should work once it's implemented by VCMI (unless the variable name changes) for Mansion, Churchyard and Beholder's Sanctuary. Temple of the Sea has the same problem as Dragon Utopia I guess, so we have to wait and see until that is figured out. So only size roll works for the banks currently, but that works for all banks.

Missing: Trapper Lodge, Ancient Lamp