### PR TITLE
Simplify specialties, fix Dargem/Dalton

### DIFF
--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroes/akka.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroes/akka.json
@@ -44,86 +44,51 @@
 				"subtype" : "primarySkill.attack",
 				"valueType" : "ADDITIVE_VALUE",
 				"effectRange" : "ONLY_MELEE_FIGHT",
-				"propagator" : "BATTLE_WIDE",
-				"propagationUpdater" : "BONUS_OWNER_UPDATER"
+				"limiters" : [
+					{
+						"type" : "HAS_ANOTHER_BONUS_LIMITER",
+						"bonusSourceType" : "SPELL_EFFECT",
+						"bonusSourceID" : "spell.bloodlust"
+					}
+				]
 			},
 			"bonuses" : {
-				"bonusAttack12" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+				"bonusDefense12" : {
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"maxlevel" : 3
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.bloodlust"
 						}
-					],
+					},
 					"val" : 10
 				},
-				"bonusAttack34" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+				"bonusDefense34" : {
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 3,
 							"maxlevel" : 5
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.bloodlust"
 						}
-					],
+					},
 					"val" : 8
 				},
-				"bonusAttack56" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+				"bonusDefense56" : {
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 5,
 							"maxlevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.bloodlust"
 						}
-					],
+					},
 					"val" : 6
 				},
-				"bonusAttack" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+				"bonusDefense7" : {
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.bloodlust"
 						}
-					],
+					},
 					"val" : 4
 				}
 			}

--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroes/dalton.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroes/dalton.json
@@ -39,9 +39,12 @@
 			"base" : {
 				"type" : "GENERAL_DAMAGE_REDUCTION",
 				"subtype" : "damageTypeMelee",
+				"sourceID" : "shield",
+				"targetSourceType" : "SPELL_EFFECT",
+				"valueType" : "PERCENT_TO_TARGET_TYPE",
 				"updater" : {
 					"type" : "GROWS_WITH_LEVEL",
-					"valPer20" : 60
+					"valPer20" : 200
 				}
 			},
 			"bonuses" : {
@@ -50,15 +53,9 @@
 						"stepSize" : 1
 					},
 					"limiters" : [
-						"allOf",
 						{
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"maxlevel" : 2
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.shield"
 						}
 					]
 				},
@@ -67,16 +64,10 @@
 						"stepSize" : 2
 					},
 					"limiters" : [
-						"allOf",
 						{
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 2,
 							"maxlevel" : 3
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.shield"
 						}
 					]
 				},
@@ -85,16 +76,10 @@
 						"stepSize" : 3
 					},
 					"limiters" : [
-						"allOf",
 						{
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 3,
 							"maxlevel" : 4
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.shield"
 						}
 					]
 				},
@@ -103,16 +88,10 @@
 						"stepSize" : 4
 					},
 					"limiters" : [
-						"allOf",
 						{
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 4,
 							"maxlevel" : 5
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.shield"
 						}
 					]
 				},
@@ -121,16 +100,10 @@
 						"stepSize" : 5
 					},
 					"limiters" : [
-						"allOf",
 						{
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 5,
 							"maxlevel" : 6
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.shield"
 						}
 					]
 				},
@@ -139,16 +112,10 @@
 						"stepSize" : 6
 					},
 					"limiters" : [
-						"allOf",
 						{
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 6,
 							"maxlevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.shield"
 						}
 					]
 				},
@@ -157,15 +124,9 @@
 						"stepSize" : 7
 					},
 					"limiters" : [
-						"allOf",
 						{
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.shield"
 						}
 					]
 				}

--- a/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/castle/cuthbert.json
+++ b/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/castle/cuthbert.json
@@ -6,73 +6,54 @@
 				"subtype" : "primarySkill.attack",
 				"valueType" : "ADDITIVE_VALUE",
 				"propagator" : "BATTLE_WIDE",
