### PR TITLE
Template addition: Doubled 8mm6

### DIFF
--- a/hota/Mods/templates/content/config/hota8xm12a.json
+++ b/hota/Mods/templates/content/config/hota8xm12a.json
@@ -17,10 +17,10 @@
 				"size" : 20,
 				"owner" : 1,
 				"monsters" : "weak",
-				"playerTowns" : { 
+				"playerTowns" : {
 					"castles" : 1
 				},
-				"mines" : { 
+				"mines" : {
 					"wood" : 1,
 					"ore" : 1
 				},
@@ -56,7 +56,7 @@
 				"size" : 20,
 				"owner" : 8,
 				"monsters" : "weak",
-				"playerTowns" : { 
+				"playerTowns" : {
 					"castles" : 1
 				},
 				"matchTerrainToTown" : true,
@@ -153,11 +153,11 @@
 				"type" : "treasure",
 				"size" : 20,
 				"monsters" : "normal",
-				"neutralTowns" : { 
+				"neutralTowns" : {
 					"towns" : 1
 				},
-				"mines" : { 
-					"wood" : 1, 
+				"mines" : {
+					"wood" : 1,
 					"ore" : 1,
 					"mercury" : 1
 				},
@@ -192,12 +192,12 @@
 				"type" : "treasure",
 				"size" : 20,
 				"monsters" : "normal",
-				"neutralTowns" : { 
+				"neutralTowns" : {
 					"towns" : 1
 				},
-				"mines" : { 
-					"wood" : 1, 
-					"ore" : 1, 
+				"mines" : {
+					"wood" : 1,
+					"ore" : 1,
 					"sulfur" : 1
 				},
 				"matchTerrainToTown" : true,
@@ -209,13 +209,13 @@
 				"type" : "treasure",
 				"size" : 20,
 				"monsters" : "normal",
-				"neutralTowns" : { 
+				"neutralTowns" : {
 					"towns" : 1
 				},
-				"mines" : { 
-					"wood" : 1, 
-					"ore" : 1, 
-					"crystal" : 1 
+				"mines" : {
+					"wood" : 1,
+					"ore" : 1,
+					"crystal" : 1
 				},
 				"matchTerrainToTown" : true,
 				"customObjectsLikeZone" : 9,
@@ -226,10 +226,10 @@
 				"type" : "treasure",
 				"size" : 20,
 				"monsters" : "normal",
-				"neutralTowns" : { 
+				"neutralTowns" : {
 					"towns" : 1
 				},
-				"mines" : { 
+				"mines" : {
 					"wood" : 1,
 					"ore" : 1,
 					"gems" : 1
@@ -243,7 +243,7 @@
 				"type" : "treasure",
 				"size" : 20,
 				"monsters" : "normal",
-				"neutralTowns" : { 
+				"neutralTowns" : {
 					"towns" : 1
 				},
 				"matchTerrainToTown" : true,
@@ -256,7 +256,7 @@
 				"type" : "treasure",
 				"size" : 20,
 				"monsters" : "normal",
-				"neutralTowns" : { 
+				"neutralTowns" : {
 					"towns" : 1
 				},
 				"matchTerrainToTown" : true,
@@ -466,7 +466,7 @@
 				"size" : 30,
 				"monsters" : "strong",
 				"matchTerrainToTown" : false,
-				"mines" : { 
+				"mines" : {
 					"gold" : 2
 				},
 				"treasure" :
@@ -518,10 +518,12 @@
 			{ "a" : "7", "b" : "30", "guard" : 3000 },
 			{ "a" : "8", "b" : "29", "guard" : 3000, "road" : "true" },
 			{ "a" : "8", "b" : "32", "guard" : 3000, "road" : "true" },
+			{ "a" : "9", "b" : "21", "guard" : 6000, "road" : "true" },
 			{ "a" : "10", "b" : "23", "guard" : 6000 },
 			{ "a" : "11", "b" : "22", "guard" : 6000 },
 			{ "a" : "11", "b" : "33", "guard" : 9000, "road" : "false" },
 			{ "a" : "11", "b" : "33", "guard" : 9000, "road" : "false" },
+			{ "a" : "12", "b" : "24", "guard" : 6000, "road" : "true" },
 			{ "a" : "13", "b" : "25", "guard" : 6000 },
 			{ "a" : "14", "b" : "26", "guard" : 3000 },
 			{ "a" : "14", "b" : "33", "guard" : 9000, "road" : "false" },
@@ -529,23 +531,21 @@
 			{ "a" : "15", "b" : "27", "guard" : 6000 },
 			{ "a" : "15", "b" : "33", "guard" : 9000, "road" : "false" },
 			{ "a" : "15", "b" : "33", "guard" : 9000, "road" : "false" },
+			{ "a" : "16", "b" : "28", "guard" : 6000 },
 			{ "a" : "17", "b" : "29", "guard" : 6000, "road" : "true" },
 			{ "a" : "18", "b" : "31", "guard" : 6000 },
 			{ "a" : "18", "b" : "33", "guard" : 9000, "road" : "false" },
 			{ "a" : "18", "b" : "33", "guard" : 9000, "road" : "false" },
 			{ "a" : "19", "b" : "30", "guard" : 6000 },
 			{ "a" : "20", "b" : "32", "guard" : 6000, "road" : "true" },
-			{ "a" : "24", "b" : "26", "guard" : 6000 },
-			{ "a" : "12", "b" : "24", "guard" : 6000, "road" : "true" },
-			{ "a" : "9", "b" : "21", "guard" : 6000, "road" : "true" },
 			{ "a" : "21", "b" : "22", "guard" : 3000, "road" : "true" },
-			{ "a" : "26", "b" : "28", "guard" : 3000 },
-			{ "a" : "16", "b" : "28", "guard" : 6000 },
-			{ "a" : "30", "b" : "31", "guard" : 3000 },
 			{ "a" : "22", "b" : "23", "guard" : 3000 },
+			{ "a" : "24", "b" : "26", "guard" : 6000 },
 			{ "a" : "25", "b" : "27", "guard" : 3000 },
-			{ "a" : "31", "b" : "32", "guard" : 3000, "road" : "true" },
-			{ "a" : "27", "b" : "29", "guard" : 3000 }
+			{ "a" : "26", "b" : "28", "guard" : 3000 },
+			{ "a" : "27", "b" : "29", "guard" : 3000 },
+			{ "a" : "30", "b" : "31", "guard" : 3000 },
+			{ "a" : "31", "b" : "32", "guard" : 3000, "road" : "true" }
 		]
 	}
 }

--- a/hota/Mods/templates/content/config/hotaDoubled8mm6.json
+++ b/hota/Mods/templates/content/config/hotaDoubled8mm6.json
@@ -1,0 +1,502 @@
+{
+	"[HotA] Doubled 8mm6" : {
+		"description" : "A variant of the standard 8mm6 template with more zones, intended to be played on XH+U to G+U.\nNo special rules on this template, so special weeks and Shrine of Magic Mystery are allowed.",
+		"maxSize" : "g+u",
+		"minSize" : "xh+u",
+		"name" : "[HotA] Doubled 8mm6",
+		"players" : "8",
+		"zones" : {
+			"1" : {
+				"type" : "playerStart",
+				"owner" : 1,
+				"size" : 20,
+				"monsters" : "normal",
+				"playerTowns" : {
+					"castles" : 1
+				},
+				"matchTerrainToTown" : true,
+				"mines" : {
+					"ore" : 1,
+					"wood" : 1
+				},
+				"treasure" : [
+					{ "min" : 10000, "max" : 15000, "density" : 1 },
+					{ "min" : 3000, "max" : 6000, "density" : 6 },
+					{ "min" : 500, "max" : 3000, "density" : 9 }
+				]
+			},
+			"2" : {
+				"type" : "playerStart",
+				"owner" : 3,
+				"size" : 20,
+				"monsters" : "normal",
+				"playerTowns" : {
+					"castles" : 1
+				},
+				"matchTerrainToTown" : true,
+				"minesLikeZone" : 1,
+				"treasureLikeZone" : 1
+			},
+			"3" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "strong",
+				"neutralTowns" : {
+					"castles" : 1
+				},
+				"matchTerrainToTown" : true,
+				"minesLikeZone" : 1,
+				"treasure" : [
+					{ "min" : 20000, "max" : 30000, "density" : 1 },
+					{ "min" : 15000, "max" : 20000, "density" : 6 },
+					{ "min" : 3000, "max" : 6000, "density" : 9 }
+				]
+			},
+			"4" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "strong",
+				"neutralTowns" : {
+					"castles" : 1
+				},
+				"matchTerrainToTown" : true,
+				"minesLikeZone" : 1,
+				"treasureLikeZone" : 3
+			},
+			"5" : {
+				"type" : "playerStart",
+				"owner" : 5,
+				"size" : 20,
+				"monsters" : "normal",
+				"playerTowns" : {
+					"castles" : 1
+				},
+				"matchTerrainToTown" : true,
+				"minesLikeZone" : 1,
+				"treasureLikeZone" : 1
+			},
+			"6" : {
+				"type" : "playerStart",
+				"owner" : 7,
+				"size" : 20,
+				"monsters" : "normal",
+				"playerTowns" : {
+					"castles" : 1
+				},
+				"matchTerrainToTown" : true,
+				"minesLikeZone" : 1,
+				"treasureLikeZone" : 1
+			},
+			"7" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "strong",
+				"neutralTowns" : {
+					"castles" : 1
+				},
+				"matchTerrainToTown" : true,
+				"minesLikeZone" : 1,
+				"treasureLikeZone" : 3
+			},
+			"8" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "strong",
+				"neutralTowns" : {
+					"castles" : 1
+				},
+				"matchTerrainToTown" : true,
+				"minesLikeZone" : 1,
+				"treasureLikeZone" : 3
+			},
+			"11" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "strong",
+				"neutralTowns" : {
+					"towns" : 1
+				},
+				"matchTerrainToTown" : false,
+				"mines" : {
+					"mercury" : 1,
+					"sulfur" : 1
+				},
+				"treasureLikeZone" : 3
+			},
+			"12" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "strong",
+				"neutralTowns" : {
+					"towns" : 1
+				},
+				"matchTerrainToTown" : false,
+				"mines" : {
+					"crystal" : 1,
+					"gems" : 1
+				},
+				"treasureLikeZone" : 3
+			},
+			"15" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "normal",
+				"matchTerrainToTown" : false,
+				"minesLikeZone" : 11,
+				"treasureLikeZone" : 1
+			},
+			"16" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "normal",
+				"matchTerrainToTown" : false,
+				"minesLikeZone" : 12,
+				"treasureLikeZone" : 1
+			},
+			"17" : {
+				"type" : "treasure",
+				"size" : 10,
+				"monsters" : "strong",
+				"matchTerrainToTown" : false,
+				"treasure" : [
+					{ "min" : 40000, "max" : 80000, "density" : 1 },
+					{ "min" : 20000, "max" : 30000, "density" : 8 },
+					{ "min" : 7500, "max" : 8000, "density" : 8 }
+				]
+			},
+			"18" : {
+				"type" : "treasure",
+				"size" : 10,
+				"monsters" : "strong",
+				"matchTerrainToTown" : false,
+				"treasureLikeZone" : 17
+			},
+			"19" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "normal",
+				"matchTerrainToTown" : false,
+				"minesLikeZone" : 11,
+				"treasureLikeZone" : 1
+			},
+			"20" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "normal",
+				"matchTerrainToTown" : false,
+				"minesLikeZone" : 12,
+				"treasureLikeZone" : 1
+			},
+			"21" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "normal",
+				"matchTerrainToTown" : false,
+				"minesLikeZone" : 11,
+				"treasureLikeZone" : 1
+			},
+			"22" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "normal",
+				"matchTerrainToTown" : false,
+				"minesLikeZone" : 12,
+				"treasureLikeZone" : 1
+			},
+			"23" : {
+				"type" : "treasure",
+				"size" : 10,
+				"monsters" : "strong",
+				"matchTerrainToTown" : false,
+				"treasureLikeZone" : 17
+			},
+			"24" : {
+				"type" : "treasure",
+				"size" : 10,
+				"monsters" : "strong",
+				"matchTerrainToTown" : false,
+				"treasureLikeZone" : 17
+			},
+			"25" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "normal",
+				"matchTerrainToTown" : false,
+				"minesLikeZone" : 11,
+				"treasureLikeZone" : 1
+			},
+			"26" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "normal",
+				"matchTerrainToTown" : false,
+				"minesLikeZone" : 12,
+				"treasureLikeZone" : 1
+			},
+			"27" : {
+				"type" : "playerStart",
+				"owner" : 8,
+				"size" : 20,
+				"monsters" : "normal",
+				"playerTowns" : {
+					"castles" : 1
+				},
+				"matchTerrainToTown" : true,
+				"minesLikeZone" : 1,
+				"treasureLikeZone" : 1
+			},
+			"28" : {
+				"type" : "playerStart",
+				"owner" : 6,
+				"size" : 20,
+				"monsters" : "normal",
+				"playerTowns" : {
+					"castles" : 1
+				},
+				"matchTerrainToTown" : true,
+				"minesLikeZone" : 1,
+				"treasureLikeZone" : 1
+			},
+			"29" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "strong",
+				"neutralTowns" : {
+					"castles" : 1
+				},
+				"matchTerrainToTown" : true,
+				"minesLikeZone" : 1,
+				"treasureLikeZone" : 3
+			},
+			"30" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "strong",
+				"neutralTowns" : {
+					"castles" : 1
+				},
+				"matchTerrainToTown" : true,
+				"minesLikeZone" : 1,
+				"treasureLikeZone" : 3
+			},
+			"31" : {
+				"type" : "playerStart",
+				"owner" : 4,
+				"size" : 20,
+				"monsters" : "normal",
+				"playerTowns" : {
+					"castles" : 1
+				},
+				"matchTerrainToTown" : true,
+				"minesLikeZone" : 1,
+				"treasureLikeZone" : 1
+			},
+			"32" : {
+				"type" : "playerStart",
+				"owner" : 2,
+				"size" : 20,
+				"monsters" : "normal",
+				"playerTowns" : {
+					"castles" : 1
+				},
+				"matchTerrainToTown" : true,
+				"minesLikeZone" : 1,
+				"treasureLikeZone" : 1
+			},
+			"33" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "strong",
+				"neutralTowns" : {
+					"castles" : 1
+				},
+				"matchTerrainToTown" : true,
+				"minesLikeZone" : 1,
+				"treasureLikeZone" : 3
+			},
+			"34" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "strong",
+				"neutralTowns" : {
+					"castles" : 1
+				},
+				"matchTerrainToTown" : true,
+				"minesLikeZone" : 1,
+				"treasureLikeZone" : 3
+			},
+			"37" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "strong",
+				"neutralTowns" : {
+					"towns" : 1
+				},
+				"matchTerrainToTown" : false,
+				"minesLikeZone" : 11,
+				"treasureLikeZone" : 3
+			},
+			"38" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "strong",
+				"neutralTowns" : {
+					"towns" : 1
+				},
+				"matchTerrainToTown" : false,
+				"minesLikeZone" : 12,
+				"treasureLikeZone" : 3
+			},
+			"41" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "normal",
+				"matchTerrainToTown" : false,
+				"minesLikeZone" : 11,
+				"treasureLikeZone" : 1
+			},
+			"42" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "normal",
+				"matchTerrainToTown" : false,
+				"minesLikeZone" : 12,
+				"treasureLikeZone" : 1
+			},
+			"43" : {
+				"type" : "treasure",
+				"size" : 10,
+				"monsters" : "strong",
+				"matchTerrainToTown" : false,
+				"treasureLikeZone" : 17
+			},
+			"44" : {
+				"type" : "treasure",
+				"size" : 10,
+				"monsters" : "strong",
+				"matchTerrainToTown" : false,
+				"treasureLikeZone" : 17
+			},
+			"45" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "normal",
+				"matchTerrainToTown" : false,
+				"minesLikeZone" : 11,
+				"treasureLikeZone" : 1
+			},
+			"46" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "normal",
+				"matchTerrainToTown" : false,
+				"minesLikeZone" : 12,
+				"treasureLikeZone" : 1
+			},
+			"47" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "normal",
+				"matchTerrainToTown" : false,
+				"minesLikeZone" : 11,
+				"treasureLikeZone" : 1
+			},
+			"48" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "normal",
+				"matchTerrainToTown" : false,
+				"minesLikeZone" : 12,
+				"treasureLikeZone" : 1
+			},
+			"49" : {
+				"type" : "treasure",
+				"size" : 10,
+				"monsters" : "strong",
+				"matchTerrainToTown" : false,
+				"treasureLikeZone" : 17
+			},
+			"50" : {
+				"type" : "treasure",
+				"size" : 10,
+				"monsters" : "strong",
+				"matchTerrainToTown" : false,
+				"treasureLikeZone" : 17
+			},
+			"51" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "normal",
+				"matchTerrainToTown" : false,
+				"minesLikeZone" : 11,
+				"treasureLikeZone" : 1
+			},
+			"52" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "normal",
+				"matchTerrainToTown" : false,
+				"minesLikeZone" : 12,
+				"treasureLikeZone" : 1
+			}
+		},
+		"connections" : [
+			{ "a" : "1", "b" : "15", "guard" : 6000, "road" : "random" },
+			{ "a" : "1", "b" : "19", "guard" : 6000, "road" : "random" },
+			{ "a" : "2", "b" : "16", "guard" : 6000, "road" : "random" },
+			{ "a" : "2", "b" : "20", "guard" : 6000, "road" : "random" },
+			{ "a" : "3", "b" : "15", "guard" : 6000, "road" : "random" },
+			{ "a" : "3", "b" : "19", "guard" : 6000, "road" : "random" },
+			{ "a" : "3", "b" : "29", "guard" : 12500, "road" : "random" },
+			{ "a" : "4", "b" : "16", "guard" : 6000, "road" : "random" },
+			{ "a" : "4", "b" : "20", "guard" : 6000, "road" : "random" },
+			{ "a" : "4", "b" : "30", "guard" : 12500, "road" : "random" },
+			{ "a" : "5", "b" : "21", "guard" : 6000, "road" : "random" },
+			{ "a" : "5", "b" : "25", "guard" : 6000, "road" : "random" },
+			{ "a" : "6", "b" : "22", "guard" : 6000, "road" : "random" },
+			{ "a" : "6", "b" : "26", "guard" : 6000, "road" : "random" },
+			{ "a" : "7", "b" : "21", "guard" : 6000, "road" : "random" },
+			{ "a" : "7", "b" : "25", "guard" : 6000, "road" : "random" },
+			{ "a" : "7", "b" : "33", "guard" : 12500, "road" : "random" },
+			{ "a" : "8", "b" : "22", "guard" : 6000, "road" : "random" },
+			{ "a" : "8", "b" : "26", "guard" : 6000, "road" : "random" },
+			{ "a" : "8", "b" : "34", "guard" : 12500, "road" : "random" },
+			{ "a" : "11", "b" : "19", "guard" : 9000, "road" : "random" },
+			{ "a" : "11", "b" : "20", "guard" : 9000, "road" : "random" },
+			{ "a" : "11", "b" : "22", "guard" : 9000, "road" : "random" },
+			{ "a" : "12", "b" : "19", "guard" : 9000, "road" : "random" },
+			{ "a" : "12", "b" : "21", "guard" : 9000, "road" : "random" },
+			{ "a" : "12", "b" : "22", "guard" : 9000, "road" : "random" },
+			{ "a" : "17", "b" : "19", "guard" : 12500, "road" : "random" },
+			{ "a" : "18", "b" : "20", "guard" : 12500, "road" : "random" },
+			{ "a" : "21", "b" : "23", "guard" : 12500, "road" : "random" },
+			{ "a" : "22", "b" : "24", "guard" : 12500, "road" : "random" },
+			{ "a" : "27", "b" : "41", "guard" : 6000, "road" : "random" },
+			{ "a" : "27", "b" : "45", "guard" : 6000, "road" : "random" },
+			{ "a" : "28", "b" : "42", "guard" : 6000, "road" : "random" },
+			{ "a" : "28", "b" : "46", "guard" : 6000, "road" : "random" },
+			{ "a" : "29", "b" : "41", "guard" : 6000, "road" : "random" },
+			{ "a" : "29", "b" : "45", "guard" : 6000, "road" : "random" },
+			{ "a" : "30", "b" : "42", "guard" : 6000, "road" : "random" },
+			{ "a" : "30", "b" : "46", "guard" : 6000, "road" : "random" },
+			{ "a" : "31", "b" : "47", "guard" : 6000, "road" : "random" },
+			{ "a" : "31", "b" : "51", "guard" : 6000, "road" : "random" },
+			{ "a" : "32", "b" : "48", "guard" : 6000, "road" : "random" },
+			{ "a" : "32", "b" : "52", "guard" : 6000, "road" : "random" },
+			{ "a" : "33", "b" : "47", "guard" : 6000, "road" : "random" },
+			{ "a" : "33", "b" : "51", "guard" : 6000, "road" : "random" },
+			{ "a" : "34", "b" : "48", "guard" : 6000, "road" : "random" },
+			{ "a" : "34", "b" : "52", "guard" : 6000, "road" : "random" },
+			{ "a" : "37", "b" : "45", "guard" : 9000, "road" : "random" },
+			{ "a" : "37", "b" : "46", "guard" : 9000, "road" : "random" },
+			{ "a" : "37", "b" : "48", "guard" : 9000, "road" : "random" },
+			{ "a" : "38", "b" : "45", "guard" : 9000, "road" : "random" },
+			{ "a" : "38", "b" : "47", "guard" : 9000, "road" : "random" },
+			{ "a" : "38", "b" : "48", "guard" : 9000, "road" : "random" },
+			{ "a" : "43", "b" : "45", "guard" : 12500, "road" : "random" },
+			{ "a" : "44", "b" : "46", "guard" : 12500, "road" : "random" },
+			{ "a" : "47", "b" : "49", "guard" : 12500, "road" : "random" },
+			{ "a" : "48", "b" : "50", "guard" : 12500, "road" : "random" }
+		]
+	}
+}

