### PR TITLE
Bulwark vanilla scaling, update gameBalance submod

### DIFF
--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroes/akka.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroes/akka.json
@@ -39,57 +39,11 @@
 			"bloodlust"
 		],
 		"specialty" : {
-			"base" : {
-				"type" : "PRIMARY_SKILL",
-				"subtype" : "primarySkill.attack",
-				"valueType" : "ADDITIVE_VALUE",
-				"effectRange" : "ONLY_MELEE_FIGHT",
-				"limiters" : [
-					{
-						"type" : "HAS_ANOTHER_BONUS_LIMITER",
-						"bonusSourceType" : "SPELL_EFFECT",
-						"bonusSourceID" : "spell.bloodlust"
-					}
-				]
-			},
 			"bonuses" : {
-				"bonusDefense12" : {
-					"limiters" : {
-						"append" : {
-							"type" : "CREATURE_LEVEL_LIMITER",
-							"maxlevel" : 3
-						}
-					},
-					"val" : 10
-				},
-				"bonusDefense34" : {
-					"limiters" : {
-						"append" : {
-							"type" : "CREATURE_LEVEL_LIMITER",
-							"minLevel" : 3,
-							"maxlevel" : 5
-						}
-					},
-					"val" : 8
-				},
-				"bonusDefense56" : {
-					"limiters" : {
-						"append" : {
-							"type" : "CREATURE_LEVEL_LIMITER",
-							"minLevel" : 5,
-							"maxlevel" : 7
-						}
-					},
-					"val" : 6
-				},
-				"bonusDefense7" : {
-					"limiters" : {
-						"append" : {
-							"type" : "CREATURE_LEVEL_LIMITER",
-							"minLevel" : 7
-						}
-					},
-					"val" : 4
+				"bloodlust" : {
+					"addInfo" : 0,
+					"subtype" : "spell.bloodlust",
+					"type" : "SPECIAL_PECULIAR_ENCHANT"
 				}
 			}
 		},
@@ -98,7 +52,7 @@
 			"biography" : "The yeti's knack for survival in the frost is often attributed to their thick hides and dense fur. However, their resilience stems from an innate magical power that radiates warmth throughout their bodies. Only a select few can consciously harness it, and Akka is among the most adept. Her expertise stems from her deep understanding of the warlike furor her clansmen tend to give in to.",
 			"specialty" : {
 				"name" : "Bloodlust",
-				"description" : "Casts Bloodlust with effect increased by 10 for level 1–2 creatures, by 8 for level 3–4 creatures, by 6 for level 5–6 creatures, and by 4 for level 7 creatures.",
+				"description" : "Casts Bloodlust with effect increased by 3 for level 1–2 creatures, by 2 for level 3–4 creatures, and by 1 for level 5–6 creatures.",
 				"tooltip" : "Spell Bonus: Bloodlust"
 			}
 		}

--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroes/biarma.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroes/biarma.json
@@ -47,7 +47,7 @@
 			"biography" : "Everyone in Vori knows: when all remedies fail, the last and only resort for the ailing is to seek out old Biarma. Those who dare to face her no longer care for Biarma's motives as to who will be granted a new lease on life, and who will instead donate their skull to the eerie adornment of her remote abode's palisade.",
 			"specialty" : {
 				"name" : "First Aid",
-				"description" : "Receives a 5% per level bonus to bonus Health provided by the First Aid Tent.",
+				"description" : "Receives a 5% per level bonus to First Aid skill.",
 				"tooltip" : "Skill Bonus: First Aid"
 			}
 		}

--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroes/creyle.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroes/creyle.json
@@ -39,7 +39,7 @@
 			"biography" : "Creyle's father, the konung, refused to let her succeed him. Knowing better than to try and reason with the old grouch, she decided to find others who would accept her leadership. Creyle then went and challenged the alpha of Vori's largest mammoth herd: she wrestled him down bare-handed, snapped off his tusk and made it into a war horn. She blasts it as she leads what is now her own herd into battle.",
 			"specialty" : {
 				"name" : "Mammoths",
-				"description" : "Increases the Speed of allied Mammoths and War Mammoths by 1 and their Attack and Defense skills by 20% for every 6 levels (rounded up).",
+				"description" : "Increases the Speed of allied Mammoths and War Mammoths by 1 and their Attack and Defense skills by 5% for every 6 levels (rounded up).",
 				"tooltip" : "Creature Bonus: Mammoths"
 			}
 		}

