### PR TITLE
Simplify templates

### DIFF
--- a/hota/Mods/templates/content/config/hota2sm4d(3).json
+++ b/hota/Mods/templates/content/config/hota2sm4d(3).json
@@ -70,13 +70,7 @@
 					{ "min" : 15000, "max" : 20000, "density" : 6 },
 					{ "min" : 10000, "max" : 15000, "density" : 9 }
 				],
-				"customObjects" : {
-					"bannedObjects" : {
-						"core:shrineOfMagicLevel1" : {
-							"hota.mapobjects:shrineOfMagicMystery" : true
-						}
-					}
-				}
+				"customObjectsLikeZone" : 1
 			},
 			"4" :
 			{
@@ -102,7 +96,7 @@
 					"gold" : 1 
 				},
 				"treasureLikeZone" : 3,
-				"customObjectsLikeZone" : 3
+				"customObjectsLikeZone" : 1
 			},
 			"6" :
 			{
@@ -154,7 +148,7 @@
 				"matchTerrainToTown" : false,
 				"minesLikeZone" : 5,
 				"treasureLikeZone" : 3,
-				"customObjectsLikeZone" : 3
+				"customObjectsLikeZone" : 1
 			},
 			"10" :
 			{
@@ -164,7 +158,7 @@
 				"matchTerrainToTown" : false,
 				"minesLikeZone" : 3,
 				"treasureLikeZone" : 3,
-				"customObjectsLikeZone" : 3
+				"customObjectsLikeZone" : 1
 			}
 		},
 		"connections" :

