### PR TITLE
Object mask fixes and biome improvements

### DIFF
--- a/hota/Mods/mapDecorations/content/config/hotaMapDecorations/hotaStatic/barchanDunes.json
+++ b/hota/Mods/mapDecorations/content/config/hotaMapDecorations/hotaStatic/barchanDunes.json
@@ -8,8 +8,8 @@
 					"hotaAVLmtdn1" : {
 						"animation" : "hota/dunes/AVLmtdn1",
 						"mask" : [
-							"VVBBBV",
-							"VBBBBB",
+							"VVVVVV",
+							"VBBBBV",
 							"VBBBBB",
 							"VVVBBB"
 						],
@@ -20,8 +20,8 @@
 					"hotaAVLmtdn2" : {
 						"animation" : "hota/dunes/AVLmtdn2",
 						"mask" : [
-							"VVBBBV",
-							"VBBBBB",
+							"VVVVVV",
+							"VVBBBB",
 							"VBBBBB",
 							"VBBBVV"
 						],
@@ -32,7 +32,7 @@
 					"hotaAVLmtdn3" : {
 						"animation" : "hota/dunes/AVLmtdn3",
 						"mask" : [
-							"VBBV",
+							"VVVV",
 							"VBBB",
 							"VVBB"
 						],
@@ -43,7 +43,7 @@
 					"hotaAVLmtdn4" : {
 						"animation" : "hota/dunes/AVLmtdn4",
 						"mask" : [
-							"VVBB",
+							"VVVV",
 							"VBBB",
 							"VBBV"
 						],

--- a/hota/Mods/mapDecorations/content/config/hotaMapDecorations/hotaStatic/carnivorousPlant.json
+++ b/hota/Mods/mapDecorations/content/config/hotaMapDecorations/hotaStatic/carnivorousPlant.json
@@ -8,7 +8,7 @@
 					"avswplnt" : {
 						"animation" : "hota/carnivorousPlant/avswplnt",
 						"mask" : [
-							"VBB",
+							"VVV",
 							"VBB"
 						],
 						"allowedTerrains" : [

--- a/hota/Mods/mapDecorations/content/config/hotaMapDecorations/hotaStatic/hotaStaticBiomes.json
+++ b/hota/Mods/mapDecorations/content/config/hotaMapDecorations/hotaStatic/hotaStaticBiomes.json
@@ -49,7 +49,7 @@
 			"crates13"
 		]
 	},
-	"chickens" : {
+	"chickensAndPig" : {
 		"biome" : {
 			"terrain" : [
 				"grass",
@@ -64,7 +64,8 @@
 		},
 		"templates" : [
 			"rooster_01",
-			"rooster_02"
+			"rooster_02",
+			"pig"
 		]
 	},
 	"frogs" : {
@@ -188,6 +189,7 @@
 			"objectType" : "rock"
 		},
 		"templates" : [
+			"udrock01",
 			"udrock02",
 			"udrock03",
 			"udrock04",

--- a/hota/Mods/mapDecorations/content/config/hotaMapDecorations/hotaStatic/palms.json
+++ b/hota/Mods/mapDecorations/content/config/hotaMapDecorations/hotaStatic/palms.json
@@ -39,6 +39,7 @@
 							"swamp"
 						]
 					},
+					
 					"avlspl01" : {
 						"animation" : "hota/trees/avlspl01",
 						"mask" : [
@@ -49,7 +50,6 @@
 							"sand"
 						]
 					},
-
 					"avlspl02" : {
 						"animation" : "hota/trees/avlspl02",
 						"mask" : [
@@ -60,18 +60,16 @@
 							"sand"
 						]
 					},
-
 					"avlspl03" : {
 						"animation" : "hota/trees/avlspl03",
 						"mask" : [
-							"VB",
+							"VV",
 							"VB"
 						],
 						"allowedTerrains" : [
 							"sand"
 						]
 					},
-
 					"avlspl04" : {
 						"animation" : "hota/trees/avlspl04",
 						"mask" : [
@@ -82,7 +80,6 @@
 							"sand"
 						]
 					},
-
 					"avlspl05" : {
 						"animation" : "hota/trees/avlspl05",
 						"mask" : [
@@ -93,7 +90,6 @@
 							"sand"
 						]
 					},
-
 					"avlspl06" : {
 						"animation" : "hota/trees/avlspl06",
 						"mask" : [
@@ -104,7 +100,6 @@
 							"sand"
 						]
 					},
-
 					"avlspl07" : {
 						"animation" : "hota/trees/avlspl07",
 						"mask" : [
@@ -115,7 +110,6 @@
 							"sand"
 						]
 					},
-
 					"avlspl08" : {
 						"animation" : "hota/trees/avlspl08",
 						"mask" : [
@@ -126,19 +120,28 @@
 							"sand"
 						]
 					},
-
 					"avlspl09" : {
 						"animation" : "hota/trees/avlspl09",
 						"mask" : [
 							"VVVV",
-							"VBBB",
+							"VVBB",
 							"VBBV"
 						],
 						"allowedTerrains" : [
 							"sand"
 						]
 					},
-
+					"avlspl10" : {
+						"animation" : "hota/trees/avlspl10",
+						"mask" : [
+							"VVVV",
+							"VBBV",
+							"VVBB"
+						],
+						"allowedTerrains" : [
+							"sand"
+						]
+					},
 					"avlspl11" : {
 						"animation" : "hota/trees/avlspl11",
 						"mask" : [
@@ -150,19 +153,6 @@
 							"sand"
 						]
 					},
-
-					"avlspl10" : {
-						"animation" : "hota/trees/avlspl10",
-						"mask" : [
-							"VBBV",
-							"VBBV",
-							"VVBB"
-						],
-						"allowedTerrains" : [
-							"sand"
-						]
-					},
-
 					"avlspl12" : {
 						"animation" : "hota/trees/avlspl12",
 						"mask" : [
@@ -174,7 +164,6 @@
 							"sand"
 						]
 					},
-
 					"avlspl13" : {
 						"animation" : "hota/trees/avlspl13",
 						"mask" : [
@@ -187,7 +176,6 @@
 							"sand"
 						]
 					},
-
 					"avlspl14" : {
 						"animation" : "hota/trees/avlspl14",
 						"mask" : [

--- a/hota/Mods/mapDecorations/content/config/hotaMapDecorations/hotaStatic/predatoryPlant.json
+++ b/hota/Mods/mapDecorations/content/config/hotaMapDecorations/hotaStatic/predatoryPlant.json
@@ -9,7 +9,7 @@
 						"animation" : "hota/trees/TPMTREE1",
 						"mask" : [
 							"VV",
-							"BB",
+							"VV",
 							"VB"
 						],
 						"allowedTerrains" : [
@@ -20,7 +20,7 @@
 						"animation" : "hota/trees/TPMTREE2",
 						"mask" : [
 							"VV",
-							"VB",
+							"VV",
 							"VB"
 						],
 						"allowedTerrains" : [
@@ -31,7 +31,7 @@
 						"animation" : "hota/trees/TPMTREE3",
 						"mask" : [
 							"VV",
-							"VB",
+							"VV",
 							"VB"
 						],
 						"allowedTerrains" : [

--- a/hota/Mods/mapDecorations/content/config/hotaMapDecorations/hotaStatic/snowHills.json
+++ b/hota/Mods/mapDecorations/content/config/hotaMapDecorations/hotaStatic/snowHills.json
@@ -15,7 +15,6 @@
 							"snow"
 						]
 					},
-
 					"avlxsn02" : {
 						"animation" : "hota/trees/avlxsn02",
 						"mask" : [
@@ -26,7 +25,6 @@
 							"snow"
 						]
 					},
-
 					"avlxsn03" : {
 						"animation" : "hota/trees/avlxsn03",
 						"mask" : [

--- a/hota/Mods/mapDecorations/content/config/hotaMapDecorations/hotaStatic/stonySphere.json
+++ b/hota/Mods/mapDecorations/content/config/hotaMapDecorations/hotaStatic/stonySphere.json
@@ -1,6 +1,6 @@
 {
 	"stonySphere" : {
-		"handler" : "generic",
+		"handler" : "static",
 		"name" : "Stony Sphere",
 		"types" : {
 			"stonySphere" : {

--- a/hota/Mods/mapDecorations/content/config/hotaMapDecorations/hotaStatic/waterfalls.json
+++ b/hota/Mods/mapDecorations/content/config/hotaMapDecorations/hotaStatic/waterfalls.json
@@ -9,7 +9,7 @@
 						"animation" : "hota/waterfall/h4wt1f",
 						"mask" : [
 							"VV",
-							"VB"
+							"BB"
 						],
 						"allowedTerrains" : [
 							"water"
@@ -19,7 +19,7 @@
 						"animation" : "hota/waterfall/h4wt2f",
 						"mask" : [
 							"VVV",
-							"VBV",
+							"VVV",
 							"VBB"
 						],
 						"allowedTerrains" : [

--- a/hota/Mods/mapDecorations/content/config/hotaMapDecorations/vanillaStatic/bushes.json
+++ b/hota/Mods/mapDecorations/content/config/hotaMapDecorations/vanillaStatic/bushes.json
@@ -1,4 +1,5 @@
 {
+	// everything in here is already defined in core. intention??
 	"hotaBushes" : {
 		"name" : "Bush",
 		"handler" : "static",
@@ -14,6 +15,7 @@
 							"swamp"
 						]
 					},
+
 					"AVLsh2d0" : {
 						"animation" : "AVLsh2d0",
 						"mask" : [
@@ -50,6 +52,7 @@
 							"dirt"
 						]
 					},
+
 					"AVLsh3g0" : {
 						"animation" : "AVLsh3g0",
 						"mask" : [

--- a/hota/Mods/mapDecorations/content/config/hotaMapDecorations/vanillaStatic/mound.json
+++ b/hota/Mods/mapDecorations/content/config/hotaMapDecorations/vanillaStatic/mound.json
@@ -12,7 +12,6 @@
 							"snow"
 						]
 					},
-
 					"avlsnh02" : {
 						"animation" : "hota/mound/avlsnh02",
 						"mask" : [
@@ -22,7 +21,6 @@
 							"snow"
 						]
 					},
-
 					"avlsnh03" : {
 						"animation" : "hota/mound/avlsnh03",
 						"mask" : [
@@ -32,7 +30,6 @@
 							"snow"
 						]
 					},
-
 					"avlsnh04" : {
 						"animation" : "hota/mound/avlsnh04",
 						"mask" : [

--- a/hota/Mods/mapDecorations/content/config/hotaMapDecorations/vanillaStatic/mountain.json
+++ b/hota/Mods/mapDecorations/content/config/hotaMapDecorations/vanillaStatic/mountain.json
@@ -49,21 +49,21 @@
 							"grass"
 						]
 					},
-					"grsmnt05" : {
-						"animation" : "hota/mountains/grsmnt05",
-						"mask" : [
-							"VBBV",
-							"VVBB"
-						],
-						"allowedTerrains" : [
-							"grass"
-						]
-					},
 					"grsmnt04" : {
 						"animation" : "hota/mountains/grsmnt04",
 						"mask" : [
 							"VVBB",
 							"VBBV"
+						],
+						"allowedTerrains" : [
+							"grass"
+						]
+					},
+					"grsmnt05" : {
+						"animation" : "hota/mountains/grsmnt05",
+						"mask" : [
+							"VBBV",
+							"VVBB"
 						],
 						"allowedTerrains" : [
 							"grass"
@@ -138,6 +138,7 @@
 							"swamp"
 						]
 					},
+
 					"AvLMtFr1" : {
 						"animation" : "hota/mountains/AvLMtFr1",
 						"mask" : [

--- a/hota/Mods/mapDecorations/content/config/hotaMapDecorations/vanillaStatic/redTrees.json
+++ b/hota/Mods/mapDecorations/content/config/hotaMapDecorations/vanillaStatic/redTrees.json
@@ -14,7 +14,6 @@
 						"allowedTerrains" : [
 							"rough",
 							"grass",
-							"swamp",
 							"dirt"
 						]
 					},
@@ -27,7 +26,6 @@
 						"allowedTerrains" : [
 							"rough",
 							"grass",
-							"swamp",
 							"dirt"
 						]
 					},
@@ -40,7 +38,6 @@
 						"allowedTerrains" : [
 							"rough",
 							"grass",
-							"swamp",
 							"dirt"
 						]
 					},
@@ -53,7 +50,6 @@
 						"allowedTerrains" : [
 							"rough",
 							"grass",
-							"swamp",
 							"dirt"
 						]
 					},
@@ -66,7 +62,6 @@
 						"allowedTerrains" : [
 							"rough",
 							"grass",
-							"swamp",
 							"dirt"
 						]
 					},
@@ -79,7 +74,6 @@
 						"allowedTerrains" : [
 							"rough",
 							"grass",
-							"swamp",
 							"dirt"
 						]
 					},
@@ -92,7 +86,6 @@
 						"allowedTerrains" : [
 							"rough",
 							"grass",
-							"swamp",
 							"dirt"
 						]
 					},
@@ -105,7 +98,6 @@
 						"allowedTerrains" : [
 							"rough",
 							"grass",
-							"swamp",
 							"dirt"
 						]
 					},
@@ -120,7 +112,6 @@
 						"allowedTerrains" : [
 							"rough",
 							"grass",
-							"swamp",
 							"dirt"
 						]
 					},
@@ -135,7 +126,6 @@
 						"allowedTerrains" : [
 							"rough",
 							"grass",
-							"swamp",
 							"dirt"
 						]
 					},
@@ -143,13 +133,12 @@
 						"animation" : "hota/trees/Avrdtr03",
 						"mask" : [
 							"VVVV",
-							"VBBB",
+							"VVBB",
 							"VBBV"
 						],
 						"allowedTerrains" : [
 							"rough",
 							"grass",
-							"swamp",
 							"dirt"
 						]
 					},
@@ -157,13 +146,12 @@
 						"animation" : "hota/trees/Avrdtr04",
 						"mask" : [
 							"VVVV",
-							"VBBB",
+							"VVBB",
 							"VBBV"
 						],
 						"allowedTerrains" : [
 							"rough",
 							"grass",
-							"swamp",
 							"dirt"
 						]
 					},
@@ -177,7 +165,6 @@
 						"allowedTerrains" : [
 							"rough",
 							"grass",
-							"swamp",
 							"dirt"
 						]
 					},
@@ -191,7 +178,6 @@
 						"allowedTerrains" : [
 							"rough",
 							"grass",
-							"swamp",
 							"dirt"
 						]
 					}

--- a/hota/Mods/mapDecorations/content/config/hotaMapDecorations/vanillaStatic/reef.json
+++ b/hota/Mods/mapDecorations/content/config/hotaMapDecorations/vanillaStatic/reef.json
@@ -26,7 +26,7 @@
 					"ZREEF3" : {
 						"animation" : "hota/reef/ZREEF3",
 						"mask" : [
-							"BV",
+							"VV",
 							"BB"
 						],
 						"allowedTerrains" : [
@@ -37,7 +37,7 @@
 					"ZREEF4" : {
 						"animation" : "hota/reef/ZREEF4",
 						"mask" : [
-							"VB",
+							"VV",
 							"BB"
 						],
 						"allowedTerrains" : [
@@ -49,7 +49,7 @@
 						"animation" : "hota/reef/ZREEF5",
 						"mask" : [
 							"VVV",
-							"VBB",
+							"VBV",
 							"BBB"
 						],
 						"allowedTerrains" : [

--- a/hota/Mods/mapDecorations/content/config/hotaMapDecorations/vanillaStatic/rock.json
+++ b/hota/Mods/mapDecorations/content/config/hotaMapDecorations/vanillaStatic/rock.json
@@ -48,7 +48,7 @@
 					"avlrfx05" : {
 						"animation" : "hota/rock/avlrfx05",
 						"mask" : [
-							"VBV",
+							"VVV",
 							"BBB"
 						],
 						"allowedTerrains" : [
@@ -58,7 +58,7 @@
 					"avlrfx06" : {
 						"animation" : "hota/rock/avlrfx06",
 						"mask" : [
-							"VB",
+							"VV",
 							"VB"
 						],
 						"allowedTerrains" : [
@@ -68,10 +68,10 @@
 					"avlrfx07" : {
 						"animation" : "hota/rock/avlrfx07",
 						"mask" : [
-							"VVVVV",
-							"VBBVV",
-							"VBBBV",
-							"VVBBV"
+							"VVVV",
+							"VVVV",
+							"VBBV",
+							"VVBB"
 						],
 						"allowedTerrains" : [
 							"water"
@@ -80,10 +80,10 @@
 					"avlrfx08" : {
 						"animation" : "hota/rock/avlrfx08",
 						"mask" : [
-							"VVVVV",
-							"VVBBV",
-							"VBBBV",
-							"VBBVV"
+							"VVVV",
+							"VVVV",
+							"VVBB",
+							"VBBV"
 						],
 						"allowedTerrains" : [
 							"water"

--- a/hota/Mods/mapDecorations/content/config/hotaMapDecorations/vanillaStatic/vanillaStaticBiomes.json
+++ b/hota/Mods/mapDecorations/content/config/hotaMapDecorations/vanillaStatic/vanillaStaticBiomes.json
@@ -239,7 +239,8 @@
 			"avlrfx05",
 			"avlrfx06",
 			"avlrfx07",
-			"avlrfx08"
+			"avlrfx08",
+			"WATERBALL"
 		]
 	},
 	"core:templateSet109" : {
@@ -252,7 +253,7 @@
 			"append" : "avlsh9x0"
 		}
 	},
-	"yellowSwampPlant" : {
+	"predatoryPlants" : {
 		"biome" : {
 			"terrain" : "swamp",
 			"objectType" : "plant"
@@ -284,9 +285,37 @@
 			"avltro13"
 		]
 	},
+	"core:templateSet100" : {
+		"templates" : {
+			"append" : "swddtree"
+		}
+	},
 	"core:volcanos" : {
 		"templates" : {
 			"append" : "AVLvol60"
+		}
+	},
+	"core:templateSet108" : {
+		"templates" : {
+			"appendItems" : [
+				"AVLrk5s0",
+				"AVLrk6s0"
+			]
+		}
+	},
+	"core:templateSet54" : {
+		"templates" : {
+			"append" : "AVLlogdrt1"
+		}
+	},
+	"core:dirtStumps" : {
+		"templates" : {
+			"append" : "AVLlogdrt1"
+		}
+	},
+	"core:roughStumps" : {
+		"templates" : {
+			"append" : "AVLlogdrt1"
 		}
 	}
 }


### PR DESCRIPTION
object mask fixes:
+ several Barchan Dunes
+ Carnivorous Plant
+ several sand palms
+ several predatory plants
+ some Waterfall (not the highland version, some other generic thing)
+ some red trees (also removed swamp from their templates because they shouldn't be on swamp)
+ several water reefs, rocks and mountains

biome improvements:
+ added the unused pig to the chickens biome and renamed it to chickensAndPig
+ added an unused rock to the underground rock biome and one to the water rock biome
+ added an unused dead tree to the core swamp set for dead vegetation
+ added a log that was defined but unused to the respective core biomes
+ added 2 unused swamp rocks to the core swamp rock biome

other:
+ cleaned up some files and swapped definitions around where it made sense
    + grsmnt05 was defined before grsmnt04 which is just confusing