--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroes/dalton.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroes/dalton.json
@@ -43,7 +43,7 @@
 				"valueType" : "PERCENT_TO_TARGET_TYPE",
 				"updater" : {
 					"type" : "GROWS_WITH_LEVEL",
-					"valPer20" : 200
+					"valPer20" : 60
 				}
 			},
 			"bonuses" : {
@@ -139,7 +139,7 @@
 			"biography" : "Plain weapons can barely scratch a Jotunn, but believing these hulks neglect protection exposes a fool. Dalton is the most adept armorer capable of forging equipment of such immense size. Lean as Vori's ores are, Dalton has penetrated the secrets of magic to ensure his creations can withstand anything, an ice demon's fury included.",
 			"specialty" : {
 				"name" : "Shield",
-				"description" : "Casts Shield with effect increased by 10% for every N hero levels, where N is the level of the target creature.",
+				"description" : "Casts Shield with effect increased by 3% for every N hero levels, where N is the level of the target creature.",
 				"tooltip" : "Spell Bonus: Shield"
 			}
 		}

--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroes/dhuin.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroes/dhuin.json
@@ -43,7 +43,7 @@
 			"biography" : "On the field where elves from all over Vori converge at springtime to compete in military prowess, a memorial stone with the name Dhuin Ironhand has been standing for years: no one has yet been able to hurl a dart any farther. Dhuin is as straight and firm as his famed spear, and many fathers show him the highest degree of reverence, entrusting their eldest sons to him for training.",
 			"specialty" : {
 				"name" : "Snow Elves",
-				"description" : "Increases the Speed of allied Snow Elves and Steel Elves by 1 and their Attack and Defense skills by 20% for every 3 levels (rounded up).",
+				"description" : "Increases the Speed of allied Snow Elves and Steel Elves by 1 and their Attack and Defense skills by 5% for every 3 levels (rounded up).",
 				"tooltip" : "Creature Bonus: Snow Elves"
 			}
 		}

--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroes/eikthurn.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroes/eikthurn.json
@@ -43,7 +43,7 @@
 			"biography" : "The Jotunns are serious about celestial omens. Those born in the days when the Great Aries dominates the starry expanse know that their fates are forever intertwined with mountain rams, willful and awesomely brave. Ever since he learned to walk, Eikthurn has been fearlessly scaling mountain peaks in the company of his tough-horned friends, adamant in that they are the only ones incapable of betrayal.",
 			"specialty" : {
 				"name" : "Mountain Rams",
-				"description" : "Increases the Speed of allied Mountain Rams and Argali by 1 and their Attack and Defense skills by 20% for every 2 levels (rounded up).",
+				"description" : "Increases the Speed of allied Mountain Rams and Argali by 1 and their Attack and Defense skills by 5% for every 2 levels (rounded up).",
 				"tooltip" : "Creature Bonus: Mountain Rams"
 			}
 		}

--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroes/glacius.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroes/glacius.json
@@ -41,7 +41,7 @@
 					"subtype" : "spell.frostRing",
 					"type" : "SPECIAL_SPELL_LEV",
 					"updater" : "TIMES_HERO_LEVEL",
-					"val" : 10
+					"val" : 3
 				}
 			}
 		},
@@ -53,7 +53,7 @@
 			"biography" : "The expanses of Vori, covered with years of snow, only seem lifeless; those who know what to look for will find out that the disembodied inhabitants of these lands make fine interlocutors, or maybe even sources of power. Glacius has a reputation for being the Bane of Spirits: their empty shells crumble into bursts of magical light, as he greedily devours their energy and unleashes it upon his enemies.",
 			"specialty" : {
 				"name" : "Frost Ring",
-				"description" : "Casts Frost Ring with Damage increased by 10% for every N hero levels, where N is the level of the target creature.",
+				"description" : "Casts Frost Ring with Damage increased by 3% for every N hero levels, where N is the level of the target creature.",
 				"tooltip" : "Spell Bonus: Frost Ring"
 			}
 		}

