### PR TITLE
Added Runes and Interference to Hermit's Shack

### DIFF
--- a/hota/Mods/bulwark/content/config/hota/bulwark/mapObjects/interactive/hermitsShack.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/mapObjects/interactive/hermitsShack.json
@@ -1,0 +1,29 @@
+{
+	"hota.highlandsterrain:hermitsShack" : {
+		"types" : {
+			"hermitsShack" : {
+				"rewards" : {
+					"append" : 	{
+						"limiter" : {
+							"noneOf" : [
+								{
+									"secondary" :
+										{
+											"runes" : 3
+										}
+								}
+							],
+							"secondary" : {
+								"runes" : 1
+							}
+						},
+						"secondary" : {
+							"runes" : 1
+						},
+						"message" : "{Hermit's Shack}\n\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
+					}
+				}
+			}
+		}
+	}
+}

--- a/hota/Mods/bulwark/mod.json
+++ b/hota/Mods/bulwark/mod.json
@@ -72,8 +72,9 @@
 		"config/hota/bulwark/dwellings.json",
 		"config/hota/bulwark/mapObjects/static/glaciers.json",
 		"config/hota/bulwark/mapObjects/mine/mines.json",
-		"config/hota/bulwark/mapObjects/interactive/trapperLodge.json",
+		"config/hota/bulwark/mapObjects/interactive/hermitsShack.json",
 		"config/hota/bulwark/mapObjects/interactive/seersHut.json",
+		"config/hota/bulwark/mapObjects/interactive/trapperLodge.json",
 		"config/hota/bulwark/mapObjects/interactive/witchHut.json",
 		"config/hota/bulwark/mapObjects/garrisons/garrisonsVertical.json",
 		"config/hota/bulwark/mapObjects/garrisons/garrisonsHorizontal.json"
@@ -81,7 +82,7 @@
 	"biomes" : [
 		"config/hota/bulwark/mapObjects/static/staticBiomes.json"
 	],
-    
+
     "chinese" : {
         "name" : "坚垒",
         "description" : "深渊号角1.8.0的新城镇坚垒"

--- a/hota/Mods/interference/content/config/hotaInterference/hermitsShack.json
+++ b/hota/Mods/interference/content/config/hotaInterference/hermitsShack.json
@@ -1,0 +1,29 @@
+{
+	"hota.highlandsterrain:hermitsShack" : {
+		"types" : {
+			"hermitsShack" : {
+				"rewards" : {
+					"append" : 	{
+						"limiter" : {
+							"noneOf" : [
+								{
+									"secondary" :
+										{
+											"interference" : 3
+										}
+								}
+							],
+							"secondary" : {
+								"interference" : 1
+							}
+						},
+						"secondary" : {
+							"interference" : 1
+						},
+						"message" : "{Hermit's Shack}\n\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
+					}
+				}
+			}
+		}
+	}
+}

--- a/hota/Mods/interference/mod.json
+++ b/hota/Mods/interference/mod.json
@@ -34,6 +34,9 @@
 	"skills" : [
 		"config/hotaInterference/interference"
 	],
+	"objects" : [
+		"config/hotaInterference/hermitsShack"
+	],
 	"polish" : {
 		"name" : "Umiejętność Interferencja",
 		"description" : "Mod dodaje nową umiejętność – Interferencję, nową bohaterkę Giselle ze specjalizacją w tej umiejętności oraz zmienia bohaterów z odpornością na czary, by korzystali z Interferencji"


### PR DESCRIPTION
Hermit's Shack couldn't upgrade Runes or Interference since they were missing from its reward list. This PR fixes that.