-				"propagationUpdater" : "BONUS_OWNER_UPDATER"
+				"propagationUpdater" : "BONUS_OWNER_UPDATER",
+				"limiters" : [
+					"allOf",
+					"OPPOSITE_SIDE",
+					{
+						"type" : "HAS_ANOTHER_BONUS_LIMITER",
+						"bonusSourceType" : "SPELL_EFFECT",
+						"bonusSourceID" : "spell.weakness"
+					}
+				]
 			},
 			"bonuses" : {
 				"weak12" : {
-					"limiters" : [
-						"allOf",
-						"OPPOSITE_SIDE",
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"maxlevel" : 3
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.weakness"
 						}
-					],
+					},
 					"val" : -4
 				},
 				"weak34" : {
-					"limiters" : [
-						"allOf",
-						"OPPOSITE_SIDE",
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 3,
 							"maxlevel" : 5
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.weakness"
 						}
-					],
+					},
 					"val" : -6
 				},
 				"weak56" : {
-					"limiters" : [
-						"allOf",
-						"OPPOSITE_SIDE",
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 5,
 							"maxlevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.weakness"
 						}
-					],
+					},
 					"val" : -8
 				},
 				"weak7" : {
-					"limiters" : [
-						"allOf",
-						"OPPOSITE_SIDE",
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.weakness"
 						}
-					],
+					},
 					"val" : -10
 				}
 			}

--- a/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/castle/loynis.json
+++ b/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/castle/loynis.json
@@ -1,221 +1,114 @@
 {
 	"core:loynis" : {
 		"specialty#override" : {
+			"base" : {
+				"valueType" : "ADDITIVE_VALUE",
+				"limiters" : [
+					{
+						"type" : "HAS_ANOTHER_BONUS_LIMITER",
+						"bonusSourceType" : "SPELL_EFFECT",
+						"bonusSourceID" : "spell.prayer"
+					}
+				]
+			},
 			"bonuses" : {
 				"bonusSpeed14" : {
 					"type" : "STACKS_SPEED",
-					"valueType" : "ADDITIVE_VALUE",
-					"propagator" : "BATTLE_WIDE",
-					"propagationUpdater" : "BONUS_OWNER_UPDATER",
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"maxlevel" : 5
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.prayer"
 						}
-					],
+					},
 					"val" : 3
-				},
-				"bonusSpeed56" : {
-					"type" : "STACKS_SPEED",
-					"valueType" : "ADDITIVE_VALUE",
-					"propagator" : "BATTLE_WIDE",
-					"propagationUpdater" : "BONUS_OWNER_UPDATER",
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
-							"type" : "CREATURE_LEVEL_LIMITER",
-							"minLevel" : 5,
-							"maxlevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.prayer"
-						}
-					],
-					"val" : 2
-				},
-				"bonusSpeed7" : {
-					"type" : "STACKS_SPEED",
-					"valueType" : "ADDITIVE_VALUE",
-					"propagator" : "BATTLE_WIDE",
-					"propagationUpdater" : "BONUS_OWNER_UPDATER",
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
-							"type" : "CREATURE_LEVEL_LIMITER",
-							"minLevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.prayer"
-						}
-					],
-					"val" : 1
 				},
 				"bonusAttack14" : {
 					"type" : "PRIMARY_SKILL",
 					"subtype" : "primarySkill.attack",
-					"valueType" : "ADDITIVE_VALUE",
-					"propagator" : "BATTLE_WIDE",
-					"propagationUpdater" : "BONUS_OWNER_UPDATER",
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"maxlevel" : 5
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.prayer"
 						}
-					],
+					},
 					"val" : 3
-				},
-				"bonusAttack56" : {
-					"type" : "PRIMARY_SKILL",
-					"subtype" : "primarySkill.attack",
-					"valueType" : "ADDITIVE_VALUE",
-					"propagator" : "BATTLE_WIDE",
-					"propagationUpdater" : "BONUS_OWNER_UPDATER",
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
-							"type" : "CREATURE_LEVEL_LIMITER",
-							"minLevel" : 5,
-							"maxlevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.prayer"
-						}
-					],
-					"val" : 2
-				},
-				"bonusAttack7" : {
-					"type" : "PRIMARY_SKILL",
-					"subtype" : "primarySkill.attack",
-					"valueType" : "ADDITIVE_VALUE",
-					"propagator" : "BATTLE_WIDE",
-					"propagationUpdater" : "BONUS_OWNER_UPDATER",
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
-							"type" : "CREATURE_LEVEL_LIMITER",
-							"minLevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.prayer"
-						}
-					],
-					"val" : 1
 				},
 				"bonusDefense14" : {
 					"type" : "PRIMARY_SKILL",
 					"subtype" : "primarySkill.defence",
-					"valueType" : "ADDITIVE_VALUE",
-					"propagator" : "BATTLE_WIDE",
-					"propagationUpdater" : "BONUS_OWNER_UPDATER",
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"maxlevel" : 5
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.prayer"
 						}