--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroes/kriv.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroes/kriv.json
@@ -42,7 +42,7 @@
 			"biography" : "When the shamans surmised that the gods would never grant their tribe another spring without a great sacrifice, the lot fell on Kriv. Chained to a runestone, he waited for death; indeed, she appeared to him as a white owl, yet only took his eyes, repaying him with the gift of seeing through time. Kriv returned to accurately predict the warm season's arrival, establishing himself as a peerless shaman.",
 			"specialty" : {
 				"name" : "Shamans",
-				"description" : "Increases the Speed of allied Shamans and Great Shamans by 1 and their Attack and Defense skills by 20% for every 5 levels (rounded up).",
+				"description" : "Increases the Speed of allied Shamans and Great Shamans by 1 and their Attack and Defense skills by 5% for every 5 levels (rounded up).",
 				"tooltip" : "Creature Bonus: Shamans"
 			}
 		}

--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroes/kynr.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroes/kynr.json
@@ -36,15 +36,14 @@
 			}
 		],
 		"specialty" : {
-			"creature" : "kobold",
-			"stepSize" : 10
+			"creature" : "kobold"
 		},
 		"texts" : {
 			"name" : "Kynr",
 			"biography" : "Many believe that Kynr is not a name, but rather a rank or title, because Kynr has always been among kobolds. Whenever disaster strikes the mines, and tunnels collapse, it is Kynr who leads the rescue parties. At his call, every kobold immediately suspends their dealings and obeys without question, knowing full well that lives are at stake.",
 			"specialty" : {
 				"name" : "Kobolds",
-				"description" : "Increases the Speed of allied Kobolds and Kobold Foremen by 1 and their Attack and Defense skills by 10% for every level (rounded up).",
+				"description" : "Increases the Speed of allied Kobolds and Kobold Foremen by 1 and their Attack and Defense skills by 5% for every level (rounded up).",
 				"tooltip" : "Creature Bonus: Kobolds"
 			}
 		}

--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroes/sial.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroes/sial.json
@@ -41,7 +41,7 @@
 					"subtype" : "spell.iceBolt",
 					"type" : "SPECIAL_SPELL_LEV",
 					"updater" : "TIMES_HERO_LEVEL",
-					"val" : 10
+					"val" : 3
 				}
 			}
 		},
@@ -53,7 +53,7 @@
 			"biography" : "Sial can always be traced on the battlefield by shards of ice statues that once were her enemies. Legend says another doing of hers is the infamous Crystal Lake, which stays frozen even through the brief summers. Once, its waters swallowed an entire tribe whose chieftain had angered her; they remain eternally still since.",
 			"specialty" : {
 				"name" : "Ice Bolt",
-				"description" : "Casts Ice Bolt with Damage increased by 10% for every N hero levels, where N is the level of the target creature.",
+				"description" : "Casts Ice Bolt with Damage increased by 3% for every N hero levels, where N is the level of the target creature.",
 				"tooltip" : "Spell Bonus: Ice Bolt"
 			}
 		}

--- a/hota/Mods/bulwark/content/config/hota/bulwark/heroes/spadum.json
+++ b/hota/Mods/bulwark/content/config/hota/bulwark/heroes/spadum.json
@@ -43,7 +43,7 @@
 			"biography" : "Spadum is not the strongest warrior or the most skilled hunter among the Yeti; still, his kin hold him in the highest regard. The answer as to why is simple: he is fluent in the languages of all races in Vori. This often helps him settle disputes over valuable land in favor of his people without the parties resorting to needless violence.",
 			"specialty" : {
 				"name" : "Yeti",
-				"description" : "Increases the Speed of allied Yeti and Yeti Runemasters by 1 and their Attack and Defense skills by 20% for every 4 levels (rounded up).",
+				"description" : "Increases the Speed of allied Yeti and Yeti Runemasters by 1 and their Attack and Defense skills by 5% for every 4 levels (rounded up).",
 				"tooltip" : "Creature Bonus: Yeti"
 			}
 		}