--- a/hota/Mods/templates/content/config/hota6lm10a.json
+++ b/hota/Mods/templates/content/config/hota6lm10a.json
@@ -33,9 +33,6 @@
 				"matchTerrainToTown" : true,
 				"customObjects" : {
 					"bannedObjects" : {
-						"core:dragonUtopia" : {
-							"dragonUtopia" : true
-						},
 						"core:shrineOfMagicLevel1" : {
 							"hota.mapobjects:shrineOfMagicMystery" : true
 						}
@@ -143,9 +140,6 @@
 				"matchTerrainToTown" : true,
 				"customObjects" : {
 					"bannedObjects" : {
-						"core:dragonUtopia" : {
-							"dragonUtopia" : true
-						},
 						"core:shrineOfMagicLevel1" : {
 							"hota.mapobjects:shrineOfMagicMystery" : true
 						}
@@ -302,9 +296,6 @@
 				],
 				"customObjects" : {
 					"bannedObjects" : {
-						"core:dragonUtopia" : {
-							"dragonUtopia" : true
-						},
 						"core:shrineOfMagicLevel1" : {
 							"hota.mapobjects:shrineOfMagicMystery" : true
 						}

--- a/hota/Mods/templates/content/config/hota8xm12a.json
+++ b/hota/Mods/templates/content/config/hota8xm12a.json
@@ -33,9 +33,6 @@
 				"matchTerrainToTown" : true,
 				"customObjects" : {
 					"bannedObjects" : {
-						"core:dragonUtopia" : {
-							"dragonUtopia" : true
-						},
 						"core:shrineOfMagicLevel1" : {
 							"hota.mapobjects:shrineOfMagicMystery" : true
 						}
@@ -173,9 +170,6 @@
 				"matchTerrainToTown" : true,
 				"customObjects" : {
 					"bannedObjects" : {
-						"core:dragonUtopia" : {
-							"dragonUtopia" : true
-						},
 						"core:shrineOfMagicLevel1" : {
 							"hota.mapobjects:shrineOfMagicMystery" : true
 						}
@@ -483,9 +477,6 @@
 				],
 				"customObjects" : {
 					"bannedObjects" : {
-						"core:dragonUtopia" : {
-							"dragonUtopia" : true
-						},
 						"core:shrineOfMagicLevel1" : {
 							"hota.mapobjects:shrineOfMagicMystery" : true
 						}

--- a/hota/Mods/templates/content/config/hotaDiamond.json
+++ b/hota/Mods/templates/content/config/hotaDiamond.json
@@ -33,9 +33,6 @@
 				"matchTerrainToTown" : true,
 				"customObjects" : {
 					"bannedObjects" : {
-						"core:dragonUtopia" : {
-							"dragonUtopia" : true
-						},
 						"core:shrineOfMagicLevel1" : {
 							"hota.mapobjects:shrineOfMagicMystery" : true
 						}
@@ -181,9 +178,6 @@
 				],
 				"customObjects" : {
 					"bannedObjects" : {
-						"core:dragonUtopia" : {
-							"dragonUtopia" : true
-						},
 						"core:shrineOfMagicLevel1" : {
 							"hota.mapobjects:shrineOfMagicMystery" : true
 						}

--- a/hota/Mods/templates/content/config/hotaJebusCross.json
+++ b/hota/Mods/templates/content/config/hotaJebusCross.json
@@ -32,15 +32,6 @@
 				],
 				"customObjects" : {
 					"bannedObjects" : {
-						"core:tavern" : {
-							"object" : true
-						},
-						"hota.highlandsterrain:hermitsShack" : {
-							"hota.highlandsterrain:hermitsShack" : true
-						},
-						"hota.highlandsterrain:mineralSpring" : {
-							"hota.highlandsterrain:mineralSpring" : true
-						},
 						"hota.mapobjects:ancientLamp" : {
 							"hota.mapobjects:ancientLamp" : true
 						}
@@ -72,7 +63,7 @@
 								"value" : 500,
 								"zoneLimit" : 3
 							}
-						},
+						}
 					]
 				}
 			},
@@ -104,20 +95,6 @@
 					{"min" : 300, "max": 3000, "density": 14}
 				],
 				"customObjects" : {
-					"bannedObjects" : {
-						"core:tavern" : {
-							"object" : true
-						},
-						"hota.highlandsterrain:hermitsShack" : {
-							"hota.highlandsterrain:hermitsShack" : true
-						},
-						"hota.highlandsterrain:mineralSpring" : {
-							"hota.highlandsterrain:mineralSpring" : true
-						},
-						"hota.mapobjects:ancientLamp" : {
-							"hota.mapobjects:ancientLamp" : true
-						}
-					},
 					"commonObjects" : [
 						{
 							"type" : "core:tavern",

--- a/hota/Mods/templates/content/config/hotaMiniNostalgia.json
+++ b/hota/Mods/templates/content/config/hotaMiniNostalgia.json
@@ -33,9 +33,6 @@
 				"matchTerrainToTown" : true,
 				"customObjects" : {
 					"bannedObjects" : {
-						"core:dragonUtopia" : {
-							"dragonUtopia" : true
-						},
 						"core:shrineOfMagicLevel1" : {
 							"hota.mapobjects:shrineOfMagicMystery" : true
 						}
@@ -81,9 +78,6 @@
 				],
 				"customObjects" : {
 					"bannedObjects" : {
-						"core:dragonUtopia" : {
-							"dragonUtopia" : true
-						},
 						"core:shrineOfMagicLevel1" : {
 							"hota.mapobjects:shrineOfMagicMystery" : true
 						}

--- a/hota/Mods/templates/content/config/hotaSpider.json
+++ b/hota/Mods/templates/content/config/hotaSpider.json
@@ -265,9 +265,6 @@
 				],
 				"customObjects" : {
 					"bannedObjects" : {
-						"core:dragonUtopia" : {
-							"dragonUtopia" : true
-						},
 						"core:shrineOfMagicLevel1" : {
 							"hota.mapobjects:shrineOfMagicMystery" : true
 						}


### PR DESCRIPTION
`"commonObjects"` already prevents placement of the specified objects under normal RMG rules, so no need to ban them specifically in that zone. So I removed the bans that are unnecessary.

No functional change