--- a/hota/Mods/templates/content/config/hotaKerberos.json
+++ b/hota/Mods/templates/content/config/hotaKerberos.json
@@ -179,6 +179,7 @@
 				"neutralTowns" : {
 					"towns" : 2
 				},
+				"townsAreSameType" : true,
 				"mines" : {
 					"gold" : 2
 				},
@@ -209,6 +210,7 @@
 				"neutralTowns" : {
 					"towns" : 2
 				},
+				"townsAreSameType" : true,
 				"matchTerrainToTown" : false,
 				"customObjectsLikeZone" : 1,
 				"minesLikeZone" : 10,
@@ -221,6 +223,7 @@
 				"neutralTowns" : {
 					"towns" : 2
 				},
+				"townsAreSameType" : true,
 				"matchTerrainToTown" : false,
 				"customObjectsLikeZone" : 1,
 				"minesLikeZone" : 10,
@@ -473,7 +476,6 @@
 			{ "a" : "19", "b" : "26", "guard" : 17500, "road" : "random" },
 			{ "a" : "19", "b" : "27", "guard" : 12000, "road" : "true" },
 			{ "a" : "19", "b" : "32", "guard" : 6000, "road" : "true" },
-			{ "a" : "20", "b" : "23", "guard" : 6000, "road" : "true" },
 			{ "a" : "20", "b" : "23", "guard" : 6000, "road" : "true" },
 			{ "a" : "20", "b" : "25", "guard" : 12000, "road" : "true" },
 			{ "a" : "20", "b" : "26", "guard" : 12000, "road" : "true" },

