### PR TITLE
Submod to ban map-editor-only alternative sprites

### DIFF
--- a/hota/Mods/gameBalance/mods/objects/mods/disabledDecorations/content/config/hotaGameBalance/disabledDecorations.json
+++ b/hota/Mods/gameBalance/mods/objects/mods/disabledDecorations/content/config/hotaGameBalance/disabledDecorations.json
@@ -1,0 +1,42 @@
+{
+	"core:prison" : {
+		"types" : {
+			"prison" : {
+				"templates" : {
+					"AVXprsn1" : {
+						"allowedTerrains" : []
+					}
+				}
+			},
+			"heroCamp" : {
+				"templates" : {
+					"AVXhcamp" : {
+						"allowedTerrains" : []
+					}
+				}
+			}
+		}
+	},
+	"core:wagon" : {
+		"types" : {
+			"wagon" : {
+				"templates" : {
+					"HATel" : {
+						"allowedTerrains" : []
+					}
+				}
+			}
+		}
+	},
+	"core:subterraneanGate" : {
+		"types" : {
+			"object" : {
+				"templates" : {
+					"HAExit01" : {
+						"allowedTerrains" : []
+					}
+				}
+			}
+		}
+	}
+}

--- a/hota/Mods/gameBalance/mods/objects/mods/disabledDecorations/mod.json
+++ b/hota/Mods/gameBalance/mods/objects/mods/disabledDecorations/mod.json
@@ -1,0 +1,14 @@
+{
+	"name" : "Disabled Decorations",
+	"description" : "Prevents some decorations meant for map editor exclusive use from spawning.",
+	"modType" : "Objects",
+	"author" : "Karyoplasma",
+	"contact" : "http://forum.df2.ru/index.php?showtopic=32286",
+	"version" : "1.0",
+	"depends" : [
+		"hota.mapdecorations"
+	],
+	"objects" : [
+		"config/hotaGameBalance/disabledDecorations.json"
+	]
+}

--- a/hota/Mods/mapDecorations/content/config/hotaMapDecorations/hotaStatic/hotaStaticBiomes.json
+++ b/hota/Mods/mapDecorations/content/config/hotaMapDecorations/hotaStatic/hotaStaticBiomes.json
@@ -152,17 +152,17 @@
 			"AVLpilr7"
 		]
 	},
-	"ruinedObjects" : {
-		"biome" : {
-			"terrain" : "dirt",
-			"objectType" : "structure"
-		},
-		"templates" : [
-			"TPDESTR2",
-			"TPDESTR3",
-			"TPDESTR4"
-		]
-	},
+//	"ruinedObjects" : {
+//		"biome" : {
+//			"terrain" : "dirt",
+//			"objectType" : "structure"
+//		},
+//		"templates" : [
+//			"TPDESTR2",
+//			"TPDESTR3",
+//			"TPDESTR4"
+//		]
+//	},
 	"core:sandYucca" : {
 		"templates" : {
 			"appendItems" : [
@@ -199,34 +199,34 @@
 			"udrock08"
 		]
 	},
-	"abandonedHouse" : {
-		"biome" : {
-			"terrain" : "lava",
-			"level" : "surface",
-			"objectType" : "structure"
-		},
-		"templates" : [
-			"AVbhou01",
-			"AVbhou02",
-			"AVbhou03"
-		]
-	},
-	"abandonedWells" : {
-		"biome" : {
-			"terrain" : [
-				"dirt",
-				"rough"
-			],
-			"level" : "surface",
-			"objectType" : "structure"
-		},
-		"templates" : [
-			"avtcvrui",
-			"TPDESTR2",
-			"TPDESTR3",
-			"TPDESTR4"
-		]
-	},
+//	"abandonedHouse" : {
+//		"biome" : {
+//			"terrain" : "lava",
+//			"level" : "surface",
+//			"objectType" : "structure"
+//		},
+//		"templates" : [
+//			"AVbhou01",
+//			"AVbhou02",
+//			"AVbhou03"
+//		]
+//	},
+//	"abandonedWells" : {
+//		"biome" : {
+//			"terrain" : [
+//				"dirt",
+//				"rough"
+//			],
+//			"level" : "surface",
+//			"objectType" : "structure"
+//		},
+//		"templates" : [
+//			"avtcvrui",
+//			"TPDESTR2",
+//			"TPDESTR3",
+//			"TPDESTR4"
+//		]
+//	},
 	"hotaSandColumns" : {
 		"biome" : {
 			"terrain" : "sand",


### PR DESCRIPTION
This PR introduces a new submod gameBalance.objects.disabledDecorations that disables some objects from mapdecorations from spawning:
+ double-sized wagon
+ mini-prison and hero camp
+ subterranean gate alternative

Others can just be added here and the user can choose whether they want the additional decorations or not.

Optimally, this would also disable biomes, but any attempt to do so was just crashing VCMI, so instead I disabled the most offensive biomes in mapdecorations (destroyed camps/houses/fountains).