-					],
+					},
 					"val" : 3
+				},
+				"bonusSpeed56" : {
+					"type" : "STACKS_SPEED",
+					"limiters" : {
+						"append" : {
+							"type" : "CREATURE_LEVEL_LIMITER",
+							"minLevel" : 5,
+							"maxlevel" : 7
+						}
+					},
+					"val" : 2
+				},
+				"bonusAttack56" : {
+					"type" : "PRIMARY_SKILL",
+					"subtype" : "primarySkill.attack",
+					"limiters" : {
+						"append" : {
+							"type" : "CREATURE_LEVEL_LIMITER",
+							"minLevel" : 5,
+							"maxlevel" : 7
+						}
+					},
+					"val" : 2
 				},
 				"bonusDefense56" : {
 					"type" : "PRIMARY_SKILL",
 					"subtype" : "primarySkill.defence",
-					"valueType" : "ADDITIVE_VALUE",
-					"propagator" : "BATTLE_WIDE",
-					"propagationUpdater" : "BONUS_OWNER_UPDATER",
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 5,
 							"maxlevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.prayer"
 						}
-					],
+					},
 					"val" : 2
+				},
+				"bonusSpeed7" : {
+					"type" : "STACKS_SPEED",
+					"limiters" : {
+						"append" : {
+							"type" : "CREATURE_LEVEL_LIMITER",
+							"minLevel" : 7
+						}
+					},
+					"val" : 1
+				},
+				"bonusAttack7" : {
+					"type" : "PRIMARY_SKILL",
+					"subtype" : "primarySkill.attack",
+					"limiters" : {
+						"append" : {
+							"type" : "CREATURE_LEVEL_LIMITER",
+							"minLevel" : 7
+						}
+					},
+					"val" : 1
 				},
 				"bonusDefense7" : {
 					"type" : "PRIMARY_SKILL",
 					"subtype" : "primarySkill.defence",
-					"valueType" : "ADDITIVE_VALUE",
-					"propagator" : "BATTLE_WIDE",
-					"propagationUpdater" : "BONUS_OWNER_UPDATER",
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.prayer"
 						}
-					],
+					},
 					"val" : 1
 				}
 			}

--- a/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/conflux/brissa.json
+++ b/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/conflux/brissa.json
@@ -4,66 +4,41 @@
 			"base" : {
 				"type" : "STACKS_SPEED",
 				"valueType" : "ADDITIVE_VALUE",
-				"propagator" : "BATTLE_WIDE",
-				"propagationUpdater" : "BONUS_OWNER_UPDATER"
+				"limiters" : [
+					{
+						"type" : "HAS_ANOTHER_BONUS_LIMITER",
+						"bonusSourceType" : "SPELL_EFFECT",
+						"bonusSourceID" : "spell.haste"
+					}
+				]
 			},
 			"bonuses" : {
 				"bonusSpeed14" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"maxlevel" : 5
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.haste"
 						}
-					],
+					},
 					"val" : 3
 				},
 				"bonusSpeed56" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 5,
 							"maxlevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.haste"
 						}
-					],
+					},
 					"val" : 2
 				},
 				"bonusSpeed7" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.haste"
 						}
-					],
+					},
 					"val" : 1
 				}
 			}

--- a/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/conflux/inteus.json
+++ b/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/conflux/inteus.json
@@ -6,86 +6,51 @@
 				"subtype" : "primarySkill.attack",
 				"valueType" : "ADDITIVE_VALUE",
 				"effectRange" : "ONLY_MELEE_FIGHT",
-				"propagator" : "BATTLE_WIDE",
-				"propagationUpdater" : "BONUS_OWNER_UPDATER"
+				"limiters" : [
+					{
+						"type" : "HAS_ANOTHER_BONUS_LIMITER",
+						"bonusSourceType" : "SPELL_EFFECT",
+						"bonusSourceID" : "spell.bloodlust"
+					}
+				]
 			},
 			"bonuses" : {
 				"bonusDefense12" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"maxlevel" : 3
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.bloodlust"
 						}
-					],
+					},
 					"val" : 10
 				},
 				"bonusDefense34" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 3,
 							"maxlevel" : 5
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.bloodlust"
 						}
-					],
+					},
 					"val" : 8
 				},
 				"bonusDefense56" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 5,
 							"maxlevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.bloodlust"
 						}