--- a/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/bulwark/akka.json
+++ b/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/bulwark/akka.json
@@ -1,0 +1,64 @@
+{
+	"hota.bulwark:15akka" : {
+		"specialty#override" : {
+			"base" : {
+				"type" : "PRIMARY_SKILL",
+				"subtype" : "primarySkill.attack",
+				"valueType" : "ADDITIVE_VALUE",
+				"effectRange" : "ONLY_MELEE_FIGHT",
+				"limiters" : [
+					{
+						"type" : "HAS_ANOTHER_BONUS_LIMITER",
+						"bonusSourceType" : "SPELL_EFFECT",
+						"bonusSourceID" : "spell.bloodlust"
+					}
+				]
+			},
+			"bonuses" : {
+				"bonusDefense12" : {
+					"limiters" : {
+						"append" : {
+							"type" : "CREATURE_LEVEL_LIMITER",
+							"maxlevel" : 3
+						}
+					},
+					"val" : 10
+				},
+				"bonusDefense34" : {
+					"limiters" : {
+						"append" : {
+							"type" : "CREATURE_LEVEL_LIMITER",
+							"minLevel" : 3,
+							"maxlevel" : 5
+						}
+					},
+					"val" : 8
+				},
+				"bonusDefense56" : {
+					"limiters" : {
+						"append" : {
+							"type" : "CREATURE_LEVEL_LIMITER",
+							"minLevel" : 5,
+							"maxlevel" : 7
+						}
+					},
+					"val" : 6
+				},
+				"bonusDefense7" : {
+					"limiters" : {
+						"append" : {
+							"type" : "CREATURE_LEVEL_LIMITER",
+							"minLevel" : 7
+						}
+					},
+					"val" : 4
+				}
+			}
+		},
+		"texts" : {
+			"specialty" : {
+				"description" : "Casts Bloodlust with effect increased by 10 for level 1–2 creatures, by 8 for level 3–4 creatures, by 6 for level 5–6 creatures, and by 4 for level 7 creatures."
+			}
+		}
+	}
+}

--- a/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/bulwark/biarma.json
+++ b/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/bulwark/biarma.json
@@ -1,0 +1,9 @@
+{
+	"hota.bulwark:13biarma" : {
+		"texts" : {
+			"specialty" : {
+				"description" : "Receives a 5% per level bonus to bonus Health provided by the First Aid Tent."
+			}
+		}
+	}
+}

--- a/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/bulwark/creyle.json
+++ b/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/bulwark/creyle.json
@@ -1,0 +1,9 @@
+{
+	"hota.bulwark:05creyle" : {
+		"texts" : {
+			"specialty" : {
+				"description" : "Increases the Speed of allied Mammoths and War Mammoths by 1 and their Attack and Defense skills by 20% for every 6 levels (rounded up)."
+			}
+		}
+	}
+}

--- a/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/bulwark/dalton.json
+++ b/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/bulwark/dalton.json
@@ -1,0 +1,16 @@
+{
+	"hota.bulwark:12dalton" : {
+		"specialty" : {
+			"base" : {
+				"updater" : {
+					"valPer20" : 200
+				}
+			}
+		},
+		"texts" : {
+			"specialty" : {
+				"description" : "Casts Shield with effect increased by 10% for every N hero levels, where N is the level of the target creature."
+			}
+		}
+	}
+}

--- a/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/bulwark/dhuin.json
+++ b/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/bulwark/dhuin.json
@@ -1,0 +1,9 @@
+{
+	"hota.bulwark:01dhuin" : {
+		"texts" : {
+			"specialty" : {
+				"description" : "Increases the Speed of allied Snow Elves and Steel Elves by 1 and their Attack and Defense skills by 20% for every 3 levels (rounded up)."
+			}
+		}
+	}
+}

--- a/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/bulwark/eikthurn.json
+++ b/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/bulwark/eikthurn.json
@@ -1,0 +1,9 @@
+{
+	"hota.bulwark:04eikthurn" : {
+		"texts" : {
+			"specialty" : {
+				"description" : "Increases the Speed of allied Mountain Rams and Argali by 1 and their Attack and Defense skills by 20% for every 2 levels (rounded up)."
+			}
+		}
+	}
+}

