### PR TITLE
Add description in form of separate file

### DIFF
--- a/hota/description.md
+++ b/hota/description.md
@@ -1,0 +1,128 @@
+# english
+
+Embark on an epic journey in **Horn of the Abyss**, a fan-made expansion for _Heroes of Might and Magic III_, standing proudly alongside the official expansions of **Armageddon's Blade** and **Shadow of Death**.
+
+## A True Tribute to Heroes of Might and Magic
+
+_Horn of the Abyss_ enhances the original game with a wealth of new features while preserving its legendary charm. Explore the new **Cove** and **Factory** factions, engage in challenging campaigns, and discover sparkling new artifacts and interesting map objects that enhance the game's strategic depth.
+
+Painstakingly balanced and polished, _Horn of the Abyss_ has been crafted with an unwavering commitment to quality. With carefully refined mechanics and a host of improvements, this expansion is a must-play for both new players and seasoned veterans. This expansion includes the careful balance changes and fixes, removal of graphical imperfections left by the developers, and the addition of a considerable amount of new content. The project is lore-oriented and attempts to keep connected with the original Might and Magic universe, with changes made to honour the vision of the original game while greatly enhancing players' experience.
+
+## Cove Town
+
+Sail the seven seas with the Captains and Navigators of the **Cove** and unleash the might of the depths unto your foes. The Cove is home to fearless Crewmates and their Pirate capatains, assisted in their navigation of the seas by powerful Sea Witches. However, this Regnan town has attracted more than just humans: from the water-borne Nymphs and Sea Serpents protected by their Nix friends to the soaring Stormbirds of the skies, the Cove is a place of marine diversity of all sorts. Take out your eneimes from afar with giant metal Cannon shots and the deadly accuracy of Sea Dogs aided by the shattering magic of Sorceresses; plunder their loot up close and personal with swift strikes from Haspids and Ayssids; and defend your ill-gotten gains with your dependable Seamen and Nix Warriors.
+
+## Factory Town
+
+Dive into new-age technology with the Mercenaries and Artificers of the **Factory** and unlock your creatures' full potential with the might of industry. Take to the skies and transcend the need for navigating tricky terrain with the brand new Airship, bringing you closer to victory with great haste. The Factory is home to plucky Halflings and their slow and steady Armadillo friends, protected by local Gunslingers, but not all natural creatures are as nice as they are - beware the burrowing Sandworm and jungle-dwelling Couatl, for they are fearsome in numbers, even if the Couatl needs some provoking to unlock its full potential. The natural evolution of humans resulted in the forming of new and curious technologies, which some have embraced fully: Mechanics were trained to help great engineers construct the explosive Automaton and eventually the colossal laser-shooting Dreadnought, both of which are able to be repaired on the battlefield if needs be.
+
+## Heroes
+
+In addition to the regular 16 heroes per town and campaign/map editor exclusive heroes from the **Cove** and **Factory**, there are a few smaller additions and changes to the roster of familiar heroes:
+
+*   **Lord Haart the Knight**
+
+*   Was originally in _Restoration of Erathia_, but was swapped out for **Sir Mullich the Knight** in _Armageddon's Blade_ and _Shadow of Death_ - he has now returned in _Horn of the Abyss_
+
+*   **Beatrice the Knight**
+
+*   **Scouting** specialist
+
+*   **Giselle the Ranger**
+
+*   **Interference** specialist
+
+*   **Ranloo the Death Knight**
+
+*   **Ballista** specialist
+
+*   **Kinkeria the Witch**
+
+*   **Scouting** specialist
+
+*   **Miscellaneous Changes**
+
+*   **Lord Haart the Death Knight** has been renamed to **Haart Lich the Death Knight** to avoid confusion
+*   In regular _Horn of the Abyss_, heroes that would be replaced by new heroes would also be disabled - this is not the case in VCMI, where every hero is available unless banned by the map or template
+
+## Secondary Skills
+
+Horn of the Abyss introduces **Interference** as a Secondary Skill to replace **Resistance**, which itself is now banned by default. This skill is a fairer and more balanced way to mitigate magic, as it decreases enemy Spell Power as opposed to being an unbalanced "roll-of-the-dice" skill that had the potential to render magic utterly ineffective.
+
+## Artifacts
+
+A new set of golden armour infused with the power of the ocean lies in wait to be adorned by only the mightiest of heroes:
+
+*   **Trident of Dominion:** _+7 Attack skill_
+*   **Shield of Naval Glory:** _+7 Defense skill_
+*   **Royal Armor of Nix:** _+6 Power skill_
+*   **Crown of the Five Seas:** _+6 Knowledge skill_
+
+### Two incredibly powerful artifacts have been added that can completely change the tide of a scenario:
+
+*   **Horn of the Abyss:** _Raises Fangarms from slain stacks of living creatures_
+*   **Sleepkeeper:** _Provides immunity to Mind spells_
+
+### Several combination artifacts have been added that were once planned for the release of _Shadow of Death_ with new names and fully fleshed-out abilities:
+
+*   **Ironfist of the Ogre:**
+
+*   _+5 Attack skill, +5 Defense skill, +4 Power skill, +4 Knowledge skill_
+*   _Casts Expert Bloodlust, Counterstrike, Fire Shield, and Haste on all allies for 50 rounds_
+*   _**Weapon**/Shield/Helm/Torso slots_
+
+*   **Diplomat's Cloak:**
+
+*   _\-30% surrender cost_
+*   _Allows retreat and surrender when battling neutral monsters or defending a town_
+*   _3x diplomatic army strength_
+*   _**Cape**/Neclakce/Ring slots_
+
+*   **Pendant of Reflection:**
+
+*   _+50% Magic Resistance_
+*   _**Neclakce**/Cape/Feet slots_
+
+*   **Golden Goose:**
+
+*   _+7000 Gold/day_
+*   _**Misc**/Misc/Misc slots_
+
+### Still hungry for more boons to get an edge over your enemies? Look no further than the assorted wares that _Horn of the Abyss_ has to offer:
+
+*   **Plate of Dying Light:** _\-25% enemy Power skill_
+*   **Seal of Sunset:** _\-10% enemy Power skill_
+*   **Charm of Eclipse:** _\-10% enemy Power skill_
+*   **Pendant of Downfall:** _\-2 enemy Morale_
+*   **Ring of Suppression:** _\-1 enemy Morale_
+*   **Hideous Mask:** _\-1 enemy Morale_
+*   **Shaman's Puppet:** _\-2 enemy Luck_
+*   **Runes of Imminency:** _\-1 enemy Luck_
+*   **Demon's Horseshoe:** _\-1 enemy Luck_
+*   **Wayfarer's Boots:** _No movement penalty over rough terrain_
+*   **Cape of Silence:** _Prevents either player from casting level 1 or 2 spells_
+
+## Miscellaneous Changes
+
+*   External dwellings now accumulate creatures weekly as long as they are owned by a player
+*   Small yet appropriate changes to overall town building cost balance
+*   Small yet appropriate changes to various creatures
+*   New **map objects** and **creature hordes**
+*   Improved **Map Editor** and **Campaign Editor** functionality
+*   New **Template Editor** to aid with Random Map Generation
+*   The **Vault of Ashes**, a new **Conflux** dwelling that boosts Firebird/Phoenix Growth
+*   **Spell Research** system that guarantees essential spells with enough research
+*   New useful **keybinds** for easy navigation and controlling creatures' abilities
+*   New terrains - **Highlands** and **Wasteland**
+*   **Conflux's** native terrain is changed to **Highlands**
+*   **Halflings** belong to **Factory** instead of being **Neutral**
+
+# ukrainian
+
+Відправляйтеся в епічну подорож у **Horn of the Abyss**, створеному фанатами доповненні до _Heroes of Might and Magic III_, яке гордо стоїть в одному ряду з офіційними доповненнями **Armageddon's Blade** і **Shadow of Death**.
+
+## Справжня данина поваги Heroes of Might and Magic
+
+_Horn of the Abyss_ покращує оригінальну гру завдяки безлічі нових функцій, зберігаючи при цьому її легендарний шарм. Досліджуйте нові фракції **Cove** і **Factory**, беріть участь у складних кампаніях і відкривайте для себе нові артефакти та цікаві об'єкти на карті, які покращують стратегічну глибину гри.
+
+Ретельно збалансоване і доведене до досконалості, _Horn of the Abyss_ було створено з незмінною відданістю якості. Завдяки ретельно вдосконаленій механіці та безлічі поліпшень, це розширення є обов'язковим як для нових гравців, так і для досвідчених ветеранів. Це розширення включає ретельні зміни балансу та виправлення, усунення графічних недоліків, залишених розробниками, та додавання значної кількості нового контенту. Проект орієнтований на історію та намагається зберегти зв'язок з оригінальним всесвітом Might and Magic, з змінами, внесеними на честь бачення оригінальної гри, одночасно значно покращуючи досвід гравців.