-					],
+					},
 					"val" : 6
 				},
 				"bonusDefense7" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.bloodlust"
 						}
-					],
+					},
 					"val" : 4
 				}
 			}

--- a/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/conflux/labetha.json
+++ b/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/conflux/labetha.json
@@ -5,86 +5,51 @@
 				"type" : "PRIMARY_SKILL",
 				"subtype" : "primarySkill.defence",
 				"valueType" : "ADDITIVE_VALUE",
-				"propagator" : "BATTLE_WIDE",
-				"propagationUpdater" : "BONUS_OWNER_UPDATER"
+				"limiters" : [
+					{
+						"type" : "HAS_ANOTHER_BONUS_LIMITER",
+						"bonusSourceType" : "SPELL_EFFECT",
+						"bonusSourceID" : "spell.stoneSkin"
+					}
+				]
 			},
 			"bonuses" : {
 				"bonusDefense12" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"maxlevel" : 3
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.stoneSkin"
 						}
-					],
+					},
 					"val" : 10
 				},
 				"bonusDefense34" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 3,
 							"maxlevel" : 5
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.stoneSkin"
 						}
-					],
+					},
 					"val" : 8
 				},
 				"bonusDefense56" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 5,
 							"maxlevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.stoneSkin"
 						}
-					],
+					},
 					"val" : 6
 				},
 				"bonusDefense7" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.stoneSkin"
 						}
-					],
+					},
 					"val" : 4
 				}
 			}

--- a/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/cove/dargem.json
+++ b/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/cove/dargem.json
@@ -4,9 +4,12 @@
 			"base" : {
 				"type" : "GENERAL_DAMAGE_REDUCTION",
 				"subtype" : "damageTypeRanged",
+				"sourceID" : "airShield",
+				"targetSourceType" : "SPELL_EFFECT",
+				"valueType" : "PERCENT_TO_TARGET_TYPE",
 				"updater" : {
 					"type" : "GROWS_WITH_LEVEL",
-					"valPer20" : 100
+					"valPer20" : 200
 				}
 			},
 			"bonuses" : {
@@ -19,11 +22,6 @@
 						{
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"maxlevel" : 2
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.airShield"
 						}
 					]
 				},
@@ -37,11 +35,6 @@
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 2,
 							"maxlevel" : 3
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.airShield"
 						}
 					]
 				},
@@ -55,11 +48,6 @@
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 3,
 							"maxlevel" : 4
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.airShield"
 						}
 					]
 				},
@@ -73,11 +61,6 @@
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 4,
 							"maxlevel" : 5
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.airShield"
 						}
 					]
 				},
@@ -91,11 +74,6 @@
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 5,
 							"maxlevel" : 6
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.airShield"
 						}
 					]
 				},
@@ -109,11 +87,6 @@
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 6,
 							"maxlevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.airShield"
 						}
 					]
 				},
@@ -126,11 +99,6 @@
 						{
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.airShield"
 						}
 					]
 				}

--- a/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/dungeon/darkstorn.json
+++ b/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/dungeon/darkstorn.json
@@ -5,86 +5,51 @@
 				"type" : "PRIMARY_SKILL",
 				"subtype" : "primarySkill.defence",
 				"valueType" : "ADDITIVE_VALUE",
-				"propagator" : "BATTLE_WIDE",
-				"propagationUpdater" : "BONUS_OWNER_UPDATER"
+				"limiters" : [
+					{
+						"type" : "HAS_ANOTHER_BONUS_LIMITER",
+						"bonusSourceType" : "SPELL_EFFECT",
+						"bonusSourceID" : "spell.stoneSkin"
+					}
+				]
 			},
 			"bonuses" : {
 				"bonusDefense12" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"maxlevel" : 3
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.stoneSkin"
 						}
-					],
+					},
 					"val" : 10
 				},
 				"bonusDefense34" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 3,
 							"maxlevel" : 5
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.stoneSkin"
 						}
-					],
+					},
 					"val" : 8
 				},
 				"bonusDefense56" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 5,
 							"maxlevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.stoneSkin"
 						}
-					],
+					},
 					"val" : 6
 				},
 				"bonusDefense7" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.stoneSkin"
 						}
-					],
+					},
 					"val" : 4
 				}
 			}

