### PR TITLE
Fix loading of Trapper Lodge parameters from h3m

### DIFF
--- a/hota/Mods/bulwark/content/config/hota/bulwark/mapObjects/interactive/trapperLodge.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/mapObjects/interactive/trapperLodge.json
@@ -29,7 +29,7 @@
 						}
 					},
 					"number" : {
-						"gainedAmount" : {
+						"gainedGoldAmount" : {
 							"amount" : [ 300, 400, 500 ]
 						},
 						"gainedCreatureAmount" : {
@@ -48,7 +48,7 @@
 						"resources" : [
 							{
 								"type" : "@gainedResource",
-								"amount" : "@gainedAmount"
+								"amount" : "@gainedGoldAmount"
 							}
 						]
 					},


### PR DESCRIPTION
Fixes Trapper Lodge parameters to be in line with what VCMI generates. `gainedResource` is actually never set since hota h3m does not have it as parameter, so it will always be rolled to gold on initialization.

Will update docs on Trapper Lodge in VCMI repo to correct version

Sea Barrel config is correct, bug on VCMI side - will open PR soon in VCMI repo with fix.