### PR TITLE
Vault of Ashes submod cleanup and consistency

### DIFF
--- a/hota/Mods/confluxVaultofAshes/content/config/hotaConfluxVaultOfAshes/confluxTown.json
+++ b/hota/Mods/confluxVaultofAshes/content/config/hotaConfluxVaultOfAshes/confluxTown.json
@@ -25,91 +25,22 @@
 				0,
 				6
 			],
-			"hallSlots" : [
-				[
-					[
-						"villageHall",
-						"townHall",
-						"cityHall",
-						"capitol"
-					],
-					[
-						"fort",
-						"citadel",
-						"castle"
-					],
-					[
-						"tavern"
-					],
-					[
-						"blacksmith"
-					]
-				],
-				[
-					[
-						"marketplace",
-						"resourceSilo"
-					],
-					[
-						"mageGuild1",
-						"mageGuild2",
-						"mageGuild3",
-						"mageGuild4",
-						"mageGuild5"
-					],
-					[
+			"hallSlots" : {
+				"modify@2" : {
+					"insert@3" : [
 						"special2"
-					],
-					[
-						"shipyard"
 					]
-				],
-				[
-					[
+				},
+				"modify@3" : {
+					"modify@1" : [
 						"special1"
 					],
-					[
+					"modify@2" : [
 						"hordePhoenix",
 						"hordePhoenixUpgr"
-					],
-					[
-						"horde1",
-						"horde1Upgr"
 					]
-				],
-				[
-					[
-						"dwellingLvl1",
-						"dwellingUpLvl1"
-					],
-					[
-						"dwellingLvl2",
-						"dwellingUpLvl2"
-					],
-					[
-						"dwellingLvl3",
-						"dwellingUpLvl3"
-					],
-					[
-						"dwellingLvl4",
-						"dwellingUpLvl4"
-					]
-				],
-				[
-					[
-						"dwellingLvl5",
-						"dwellingUpLvl5"
-					],
-					[
-						"dwellingLvl6",
-						"dwellingUpLvl6"
-					],
-					[
-						"dwellingLvl7",
-						"dwellingUpLvl7"
-					]
-				]
-			],
+				}
+			},
 			"hallBackground" : "TPTHBKNC.pcx",
 			"buildings" : {
 				"hordePhoenix" : {

--- a/hota/Mods/confluxVaultofAshes/content/config/hotaConfluxVaultOfAshes/creatures.json
+++ b/hota/Mods/confluxVaultofAshes/content/config/hotaConfluxVaultOfAshes/creatures.json
@@ -1,4 +1,8 @@
 {
+	"core:firebird" : {
+		"horde" : 1,
+		"growth" : 1
+	},
 	"core:phoenix" : {
 		"horde" : 1,
 		"growth" : 1

--- a/hota/Mods/gameBalance/mods/creatures/content/config/hotaGameBalance/creatures.json
+++ b/hota/Mods/gameBalance/mods/creatures/content/config/hotaGameBalance/creatures.json
@@ -38,8 +38,6 @@
 	"core:firebird" : {
 		"aiValue" : 4336,
 		"fightValue" : 3097,
-		"horde" : 1,
-		"growth" : 1,
 		"cost" : {
 			"gold" : 2000
 		},
@@ -53,8 +51,6 @@
 		}
 	},
 	"core:phoenix" : {
-		"horde" : 1,
-		"growth" : 1,
 		"cost" : {
 			"gold" : 3000
 		},


### PR DESCRIPTION
The Vault of Ashes submod only adjusted Phoenix growth and horde fields, not Firebird. It was uncaught because gameBalance set both anyway. This seemed odd to me because if you disabled Vault of Ashes but enabled gameBalance, it would reduce Phoenix and Firebird growth and give them a horde bonus instead that couldn't be accessed.

Now, the Vault of Ashes adjusts the growth and I also replaced the hall slot modification with the newer vector manipulation to clean up the file a bit.