--- a/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/factory/eanswythe.json
+++ b/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/factory/eanswythe.json
@@ -6,73 +6,54 @@
 				"subtype" : "primarySkill.attack",
 				"valueType" : "ADDITIVE_VALUE",
 				"propagator" : "BATTLE_WIDE",
-				"propagationUpdater" : "BONUS_OWNER_UPDATER"
+				"propagationUpdater" : "BONUS_OWNER_UPDATER",
+				"limiters" : [
+					"allOf",
+					"OPPOSITE_SIDE",
+					{
+						"type" : "HAS_ANOTHER_BONUS_LIMITER",
+						"bonusSourceType" : "SPELL_EFFECT",
+						"bonusSourceID" : "spell.weakness"
+					}
+				]
 			},
 			"bonuses" : {
 				"weak12" : {
-					"limiters" : [
-						"allOf",
-						"OPPOSITE_SIDE",
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"maxlevel" : 3
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.weakness"
 						}
-					],
+					},
 					"val" : -4
 				},
 				"weak34" : {
-					"limiters" : [
-						"allOf",
-						"OPPOSITE_SIDE",
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 3,
 							"maxlevel" : 5
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.weakness"
 						}
-					],
+					},
 					"val" : -6
 				},
 				"weak56" : {
-					"limiters" : [
-						"allOf",
-						"OPPOSITE_SIDE",
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 5,
 							"maxlevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.weakness"
 						}
-					],
+					},
 					"val" : -8
 				},
 				"weak7" : {
-					"limiters" : [
-						"allOf",
-						"OPPOSITE_SIDE",
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.weakness"
 						}
-					],
+					},
 					"val" : -10
 				}
 			}

--- a/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/fortress/merist.json
+++ b/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/fortress/merist.json
@@ -5,86 +5,51 @@
 				"type" : "PRIMARY_SKILL",
 				"subtype" : "primarySkill.defence",
 				"valueType" : "ADDITIVE_VALUE",
-				"propagator" : "BATTLE_WIDE",
-				"propagationUpdater" : "BONUS_OWNER_UPDATER"
+				"limiters" : [
+					{
+						"type" : "HAS_ANOTHER_BONUS_LIMITER",
+						"bonusSourceType" : "SPELL_EFFECT",
+						"bonusSourceID" : "spell.stoneSkin"
+					}
+				]
 			},
 			"bonuses" : {
 				"bonusDefense12" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"maxlevel" : 3
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.stoneSkin"
 						}
-					],
+					},
 					"val" : 10
 				},
 				"bonusDefense34" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 3,
 							"maxlevel" : 5
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.stoneSkin"
 						}
-					],
+					},
 					"val" : 8
 				},
 				"bonusDefense56" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 5,
 							"maxlevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.stoneSkin"
 						}
-					],
+					},
 					"val" : 6
 				},
 				"bonusDefense7" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.stoneSkin"
 						}
-					],
+					},
 					"val" : 4
 				}
 			}

--- a/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/fortress/mirlanda.json
+++ b/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/fortress/mirlanda.json
@@ -6,73 +6,54 @@
 				"subtype" : "primarySkill.attack",
 				"valueType" : "ADDITIVE_VALUE",
 				"propagator" : "BATTLE_WIDE",
-				"propagationUpdater" : "BONUS_OWNER_UPDATER"
+				"propagationUpdater" : "BONUS_OWNER_UPDATER",
+				"limiters" : [
+					"allOf",
+					"OPPOSITE_SIDE",
+					{
+						"type" : "HAS_ANOTHER_BONUS_LIMITER",
+						"bonusSourceType" : "SPELL_EFFECT",
+						"bonusSourceID" : "spell.weakness"
+					}
+				]
 			},
 			"bonuses" : {
 				"weak12" : {
-					"limiters" : [
-						"allOf",
-						"OPPOSITE_SIDE",
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"maxlevel" : 3
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.weakness"
 						}
-					],
+					},
 					"val" : -4
 				},
 				"weak34" : {
-					"limiters" : [
-						"allOf",
-						"OPPOSITE_SIDE",
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 3,
 							"maxlevel" : 5
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.weakness"
 						}
-					],
+					},
 					"val" : -6
 				},
 				"weak56" : {
-					"limiters" : [
-						"allOf",
-						"OPPOSITE_SIDE",
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 5,
 							"maxlevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.weakness"
 						}
-					],
+					},
 					"val" : -8
 				},
 				"weak7" : {
-					"limiters" : [
-						"allOf",
-						"OPPOSITE_SIDE",
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.weakness"
 						}
-					],
+					},
 					"val" : -10
 				}
 			}

