### PR TITLE
Fixups and Couatl ability refactor

### DIFF
--- a/hota/Mods/factory/content/config/hota/factory/creatures/crimsonCouatl.json
+++ b/hota/Mods/factory/content/config/hota/factory/creatures/crimsonCouatl.json
@@ -59,7 +59,8 @@
 			"castsymMeditation" : {
 				"type" : "SPELLCASTER",
 				"subtype" : "meditation02",
-				"val" : 0
+				"val" : 0,
+				"description" : "{Meditation}\nCan cast Meditation without skipping its turn."
 			},
 			"castsCount" : {
 				"type" : "CASTS",

--- a/hota/Mods/factory/content/config/hota/factory/creatures/hotaCouatl.json
+++ b/hota/Mods/factory/content/config/hota/factory/creatures/hotaCouatl.json
@@ -61,7 +61,8 @@
 			"castsymMeditation" : {
 				"type" : "SPELLCASTER",
 				"subtype" : "meditation01",
-				"val" : 1
+				"val" : 0,
+				"description" : "{Meditation}\nCan cast Meditation, skipping its turn."
 			},
 			"castsCount" : {
 				"type" : "CASTS",

--- a/hota/Mods/factory/content/config/hota/factory/spells/meditation01.json
+++ b/hota/Mods/factory/content/config/hota/factory/spells/meditation01.json
@@ -2,18 +2,16 @@
 	"meditation01" : {
 		"type" : "ability",
 		"name" : "Meditation",
+		"level" : 0,
+		"power" : 0,
+		"defaultGainChance" : 0,
+		"gainChance" : {},
 		"school" : {
 			"air" : false,
 			"earth" : false,
 			"fire" : false,
 			"water" : false
 		},
-		"level" : 1,
-		"power" : 1,
-		"defaultGainChance" : 0,
-		"gainChance" : {},
-
-		//implosion animation?
 		"animation" : {
 			"affect" : [
 				{
@@ -21,260 +19,59 @@
 				}
 			]
 		},
-
 		"flags" : {
 			"positive" : true,
-			"nonMagical" : true,
 			"special" : true
 		},
-
 		"targetCondition" : {
-			"anyOf" : {
-				"factory:creature.hotaCouatl" : "absolute"
-			}
 		},
-		"canCastOnSelf" : true,
+		"canCastWithoutSkip" : false,
 		"canCastOnlyOnSelf" : true,
 		"graphics" : {
 			"iconEffect" : "hota/factory/spells/medi001.png"
 		},
 		"sounds" : {
-			"cast" : "ENERMOVE" //fear snd
 		},
 		"targetType" : "CREATURE",
-
 		"levels" : {
 			"base" : {
+				"description" : "{Meditation}\n\nTemporary invulnerability.\n",
 				"range" : "0",
-				"power" : 1,
-				"cost" : 6,
+				"power" : 0,
+				"cost" : 0,
 				"targetModifier" : {
 					"smart" : true
+				},
+				"battleEffects" : {
+					"couatlMeditation" : {
+						"type" : "core:timed",
+						"bonus" : {
+							"invincible" : {
+								"type" : "INVINCIBLE",
+								"duration" : [
+									"N_TURNS"
+								],
+								"turns" : 1
+							},
+							"immunityToHarmfulEffects" : {
+								"type" : "NEGATIVE_EFFECTS_IMMUNITY",
+								"subtype" : "spellSchool.any",
+								"duration" : [
+									"N_TURNS"
+								],
+								"turns" : 1
+							}
+						}
+					}
 				}
 			},
 			"none" : {
-				"description" : "lower meditations",
-
-				"effects" : {
-					"notActive" : {
-						"val" : 0,
-						"type" : "NOT_ACTIVE",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"damageReduction" : {
-						"type" : "INVINCIBLE",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"immnunityDispel" : {
-						"type" : "SPELL_IMMUNITY",
-						"subtype" : "dispel",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"immnunityDispelHelpful" : {
-						"type" : "SPELL_IMMUNITY",
-						"subtype" : "dispelHelpful",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"immuneToFire" : {
-						"subtype" : "fire",
-						"type" : "SPELL_SCHOOL_IMMUNITY",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"immuneToAir" : {
-						"subtype" : "air",
-						"type" : "SPELL_SCHOOL_IMMUNITY",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"immuneToWater" : {
-						"subtype" : "water",
-						"type" : "SPELL_SCHOOL_IMMUNITY",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"immuneToEarth" : {
-						"subtype" : "earth",
-						"type" : "SPELL_SCHOOL_IMMUNITY",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"receptive" : {
-						"type" : "RECEPTIVE",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"noRetaliation" : {
-						"type" : "NO_RETALIATION",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					}
-				}
 			},
 			"basic" : {
-				"description" : "lower meditations",
-
-				"effects" : {
-					"notActive" : {
-						"val" : 0,
-						"type" : "NOT_ACTIVE",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"damageReduction" : {
-						"type" : "INVINCIBLE",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"levelSpellImmunity" : {
-						"val" : 5,
-						"type" : "LEVEL_SPELL_IMMUNITY",
-						"valueType" : "INDEPENDENT_MAX",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"receptive" : {
-						"type" : "RECEPTIVE",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"noRetaliation" : {
-						"type" : "NO_RETALIATION",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					}
-				}
 			},
 			"advanced" : {
-				"description" : "lower meditations",
-
-				"effects" : {
-					"notActive" : {
-						"val" : 0,
-						"type" : "NOT_ACTIVE",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"damageReduction" : {
-						"type" : "GENERAL_DAMAGE_REDUCTION",
-						"subtype" : "damageTypeMelee",
-						"val" : 100,
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"damageReductionShots" : {
-						"type" : "GENERAL_DAMAGE_REDUCTION",
-						"subtype" : "damageTypeRanged",
-						"val" : 100,
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"magicDamageReduction" : {
-						"type" : "SPELL_DAMAGE_REDUCTION",
-						"subtype" : "any",
-						"val" : 100,
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"noRetaliation" : {
-						"type" : "NO_RETALIATION",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					}
-				}
 			},
 			"expert" : {
-				"description" : "lower meditations",
-				"cost" : 5,
-
-				"effects" : {
-					"notActive" : {
-						"val" : 0,
-						"type" : "NOT_ACTIVE",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 2
-					},
-					"damageReduction" : {
-						"type" : "GENERAL_DAMAGE_REDUCTION",
-						"subtype" : "damageTypeMelee",
-						"val" : 100,
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 2
-					},
-					"damageReductionShots" : {
-						"type" : "GENERAL_DAMAGE_REDUCTION",
-						"subtype" : "damageTypeRanged",
-						"val" : 100,
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 2
-					},
-					"magicDamageReduction" : {
-						"type" : "SPELL_DAMAGE_REDUCTION",
-						"subtype" : "any",
-						"val" : 100,
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 2
-					},
-					"noRetaliation" : {
-						"type" : "NO_RETALIATION",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 2
-					}
-				}
 			}
 		}
 	}

--- a/hota/Mods/factory/content/config/hota/factory/spells/meditation02.json
+++ b/hota/Mods/factory/content/config/hota/factory/spells/meditation02.json
@@ -2,18 +2,16 @@
 	"meditation02" : {
 		"type" : "ability",
 		"name" : "Meditation",
+		"level" : 0,
+		"power" : 0,
+		"defaultGainChance" : 0,
+		"gainChance" : {},
 		"school" : {
 			"air" : false,
 			"earth" : false,
 			"fire" : false,
 			"water" : false
 		},
-		"level" : 1,
-		"power" : 2,
-		"defaultGainChance" : 0,
-		"gainChance" : {},
-
-		//implosion animation?
 		"animation" : {
 			"affect" : [
 				{
@@ -21,257 +19,59 @@
 				}
 			]
 		},
-
 		"flags" : {
 			"positive" : true,
-			"nonMagical" : true,
 			"special" : true
 		},
-
 		"targetCondition" : {
-			"anyOf" : {
-				"factory:creature.crimsonCouatl" : "absolute"
-			}
 		},
-
-		"canCastOnSelf" : true,
 		"canCastWithoutSkip" : true,
 		"canCastOnlyOnSelf" : true,
-
 		"graphics" : {
 			"iconEffect" : "hota/factory/spells/medi001.png"
 		},
 		"sounds" : {
-			"cast" : "ENERMOVE" //fear snd
 		},
 		"targetType" : "CREATURE",
-
 		"levels" : {
 			"base" : {
+				"description" : "{Meditation}\n\nTemporary invulnerability.\n",
 				"range" : "0",
-				"power" : 1,
+				"power" : 0,
+				"cost" : 0,
 				"targetModifier" : {
 					"smart" : true
 				},
-				"cost" : 6
+				"battleEffects" : {
+					"crimsonMeditation" : {
+						"type" : "core:timed",
+						"bonus" : {
+							"invincible" : {
+								"type" : "INVINCIBLE",
+								"duration" : [
+									"N_TURNS"
+								],
+								"turns" : 1
+							},
+							"immunityToHarmfulEffects" : {
+								"type" : "NEGATIVE_EFFECTS_IMMUNITY",
+								"subtype" : "spellSchool.any",
+								"duration" : [
+									"N_TURNS"
+								],
+								"turns" : 1
+							}
+						}
+					}
+				}
 			},
 			"none" : {
-				"description" : "{Meditation}\n\nMakes the unit invincible for this turn.\n",
-
-				"effects" : {
-					"notActive" : {
-						"type" : "BLOCKS_RETALIATION",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"damageReduction" : {
-						"type" : "INVINCIBLE",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"immnunityDispel" : {
-						"type" : "SPELL_IMMUNITY",
-						"subtype" : "dispel",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"immnunityDispelHelpful" : {
-						"type" : "SPELL_IMMUNITY",
-						"subtype" : "dispelHelpful",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"immuneToFire" : {
-						"subtype" : "fire",
-						"type" : "SPELL_SCHOOL_IMMUNITY",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"immuneToAir" : {
-						"subtype" : "air",
-						"type" : "SPELL_SCHOOL_IMMUNITY",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"immuneToWater" : {
-						"subtype" : "water",
-						"type" : "SPELL_SCHOOL_IMMUNITY",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"immuneToEarth" : {
-						"subtype" : "earth",
-						"type" : "SPELL_SCHOOL_IMMUNITY",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"receptive" : {
-						"type" : "RECEPTIVE",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"noRetaliation" : {
-						"type" : "NO_RETALIATION",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"activeHealth" : {
-						"type" : "STACK_HEALTH",
-						"val" : 10,
-						"valueType" : "PERCENT_TO_BASE",
-						"duration" : "N_TURNS",
-						"turns" : 1
-					} //Temporarily increases HP by 10% to trigger the effect; removes after one turn with no other effects.
-				}
 			},
 			"basic" : {
-				"description" : "high meditations"
 			},
 			"advanced" : {
-				"description" : "high meditations",
-
-				"effects" : {
-					"notActive" : {
-						"type" : "BLOCKS_RETALIATION",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"damageReduction" : {
-						"type" : "GENERAL_DAMAGE_REDUCTION",
-						"subtype" : "damageTypeMelee",
-						"val" : 100,
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"damageReductionShots" : {
-						"type" : "GENERAL_DAMAGE_REDUCTION",
-						"subtype" : "damageTypeRanged",
-						"val" : 100,
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"magicDamageReduction" : {
-						"type" : "SPELL_DAMAGE_REDUCTION",
-						"subtype" : "any",
-						"val" : 100,
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"levelSpellImmunity" : {
-						"val" : 5,
-						"type" : "LEVEL_SPELL_IMMUNITY",
-						"valueType" : "INDEPENDENT_MAX",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"nonLiving" : {
-						"type" : "NON_LIVING",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"noRetaliation" : {
-						"type" : "NO_RETALIATION",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					}
-				}
 			},
 			"expert" : {
-				"description" : "high meditations",
-
-				"effects" : {
-					"notActive" : {
-						"type" : "BLOCKS_RETALIATION",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"damageReduction" : {
-						"type" : "GENERAL_DAMAGE_REDUCTION",
-						"subtype" : "damageTypeMelee",
-						"val" : 100,
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"damageReductionShots" : {
-						"type" : "GENERAL_DAMAGE_REDUCTION",
-						"subtype" : "damageTypeRanged",
-						"val" : 100,
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"magicDamageReduction" : {
-						"type" : "SPELL_DAMAGE_REDUCTION",
-						"subtype" : "any",
-						"val" : 100,
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"levelSpellImmunity" : {
-						"val" : 5,
-						"type" : "LEVEL_SPELL_IMMUNITY",
-						"valueType" : "INDEPENDENT_MAX",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"nonLiving" : {
-						"type" : "NON_LIVING",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					},
-					"noRetaliation" : {
-						"type" : "NO_RETALIATION",
-						"duration" : [
-							"N_TURNS"
-						],
-						"turns" : 1
-					}
-				}
 			}
 		}
 	}

--- a/hota/Mods/gameBalance/mods/objects/content/config/hotaGameBalance/creatureBanks.json
+++ b/hota/Mods/gameBalance/mods/objects/content/config/hotaGameBalance/creatureBanks.json
@@ -9,6 +9,7 @@
 							"min" : 0,
 							"max" : 30
 						},
+						"mapDice" : 0,
 						"guards" : [
 							{
 								"type" : "naga",
@@ -42,6 +43,7 @@
 							"min" : 30,
 							"max" : 60
 						},
+						"mapDice" : 1,
 						"guards" : [
 							{
 								"type" : "naga",
@@ -75,6 +77,7 @@
 							"min" : 60,
 							"max" : 90
 						},
+						"mapDice" : 2,
 						"guards" : [
 							{
 								"type" : "naga",
@@ -108,6 +111,7 @@
 							"min" : 90,
 							"max" : 100
 						},
+						"mapDice" : 3,
 						"guards" : [
 							{
 								"type" : "naga",

--- a/hota/Mods/mapObjects/content/config/hotaMapObjects/beholderSanctuary.json
+++ b/hota/Mods/mapObjects/content/config/hotaMapObjects/beholderSanctuary.json
@@ -2,7 +2,7 @@
 	"core:creatureBank" : {
 		"types" : {
 			"beholderSanctuary" : {
-				"name" : "Beholder Sanctuary",
+				"name" : "Beholders' Sanctuary",
 				"templates" : {
 					"base" : {
 						"animation" : "hota/banks/SANCT_WT.def",

--- a/hota/Mods/wastelandTerrain/content/config/hota/wasteland/hotaStatic/tarPit.json
+++ b/hota/Mods/wastelandTerrain/content/config/hota/wasteland/hotaStatic/tarPit.json
@@ -4,6 +4,9 @@
 		"handler" : "static",
 		"types" : {
 			"tarPit" : {
+				"sounds" : {
+					"ambient" : [ "LOOPEART" ]
+				},
 				"templates" : {
 					"AVLwloi1" : {
 						"animation" : "hota/wasteland/hotaStatic/lakes/AVLwloi1",


### PR DESCRIPTION
+ Refactored the (Crimson) Couatl ability spell
+ Updated the description on that ability

It was unnecessarily complicated and completely illogical: why non-magical (does not affect non damage spells), why so many bonuses that contradict each other (dispel+dispelhelpful immune into receptive makes 0 sense). I removed all of that and this is functionally identical (when https://github.com/vcmi/vcmi/issues/6762 is fixed) to what it was before. It is simply impossible to make a buff undispellable, you can even change Dispel's targetCondition to exclude Couatls, it doesn't matter, it will ignore that.

+ Added Tar Pit ambient sound (@misiokles )
+ Corrected Beholders' Sanctuary name
+ preconfigure support for the Naga Bank we (unnecessarily) overwrite (it gives gems in core as well for whatever reason)