--- a/hota/Mods/templates/mod.json
+++ b/hota/Mods/templates/mod.json
@@ -40,6 +40,7 @@
 		"config/hotaBoomerang.json",
 	//	"config/hotaClashOfDragons.json",
 		"config/hotaDiamond.json",
+		"config/hotaDoubled8mm6.json",
 	//	"config/hotaFirewalk.json",
 		"config/hotaJebusCross.json",
 		"config/hotaKerberos.json",

--- a/hota/Mods/templates/mod.json
+++ b/hota/Mods/templates/mod.json
@@ -25,7 +25,8 @@
 			"Added HotA versions of 2sm4d(3), 6lm10a, 8xm12a, Diamond, Jebus Cross, Mini-Nostalgia and Spider.",
 			"Added Black'n'Blue, Boomerang, Apocalypse and Kerberos.",
 			"Added M200 templates 2sm2c(2), Nine-day Wonder and Skirmish(M).",
-			"Added HotA rules to Nostalgia - no special weeks, Shrine of Magic Mystery banned."
+			"Added HotA rules to Nostalgia - no special weeks, Shrine of Magic Mystery banned.",
+			"Added XH+U to G+U template: Doubled 8mm6."
 		]
 	},
 	"templates" : [


### PR DESCRIPTION
This template is part of the Original Template Pack in HotA. 
It's a version of regular 8mm6 with more zones for XH+U or G+U map sizes. It doesn't have any special rules or bans, but it's actually a cool template, so I ported it.

Fixes:
+ removed erroneous double connection in Kerberos and fixed the treasure zone towns (should be same type)
+ fixed formatting in 8mx12a and reordered connections (tripped me up when I double-checked them, but they were correct)