### PR TITLE
Trailblazer and pre-configure support for Trapper Lodge

### DIFF
--- a/hota/Mods/bulwark/content/config/hota/bulwark/mapObjects/interactive/trapperLodge.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/mapObjects/interactive/trapperLodge.json
@@ -19,33 +19,49 @@
 					"value" : 500,
 					"rarity" : 50
 				},
+				"variables" : {
+					"resource" : {
+						"gainedResource" : "gold"
+					},
+					"creature" : {
+						"gainedCreature" : {
+							"anyOf" : [ "kobold", "gremlin" ]
+						}
+					},
+					"number" : {
+						"gainedAmount" : {
+							"amount" : [ 300, 400, 500 ]
+						},
+						"gainedCreatureAmount" : {
+							"min" : 3,
+							"max" : 5
+						}
+					}
+				},
 				"rewards" : [
 					{
 						"message" : "{Trapper Lodge}\n\nRummaging about the snowbound lodge, you find a bag of gold someone stashed here.",
 						"appearChance" : {
 							"max" : 50
 						},
-						"resources" : {
-							"gold" : [
-								300,
-								400,
-								500
-							]
-						}
+						"mapDice" : 0,
+						"resources" : [
+							{
+								"type" : "@gainedResource",
+								"amount" : "@gainedAmount"
+							}
+						]
 					},
 					{
 						"message" : "{Trapper Lodge}\n\nIn the snowbound lodge, you meet several creatures, waiting here until the blizzard passes. Do you wish to take them along?",
+						"mapDice" : 1,
 						"appearChance" : {
 							"min" : 50
 						},
 						"creatures" : [
 							{
-								"anyOf" : [
-									"gremlin",
-									"kobold"
-								],
-								"min" : 3,
-								"max" : 5
+								"type" : "@gainedCreature",
+								"amount" : "@gainedCreatureAmount"
 							}
 						]
 					}

--- a/hota/Mods/wastelandTerrain/content/config/hota/wasteland/hotaInteractive/grave.json
+++ b/hota/Mods/wastelandTerrain/content/config/hota/wasteland/hotaInteractive/grave.json
@@ -18,6 +18,9 @@
 					"rarity" : 30
 				},
 				"variables" : {
+					"resource" : {
+						"gainedResource" : "gold"
+					},
 					"artifact" : {
 						"gainedArtifact" : { 
 							"anyOf" : [
@@ -45,7 +48,7 @@
 						"message" : "{Grave}\n\nThis tomb is fresh, and even the shovel someone dug it with hasn't been stolen yet.\nDo you want to take up the latter, cover your nose with a handkerchief, and extract something valuable from the ground and call it a day?",
 						"resources" : [
 							{
-								"type" : "gold",
+								"type" : "@gainedResource",
 								"amount" : "@gainedAmount"
 							}
 						],

--- a/hota/Mods/wastelandTerrain/content/config/hota/wasteland/hotaInteractive/trailblazer.json
+++ b/hota/Mods/wastelandTerrain/content/config/hota/wasteland/hotaInteractive/trailblazer.json
@@ -1,20 +1,68 @@
 {
 	"trailblazer" : {
-		"handler" : "generic",
+		"handler" : "configurable",
 		"name" : "Trailblazer",
+		"base" : {
+			"sounds" : {
+				"visit" : [
+					"STORE"
+				]
+			}
+		},
 		"types" : {
 			"trailblazer" : {
-				//				"aiValue" : 3000,
-				//				"rmg" : {
-				//					"value"		: 200,
-				//					"rarity" 	: 40,
-				//					"zoneLimit" : 1
-				//				},
-				"sounds" : {
-					"visit" : [
-						"STORE"
-					]
+				"name" : "Trailblazer",
+				"description" : "\nReduces movement cost on wastelands down to 75% until the end of the week.\n",
+				"aiValue" : 3000,
+				"rmg" : {
+					"value"		: 200,
+					"rarity" 	: 40,
+					"zoneLimit" : 1
 				},
+				"onVisitedMessage" : "{Trailblazer}\n\n\"Hey, that's my tent. Better be sure it's not my fault we're running in circles,\" the trailblazer shrugs.",
+				"visitMode" : "bonus",
+				"rewards" : [
+					{
+						"message" : "{Trailblazer}\n\n\"I know these wastelands like the back of my hand. Even if I haven't been somewhere, I'll figure out how to find the way. I suppose I could tag along with you for a week if you need a hand,\" says the man in this tent.",
+						"bonuses" : [
+							{
+								"type" : "ROUGH_TERRAIN_DISCOUNT",
+								"val" : 50,
+								"duration" : "ONE_WEEK",
+								"limiters" : [
+									{
+										"type" : "TERRAIN_LIMITER",
+										"terrain" : "wasteland"
+									}
+								]
+							},
+							{
+								"type" : "BASE_TILE_MOVEMENT_COST",
+								"val" : -25,
+								"duration" : "ONE_WEEK",
+								"valueType" : "BASE_NUMBER",
+								"limiters" : [
+									{
+										"type" : "TERRAIN_LIMITER",
+										"terrain" : "wasteland"
+									}
+								],
+							},
+							{
+								"type" : "BASE_TILE_MOVEMENT_COST",
+								"val" : 75,
+								"duration" : "ONE_WEEK",
+								"valueType" : "INDEPENDENT_MAX",
+								"limiters" : [
+									{
+										"type" : "TERRAIN_LIMITER",
+										"terrain" : "wasteland"
+									}
+								]
+							}
+						]
+					}
+				],
 				"templates" : {
 					"avstrblz" : {
 						"animation" : "hota/wasteland/hotaInteractive/trailblazer/avstrblz",


### PR DESCRIPTION
+ added Trapper Lodge preconfigure support
+ added gainedResource to Grave (can only be set to gold in HotA maps atm, but if that changes in the future, it would now work with any resource type)

Edit: couldn't sleep (again)
+ implemented Trailblazer 
    + tested with and without Pathfinding on 3 different terrains and works properly from what I can tell
+ Unbanned Trailblazer from RMG