--- a/hota/description.md
+++ b/hota/description.md
@@ -58,12 +58,12 @@ A new set of golden armour infused with the power of the ocean lies in wait to b
 *   **Royal Armor of Nix:** _+6 Power skill_
 *   **Crown of the Five Seas:** _+6 Knowledge skill_
 
-### Two incredibly powerful artifacts have been added that can completely change the tide of a scenario:
+Two incredibly powerful artifacts have been added that can completely change the tide of a scenario:
 
 *   **Horn of the Abyss:** _Raises Fangarms from slain stacks of living creatures_
 *   **Sleepkeeper:** _Provides immunity to Mind spells_
 
-### Several combination artifacts have been added that were once planned for the release of _Shadow of Death_ with new names and fully fleshed-out abilities:
+Several combination artifacts have been added that were once planned for the release of _Shadow of Death_ with new names and fully fleshed-out abilities:
 
 *   **Ironfist of the Ogre:**
 
@@ -88,7 +88,7 @@ A new set of golden armour infused with the power of the ocean lies in wait to b
 *   _+7000 Gold/day_
 *   _**Misc**/Misc/Misc slots_
 
-### Still hungry for more boons to get an edge over your enemies? Look no further than the assorted wares that _Horn of the Abyss_ has to offer:
+Still hungry for more boons to get an edge over your enemies? Look no further than the assorted wares that _Horn of the Abyss_ has to offer:
 
 *   **Plate of Dying Light:** _\-25% enemy Power skill_
 *   **Seal of Sunset:** _\-10% enemy Power skill_
