### PR TITLE
Remove unnecessary fields

### DIFF
--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroes/dalton.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroes/dalton.json
@@ -39,7 +39,6 @@
 			"base" : {
 				"type" : "GENERAL_DAMAGE_REDUCTION",
 				"subtype" : "damageTypeMelee",
-				"sourceID" : "shield",
 				"targetSourceType" : "SPELL_EFFECT",
 				"valueType" : "PERCENT_TO_TARGET_TYPE",
 				"updater" : {

--- a/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/cove/dargem.json
+++ b/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/cove/dargem.json
@@ -4,7 +4,6 @@
 			"base" : {
 				"type" : "GENERAL_DAMAGE_REDUCTION",
 				"subtype" : "damageTypeRanged",
-				"sourceID" : "airShield",
 				"targetSourceType" : "SPELL_EFFECT",
 				"valueType" : "PERCENT_TO_TARGET_TYPE",
 				"updater" : {
@@ -18,7 +17,6 @@
 						"stepSize" : 1
 					},
 					"limiters" : [
-						"allOf",
 						{
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"maxlevel" : 2
@@ -30,7 +28,6 @@
 						"stepSize" : 2
 					},
 					"limiters" : [
-						"allOf",
 						{
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 2,
@@ -43,7 +40,6 @@
 						"stepSize" : 3
 					},
 					"limiters" : [
-						"allOf",
 						{
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 3,
@@ -56,7 +52,6 @@
 						"stepSize" : 4
 					},
 					"limiters" : [
-						"allOf",
 						{
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 4,
@@ -69,7 +64,6 @@
 						"stepSize" : 5
 					},
 					"limiters" : [
-						"allOf",
 						{
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 5,
@@ -95,7 +89,6 @@
 						"stepSize" : 7
 					},
 					"limiters" : [
-						"allOf",
 						{
 							"type" : "CREATURE_LEVEL_LIMITER",
 							"minLevel" : 7


### PR DESCRIPTION
No functional change.

sourceID doesn't do what I thought it would do, it's an internal field, not a limiting field.
Also removed "allOf" aggregator on Dargem's limiters as that is the default anyway, so no need to put it here.