--- a/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/inferno/ash.json
+++ b/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/inferno/ash.json
@@ -6,86 +6,51 @@
 				"subtype" : "primarySkill.attack",
 				"valueType" : "ADDITIVE_VALUE",
 				"effectRange" : "ONLY_MELEE_FIGHT",
-				"propagator" : "BATTLE_WIDE",
-				"propagationUpdater" : "BONUS_OWNER_UPDATER"
+				"limiters" : [
+					{
+						"type" : "HAS_ANOTHER_BONUS_LIMITER",
+						"bonusSourceType" : "SPELL_EFFECT",
+						"bonusSourceID" : "spell.bloodlust"
+					}
+				]
 			},
 			"bonuses" : {
 				"bonusDefense12" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"maxlevel" : 3
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.bloodlust"
 						}
-					],
+					},
 					"val" : 10
 				},
 				"bonusDefense34" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 3,
 							"maxlevel" : 5
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.bloodlust"
 						}
-					],
+					},
 					"val" : 8
 				},
 				"bonusDefense56" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 5,
 							"maxlevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.bloodlust"
 						}
-					],
+					},
 					"val" : 6
 				},
 				"bonusDefense7" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.bloodlust"
 						}
-					],
+					},
 					"val" : 4
 				}
 			}

--- a/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/inferno/olema.json
+++ b/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/inferno/olema.json
@@ -6,73 +6,54 @@
 				"subtype" : "primarySkill.attack",
 				"valueType" : "ADDITIVE_VALUE",
 				"propagator" : "BATTLE_WIDE",
-				"propagationUpdater" : "BONUS_OWNER_UPDATER"
+				"propagationUpdater" : "BONUS_OWNER_UPDATER",
+				"limiters" : [
+					"allOf",
+					"OPPOSITE_SIDE",
+					{
+						"type" : "HAS_ANOTHER_BONUS_LIMITER",
+						"bonusSourceType" : "SPELL_EFFECT",
+						"bonusSourceID" : "spell.weakness"
+					}
+				]
 			},
 			"bonuses" : {
 				"weak12" : {
-					"limiters" : [
-						"allOf",
-						"OPPOSITE_SIDE",
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"maxlevel" : 3
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.weakness"
 						}
-					],
+					},
 					"val" : -4
 				},
 				"weak34" : {
-					"limiters" : [
-						"allOf",
-						"OPPOSITE_SIDE",
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 3,
 							"maxlevel" : 5
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.weakness"
 						}
-					],
+					},
 					"val" : -6
 				},
 				"weak56" : {
-					"limiters" : [
-						"allOf",
-						"OPPOSITE_SIDE",
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 5,
 							"maxlevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.weakness"
 						}
-					],
+					},
 					"val" : -8
 				},
 				"weak7" : {
-					"limiters" : [
-						"allOf",
-						"OPPOSITE_SIDE",
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.weakness"
 						}
-					],
+					},
 					"val" : -10
 				}
 			}

--- a/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/necropolis/xsi.json
+++ b/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/necropolis/xsi.json
@@ -5,86 +5,51 @@
 				"type" : "PRIMARY_SKILL",
 				"subtype" : "primarySkill.defence",
 				"valueType" : "ADDITIVE_VALUE",
-				"propagator" : "BATTLE_WIDE",
-				"propagationUpdater" : "BONUS_OWNER_UPDATER"
+				"limiters" : [
+					{
+						"type" : "HAS_ANOTHER_BONUS_LIMITER",
+						"bonusSourceType" : "SPELL_EFFECT",
+						"bonusSourceID" : "spell.stoneSkin"
+					}
+				]
 			},
 			"bonuses" : {
 				"bonusDefense12" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"maxlevel" : 3
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.stoneSkin"
 						}
-					],
+					},
 					"val" : 10
 				},
 				"bonusDefense34" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 3,
 							"maxlevel" : 5
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.stoneSkin"
 						}
-					],
+					},
 					"val" : 8
 				},
 				"bonusDefense56" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 5,
 							"maxlevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.stoneSkin"
 						}
-					],
+					},
 					"val" : 6
 				},
 				"bonusDefense7" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.stoneSkin"
 						}
-					],
+					},
 					"val" : 4
 				}
 			}