@@ -116,13 +116,3 @@ A new set of golden armour infused with the power of the ocean lies in wait to b
 *   New terrains - **Highlands** and **Wasteland**
 *   **Conflux's** native terrain is changed to **Highlands**
 *   **Halflings** belong to **Factory** instead of being **Neutral**
-
-# ukrainian
-
-Відправляйтеся в епічну подорож у **Horn of the Abyss**, створеному фанатами доповненні до _Heroes of Might and Magic III_, яке гордо стоїть в одному ряду з офіційними доповненнями **Armageddon's Blade** і **Shadow of Death**.
-
-## Справжня данина поваги Heroes of Might and Magic
-
-_Horn of the Abyss_ покращує оригінальну гру завдяки безлічі нових функцій, зберігаючи при цьому її легендарний шарм. Досліджуйте нові фракції **Cove** і **Factory**, беріть участь у складних кампаніях і відкривайте для себе нові артефакти та цікаві об'єкти на карті, які покращують стратегічну глибину гри.
-
-Ретельно збалансоване і доведене до досконалості, _Horn of the Abyss_ було створено з незмінною відданістю якості. Завдяки ретельно вдосконаленій механіці та безлічі поліпшень, це розширення є обов'язковим як для нових гравців, так і для досвідчених ветеранів. Це розширення включає ретельні зміни балансу та виправлення, усунення графічних недоліків, залишених розробниками, та додавання значної кількості нового контенту. Проект орієнтований на історію та намагається зберегти зв'язок з оригінальним всесвітом Might and Magic, з змінами, внесеними на честь бачення оригінальної гри, одночасно значно покращуючи досвід гравців.


### PR DESCRIPTION
Mod description is now located in separate & easy-to-edit .md file

Description itself is identical to existing html-based description. Old descriptions in mod.json are still present to avoid breaking it for 1.7.1 clients

Will merge this myself once other PR's are ready