--- a/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/bulwark/glacius.json
+++ b/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/bulwark/glacius.json
@@ -1,0 +1,16 @@
+{
+	"hota.bulwark:10glacius" : {
+		"specialty" : {
+			"bonuses" : {
+				"frostRing" : {
+					"val" : 10
+				}
+			}
+		},
+		"texts" : {
+			"specialty" : {
+				"description" : "Casts Frost Ring with Damage increased by 10% for every N hero levels, where N is the level of the target creature."
+			}
+		}
+	}
+}

--- a/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/bulwark/kriv.json
+++ b/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/bulwark/kriv.json
@@ -1,0 +1,9 @@
+{
+	"hota.bulwark:09kriv" : {
+		"texts" : {
+			"specialty" : {
+				"description" : "Increases the Speed of allied Shamans and Great Shamans by 1 and their Attack and Defense skills by 20% for every 5 levels (rounded up)."
+			}
+		}
+	}
+}

--- a/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/bulwark/kynr.json
+++ b/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/bulwark/kynr.json
@@ -1,0 +1,12 @@
+{
+	"hota.bulwark:07kynr" : {
+		"specialty" : {
+			"stepSize" : 10
+		},
+		"texts" : {
+			"specialty" : {
+				"description" : "Increases the Speed of allied Kobolds and Kobold Foremen by 1 and their Attack and Defense skills by 10% for every level (rounded up)."
+			}
+		}
+	}
+}

--- a/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/bulwark/sial.json
+++ b/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/bulwark/sial.json
@@ -1,0 +1,16 @@
+{
+	"hota.bulwark:11sial" : {
+		"specialty" : {
+			"bonuses" : {
+				"iceBolt" : {
+					"val" : 10
+				}
+			}
+		},
+		"texts" : {
+			"specialty" : {
+				"description" : "Casts Ice Bolt with Damage increased by 10% for every N hero levels, where N is the level of the target creature."
+			}
+		}
+	}
+}

--- a/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/bulwark/spadum.json
+++ b/hota/Mods/gameBalance/mods/heroes/content/config/hotaGameBalance/bulwark/spadum.json
@@ -1,0 +1,9 @@
+{
+	"hota.bulwark:06spadum" : {
+		"texts" : {
+			"specialty" : {
+				"description" : "Increases the Speed of allied Yeti and Yeti Runemasters by 1 and their Attack and Defense skills by 20% for every 4 levels (rounded up)."
+			}
+		}
+	}
+}

--- a/hota/Mods/gameBalance/mods/heroes/mod.json
+++ b/hota/Mods/gameBalance/mods/heroes/mod.json
@@ -6,6 +6,7 @@
 	"contact" : "http://forum.df2.ru/index.php?showtopic=32286",
 	"version" : "1.1",
 	"softDepends" : [
+		"hota.bulwark",
 		"hota.cove",
 		"hota.factory",
 		"hota.heroes"
@@ -16,6 +17,18 @@
 		}
 	},
 	"heroes" : [
+		"config/hotaGameBalance/bulwark/akka.json",
+		"config/hotaGameBalance/bulwark/biarma.json",
+		"config/hotaGameBalance/bulwark/creyle.json",
+		"config/hotaGameBalance/bulwark/dalton.json",
+		"config/hotaGameBalance/bulwark/dhuin.json",
+		"config/hotaGameBalance/bulwark/eikthurn.json",
+		"config/hotaGameBalance/bulwark/glacius.json",
+		"config/hotaGameBalance/bulwark/kriv.json",
+		"config/hotaGameBalance/bulwark/kynr.json",
+		"config/hotaGameBalance/bulwark/sial.json",
+		"config/hotaGameBalance/bulwark/spadum.json",
+
 		"config/hotaGameBalance/castle/adela.json",
 		"config/hotaGameBalance/castle/adelaide.json",
 		"config/hotaGameBalance/castle/catherine.json",


### PR DESCRIPTION
As discussed in #305:

Changed the Bulwark heroes to use vanilla scaling and updated the gameBalance.heroes submod to buff Bulwark heroes as well.

No functional change when gameBalance is enabled.