--- a/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/stronghold/terek.json
+++ b/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/stronghold/terek.json
@@ -4,66 +4,41 @@
 			"base" : {
 				"type" : "STACKS_SPEED",
 				"valueType" : "ADDITIVE_VALUE",
-				"propagator" : "BATTLE_WIDE",
-				"propagationUpdater" : "BONUS_OWNER_UPDATER"
+				"limiters" : [
+					{
+						"type" : "HAS_ANOTHER_BONUS_LIMITER",
+						"bonusSourceType" : "SPELL_EFFECT",
+						"bonusSourceID" : "spell.haste"
+					}
+				]
 			},
 			"bonuses" : {
 				"bonusSpeed14" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"maxlevel" : 5
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.haste"
 						}
-					],
+					},
 					"val" : 3
 				},
 				"bonusSpeed56" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 5,
 							"maxlevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.haste"
 						}
-					],
+					},
 					"val" : 2
 				},
 				"bonusSpeed7" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.haste"
 						}
-					],
+					},
 					"val" : 1
 				}
 			}

--- a/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/stronghold/zubin.json
+++ b/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/stronghold/zubin.json
@@ -6,86 +6,51 @@
 				"subtype" : "primarySkill.attack",
 				"valueType" : "ADDITIVE_VALUE",
 				"effectRange" : "ONLY_DISTANCE_FIGHT",
-				"propagator" : "BATTLE_WIDE",
-				"propagationUpdater" : "BONUS_OWNER_UPDATER"
+				"limiters" : [
+					{
+						"type" : "HAS_ANOTHER_BONUS_LIMITER",
+						"bonusSourceType" : "SPELL_EFFECT",
+						"bonusSourceID" : "spell.precision"
+					}
+				]
 			},
 			"bonuses" : {
 				"bonusDefense12" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"maxlevel" : 3
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.precision"
 						}
-					],
+					},
 					"val" : 10
 				},
 				"bonusDefense34" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 3,
 							"maxlevel" : 5
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.precision"
 						}
-					],
+					},
 					"val" : 8
 				},
 				"bonusDefense56" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 5,
 							"maxlevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.precision"
 						}
-					],
+					},
 					"val" : 6
 				},
 				"bonusDefense7" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.precision"
 						}
-					],
+					},
 					"val" : 4
 				}
 			}

--- a/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/tower/cyra.json
+++ b/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/tower/cyra.json
@@ -4,66 +4,41 @@
 			"base" : {
 				"type" : "STACKS_SPEED",
 				"valueType" : "ADDITIVE_VALUE",
-				"propagator" : "BATTLE_WIDE",
-				"propagationUpdater" : "BONUS_OWNER_UPDATER"
+				"limiters" : [
+					{
+						"type" : "HAS_ANOTHER_BONUS_LIMITER",
+						"bonusSourceType" : "SPELL_EFFECT",
+						"bonusSourceID" : "spell.haste"
+					}
+				]
 			},
 			"bonuses" : {
 				"bonusSpeed14" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"maxlevel" : 5
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.haste"
 						}
-					],
+					},
 					"val" : 3
 				},
 				"bonusSpeed56" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 5,
 							"maxlevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.haste"
 						}
-					],
+					},
 					"val" : 2
 				},
 				"bonusSpeed7" : {
-					"limiters" : [
-						"allOf",
-						[
-							"noneOf",
-							"OPPOSITE_SIDE"
-						],
-						{
+					"limiters" : {
+						"append" : {
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 7
-						},
-						{
-							"type" : "HAS_ANOTHER_BONUS_LIMITER",
-							"bonusSourceType" : "SPELL_EFFECT",
-							"bonusSourceID" : "spell.haste"
 						}
-					],
+					},
 					"val" : 1
 				}
 			}


### PR DESCRIPTION
+ Fixed scaling of Dalton's and Dargem's specialties
    + they used to give a flat bonus to creatures affected by the spell, based on numbers using the skill's expert level
    + now modifies the spell effect, so scaling is correct at all skill levels

+ Removed unnecessary propagators and limiters from the specialties
    + e.g. Stone Skin specialty had BATTLE_WIDE propagator with noneOf and OPPOSITE_SIDE, which is unnecessary, just don't use BATTLE_WIDE. Dunno what I was thinking. Limiting when affected by spell is enough.
    + functionally identical, just simpler to read due to better structure