### PR TITLE
Bugfixes and updates

### DIFF
--- a/hota/Mods/bulwark/content/config/hota/bulwark/spells/freezingShot.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/spells/freezingShot.json
@@ -28,6 +28,8 @@
 		},
 		"levels" : {
 			"base" : {
+				"cost" : 0,
+				"description" : "{Frozen}\n\nIncapacitates the enemy for 3 turns. During the frozen period, the enemy receives 25% increased damage from attacks.\n",
 				"range" : "0",
 				"power" : 0,
 				"targetModifier" : {
@@ -56,20 +58,12 @@
 				}
 			},
 			"basic" : {
-				"cost" : 0,
-				"description" : "{Frozen}\n\nIncapacitates the enemy for 3 turns. During the frozen period, the enemy receives 25% increased damage from attacks."
 			},
 			"advanced" : {
-				"cost" : 0,
-				"description" : "{Frozen}\n\nIncapacitates the enemy for 3 turns. During the frozen period, the enemy receives 25% increased damage from attacks."
 			},
 			"expert" : {
-				"cost" : 0,
-				"description" : "{Frozen}\n\nIncapacitates the enemy for 3 turns. During the frozen period, the enemy receives 25% increased damage from attacks."
 			},
 			"none" : {
-				"cost" : 0,
-				"description" : "{Frozen}\n\nIncapacitates the enemy for 3 turns. During the frozen period, the enemy receives 25% increased damage from attacks."
 			}
 		},
 		"targetCondition" : {

--- a/hota/Mods/bulwark/content/config/hota/bulwark/spells/freezingShot.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/spells/freezingShot.json
@@ -2,8 +2,8 @@
 	"freezingShot" : {
 		"name" : "Freezing Shot",
 		"type" : "ability",
-		"targetType" : "NO_TARGET",
-		"level" : 3,
+		"targetType" : "CREATURE",
+		"level" : 4,
 		"power" : 0,
 		"school" : {},
 		"flags" : {

--- a/hota/Mods/cannon/Content/config/hotaCannon/artillery.json
+++ b/hota/Mods/cannon/Content/config/hotaCannon/artillery.json
@@ -3,12 +3,12 @@
 		"base" : {
 			"effects" : {
 				"cannonExtra" : {
-					"subtype" : "hota.cannon:creature.cannon",
+					"subtype" : "cannon",
 					"type" : "BONUS_DAMAGE_CHANCE",
 					"valueType" : "BASE_NUMBER"
 				},
 				"damagePowerCannon" : {
-					"subtype" : "hota.cannon:creature.cannon",
+					"subtype" : "cannon",
 					"type" : "BONUS_DAMAGE_PERCENTAGE",
 					"valueType" : "BASE_NUMBER"
 				},
@@ -18,11 +18,16 @@
 					"limiters" : [
 						{
 							"type" : "CREATURE_TYPE_LIMITER",
-							"creature" : "hota.cannon:creature.cannon"
+							"creature" : "cannon"
 						}
 					],
 					"valueType" : "INDEPENDENT_MIN",
 					"val" : 40
+				},
+				"manualControlCannon" : {
+					"type" : "MANUAL_CONTROL",
+					"subtype" : "cannon",
+					"val" : 100
 				}
 			}
 		},

--- a/hota/Mods/cannon/Content/config/hotaCannon/cannonCreature.json
+++ b/hota/Mods/cannon/Content/config/hotaCannon/cannonCreature.json
@@ -79,6 +79,10 @@
 			"noRetaliation" : {
 				"type" : "NO_RETALIATION",
 				"val" : 0
+			},
+			"cpuControlledCannon" : {
+				"hidden" : true,
+				"type" : "CPU_CONTROLLED"
 			}
 		},
 		"stackExperience" : [

--- a/hota/Mods/factory/content/config/hota/factory/creatures/hotaEngineer.json
+++ b/hota/Mods/factory/content/config/hota/factory/creatures/hotaEngineer.json
@@ -55,9 +55,9 @@
 				"type" : "TWO_HEX_ATTACK_BREATH"
 			},
 			"repair" : {
-				"type" : "SPELLCASTER",
+				"type" : "ADJACENT_SPELLCASTER",
 				"subtype" : "hotaRepair",
-				"val" : 2
+				"description" : "{Repair}\nRepairs mechanical creatures (20 Health per Engineer)."
 			},
 			"castLength" : {
 				"type" : "SPECIFIC_SPELL_POWER",

--- a/hota/Mods/factory/content/config/hota/factory/creatures/hotaMechanic.json
+++ b/hota/Mods/factory/content/config/hota/factory/creatures/hotaMechanic.json
@@ -58,9 +58,9 @@
 				"type" : "TWO_HEX_ATTACK_BREATH"
 			},
 			"repair" : {
-				"type" : "SPELLCASTER",
+				"type" : "ADJACENT_SPELLCASTER",
 				"subtype" : "hotaRepair",
-				"val" : 2
+				"description" : "{Repair}\nRepairs mechanical creatures (10 Health per Mechanic)."
 			},
 			"castLength" : {
 				"type" : "SPECIFIC_SPELL_POWER",

--- a/hota/Mods/factory/content/config/hota/factory/spells/hotaRepair.json
+++ b/hota/Mods/factory/content/config/hota/factory/spells/hotaRepair.json
@@ -5,12 +5,12 @@
 		"name" : "Repair",
 		"school" : {
 			"air" : false,
-			"earth" : true,
+			"earth" : false,
 			"fire" : false,
 			"water" : false
 		},
-		"level" : 3,
-		"power" : 30,
+		"level" : 0,
+		"power" : 0,
 
 		"defaultGainChance" : 0,
 		"gainChance" : {},
@@ -23,14 +23,18 @@
 
 		"flags" : {
 			"positive" : true,
-			"rising" : true
+			"rising" : true,
+			"special" : true
 		},
 		"targetCondition" : {
-			"noneOf" : {
-				"bonus.UNDEAD" : "absolute"
-			},
 			"anyOf" : {
 				"bonus.MECHANICAL" : "absolute"
+			},
+			"noneOf" : {
+				"bonus.GARGOYLE" : "absolute",
+				"bonus.NON_LIVING" : "absolute",
+				"bonus.SIEGE_WEAPON" : "absolute",
+				"bonus.UNDEAD" : "absolute"
 			}
 		},
 
@@ -44,15 +48,15 @@
 
 		"levels" : {
 			"base" : {
-				"cost" : 12,
+				"description" : "not shown",
+				"cost" : 0,
 				"range" : "0",
-				"power" : 30,
+				"power" : 0,
 				"battleEffects" : {
 					"heal" : {
 						"type" : "core:heal",
 						"healLevel" : "resurrect",
-						"healPower" : "oneBattle",
-						"minFullUnits" : 1
+						"healPower" : "permanent"
 					},
 					"cure" : {
 						"type" : "core:dispel",
@@ -68,34 +72,12 @@
 				}
 			},
 			"none" : {
-				"description" : "Target, allied non living and mechanical troop with dead creatures has (30 + (power x 30)) health worth of creatures repaired for the duration of the current battle."
 			},
 			"basic" : {
-				"description" : "Target, allied non living and mechanical troop with dead creatures has (30 + (power x 30)) health worth of creatures repaired permanently.",
-				"power" : 30,
-				"battleEffects" : {
-					"heal" : {
-						"healPower" : "permanent"
-					}
-				}
 			},
 			"advanced" : {
-				"description" : "Target, allied non living and mechanical troop with dead creatures has (50 + (power x 30)) health worth of creatures repaired permanently.",
-				"power" : 50,
-				"battleEffects" : {
-					"heal" : {
-						"healPower" : "permanent"
-					}
-				}
 			},
 			"expert" : {
-				"description" : "Target, allied non living and mechanical troop with dead creatures has (70 + (power x 30)) health worth of creatures repaired permanently.",
-				"power" : 70,
-				"battleEffects" : {
-					"heal" : {
-						"healPower" : "permanent"
-					}
-				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes:
+ Mechanic/Engineer ability
    + `ADJACENT_SPELLCASTER` bonus was made for this I think. It's a bit buggy, but works in 99% of the cases. Rest will be fixed with VCMI update
+ Fixed spell tags in freezingShot (level potentially had a gameplay effect, the target I just did because HotA has that tag as well)
+ Fixed cannon being controllable without Artillery skill (fixes #97 at long last)