### PR TITLE
New beta update changes

### DIFF
--- a/hota/Mods/cove/Content/config/hota/cove/spells/specialClone.json
+++ b/hota/Mods/cove/Content/config/hota/cove/spells/specialClone.json
@@ -19,6 +19,7 @@
 			]
 		},
 		"flags" : {
+			"persistent" : true,
 			"positive" : true,
 			"special" : true
 		},

--- a/hota/Mods/factory/content/config/hota/factory/spells/meditation01.json
+++ b/hota/Mods/factory/content/config/hota/factory/spells/meditation01.json
@@ -20,6 +20,7 @@
 			]
 		},
 		"flags" : {
+			"persistent" : true,
 			"positive" : true,
 			"special" : true
 		},
@@ -49,17 +50,15 @@
 							"invincible" : {
 								"type" : "INVINCIBLE",
 								"duration" : [
-									"N_TURNS"
-								],
-								"turns" : 1
+									"STACK_GETS_TURN"
+								]
 							},
 							"immunityToHarmfulEffects" : {
 								"type" : "NEGATIVE_EFFECTS_IMMUNITY",
 								"subtype" : "spellSchool.any",
 								"duration" : [
-									"N_TURNS"
-								],
-								"turns" : 1
+									"STACK_GETS_TURN"
+								]
 							}
 						}
 					}

--- a/hota/Mods/factory/content/config/hota/factory/spells/meditation02.json
+++ b/hota/Mods/factory/content/config/hota/factory/spells/meditation02.json
@@ -20,6 +20,7 @@
 			]
 		},
 		"flags" : {
+			"persistent" : true,
 			"positive" : true,
 			"special" : true
 		},
@@ -49,17 +50,15 @@
 							"invincible" : {
 								"type" : "INVINCIBLE",
 								"duration" : [
-									"N_TURNS"
-								],
-								"turns" : 1
+									"STACK_GETS_TURN"
+								]
 							},
 							"immunityToHarmfulEffects" : {
 								"type" : "NEGATIVE_EFFECTS_IMMUNITY",
 								"subtype" : "spellSchool.any",
 								"duration" : [
-									"N_TURNS"
-								],
-								"turns" : 1
+									"STACK_GETS_TURN"
+								]
 							}
 						}
 					}

--- a/hota/Mods/highlandsTerrain/content/config/hota/highlands/hotaInteractive/hermitsShack.json
+++ b/hota/Mods/highlandsTerrain/content/config/hota/highlands/hotaInteractive/hermitsShack.json
@@ -9,7 +9,7 @@
 				"rmg" : {
 					"value" : 1500,
 					"rarity" : 80,
-					"zoneLimit" : 3,
+					"zoneLimit" : 1,
 					"mapLimit" : 32
 				},
 

--- a/hota/Mods/interference/content/config/hotaInterference/interference.json
+++ b/hota/Mods/interference/content/config/hotaInterference/interference.json
@@ -6,6 +6,7 @@
 			"magic" : 0
 		},
 		"specialty" : [
+			"main"
 		],
 		"base" : {
 			"effects" : {

--- a/hota/Mods/interference/content/config/rampart/heroes/giselle.json
+++ b/hota/Mods/interference/content/config/rampart/heroes/giselle.json
@@ -32,16 +32,8 @@
 			}
 		],
 		"specialty" : {
+			"secondary" : "interference",
 			"bonuses" : {
-				"battleWide" : {
-					"type" : "PRIMARY_SKILL",
-					"subtype" : "spellpower",
-					"val" : 5,
-					"targetSourceType" : "SECONDARY_SKILL",
-					"valueType" : "PERCENT_TO_TARGET_TYPE",
-					"propagator" : "BATTLE_WIDE",
-					"propagationUpdater" : "TIMES_HERO_LEVEL"
-				},
 				"selfCounter" : {
 					"type" : "PRIMARY_SKILL",
 					"subtype" : "spellpower",

--- a/hota/Mods/mapSupport/mod.json
+++ b/hota/Mods/mapSupport/mod.json
@@ -829,6 +829,10 @@
 							8,
 							3
 						],
+						"boatBulwark" : [
+							8,
+							6
+						],
 						"boatNeutral" : [
 							8,
 							4

--- a/hota/Mods/wastelandTerrain/content/config/hota/wasteland/hotaInteractive/grave.json
+++ b/hota/Mods/wastelandTerrain/content/config/hota/wasteland/hotaInteractive/grave.json
@@ -12,7 +12,7 @@
 		"types" : {
 			"grave" : {
 				"name" : "Grave",
-				"description" : "(Takes all movement points for this and the next turn, and gives 1500-4000 gold, a random Treasure or Minor artifact, and -3 morale until the next battle.)",
+				"description" : "(Digging gives 1500-4000 gold, a random Treasure or Minor artifact, and -3 morale until the next battle.)",
 				"rmg" : {
 					"value" : 500,
 					"rarity" : 30
@@ -42,10 +42,13 @@
 				"removable" : true,
 				"blockedVisitable" : false,
 				"showScoutedPreview" : false,
-				"canRefuse" : true,
+				"onEmptyMessage" : "{Grave}\n\nThis tomb is fresh, and even the shovel someone dug it with hasn't been stolen yet.\n\nHowever, digging for artifacts requires an entire day.",
 				"rewards" : [
 					{
-						"message" : "{Grave}\n\nThis tomb is fresh, and even the shovel someone dug it with hasn't been stolen yet.\nDo you want to take up the latter, cover your nose with a handkerchief, extract something valuable from the ground and call it a day?\n{Your hero will be too exhausted from digging to move for this and the next turn.}",
+						"limiter" : {
+							"movePercentage" : 100
+						},
+						"message" : "{Grave}\n\nYou take up the shovel, cover your nose with a handkerchief and extract something valuable from the ground.",
 						"resources" : [
 							{
 								"type" : "@gainedResource",
@@ -62,14 +65,6 @@
 								"duration" : "ONE_BATTLE",
 								"description" : "Grave Digging",
 								"stacking" : "GraveDigging"
-							},
-							{
-								"type" : "MOVEMENT",
-								"subtype" : "heroMovementLand",
-								"val" : 0,
-								"valueType" : "INDEPENDENT_MIN",
-								"duration" : "N_DAYS",
-								"turns" : 2
 							}
 						],
 						"movePercentage" : 0,


### PR DESCRIPTION
Requires VCMI-branch-beta-d439da3 or above

needs review:
+ Grave (please make sure that's an okay change gameplay-wise)
    + added movement percentage limiter
    + changed messages
    + made Grave not refusable anymore so you don't see the rewards prior to digging
+ added bulwarkBoat to mapSupport
    + I "tested" this by spawning every boat on a map in the HotA editor and changing the numbers until the VCMI-loaded boats matched with the HotA one

new beta stuff extended:
+ Made Special Clone effect (the one that denies casting the spell again) undispellable
+ Made (Crimson) Couatl ability undispellable and changed the duration to the more appropriate STACK_GETS_TURN
+ Shorter form of Interference specialty. Tested and works in all cases the other one did.

Regular fix: 
+ Hermit's Shack wrong zoneLimit

Oh, and re:mapsupport's mod.json creature section:
creature with index 152 is called "Electric Tower", i don't think it is used tho