### PR TITLE
Fix Doubled 8mm6 template crashing on water maps

### DIFF
--- a/mods/templates/content/config/hotaDoubled8mm6.json
+++ b/mods/templates/content/config/hotaDoubled8mm6.json
@@ -133,7 +133,7 @@
 				"minesLikeZone" : 1,
 				"treasureLikeZone" : 3
 			},
-			"11" : {
+			"9" : {
 				"type" : "treasure",
 				"size" : 20,
 				"monsters" : "strong",
@@ -147,7 +147,7 @@
 				},
 				"treasureLikeZone" : 3
 			},
-			"12" : {
+			"10" : {
 				"type" : "treasure",
 				"size" : 20,
 				"monsters" : "strong",
@@ -161,23 +161,23 @@
 				},
 				"treasureLikeZone" : 3
 			},
-			"15" : {
+			"11" : {
 				"type" : "treasure",
 				"size" : 20,
 				"monsters" : "normal",
 				"matchTerrainToTown" : false,
-				"minesLikeZone" : 11,
+				"mineslikeZone" : 9,
 				"treasureLikeZone" : 1
 			},
-			"16" : {
+			"12" : {
 				"type" : "treasure",
 				"size" : 20,
 				"monsters" : "normal",
 				"matchTerrainToTown" : false,
-				"minesLikeZone" : 12,
+				"mineslikeZone" : 10,
 				"treasureLikeZone" : 1
 			},
-			"17" : {
+			"13" : {
 				"type" : "treasure",
 				"size" : 10,
 				"monsters" : "strong",
@@ -200,35 +200,65 @@
 					}
 				]
 			},
-			"18" : {
+			"14" : {
 				"type" : "treasure",
 				"size" : 10,
 				"monsters" : "strong",
 				"matchTerrainToTown" : false,
-				"treasureLikeZone" : 17
+				"treasurelikeZone" : 13
+			},
+			"15" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "normal",
+				"matchTerrainToTown" : false,
+				"mineslikeZone" : 9,
+				"treasureLikeZone" : 1
+			},
+			"16" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "normal",
+				"matchTerrainToTown" : false,
+				"mineslikeZone" : 10,
+				"treasureLikeZone" : 1
+			},
+			"17" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "normal",
+				"matchTerrainToTown" : false,
+				"mineslikeZone" : 9,
+				"treasureLikeZone" : 1
+			},
+			"18" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "normal",
+				"matchTerrainToTown" : false,
+				"mineslikeZone" : 10,
+				"treasureLikeZone" : 1
 			},
 			"19" : {
 				"type" : "treasure",
-				"size" : 20,
-				"monsters" : "normal",
+				"size" : 10,
+				"monsters" : "strong",
 				"matchTerrainToTown" : false,
-				"minesLikeZone" : 11,
-				"treasureLikeZone" : 1
+				"treasurelikeZone" : 13
 			},
 			"20" : {
 				"type" : "treasure",
-				"size" : 20,
-				"monsters" : "normal",
+				"size" : 10,
+				"monsters" : "strong",
 				"matchTerrainToTown" : false,
-				"minesLikeZone" : 12,
-				"treasureLikeZone" : 1
+				"treasurelikeZone" : 13
 			},
 			"21" : {
 				"type" : "treasure",
 				"size" : 20,
 				"monsters" : "normal",
 				"matchTerrainToTown" : false,
-				"minesLikeZone" : 11,
+				"mineslikeZone" : 9,
 				"treasureLikeZone" : 1
 			},
 			"22" : {
@@ -236,40 +266,10 @@
 				"size" : 20,
 				"monsters" : "normal",
 				"matchTerrainToTown" : false,
-				"minesLikeZone" : 12,
+				"mineslikeZone" : 10,
 				"treasureLikeZone" : 1
 			},
 			"23" : {
-				"type" : "treasure",
-				"size" : 10,
-				"monsters" : "strong",
-				"matchTerrainToTown" : false,
-				"treasureLikeZone" : 17
-			},
-			"24" : {
-				"type" : "treasure",
-				"size" : 10,
-				"monsters" : "strong",
-				"matchTerrainToTown" : false,
-				"treasureLikeZone" : 17
-			},
-			"25" : {
-				"type" : "treasure",
-				"size" : 20,
-				"monsters" : "normal",
-				"matchTerrainToTown" : false,
-				"minesLikeZone" : 11,
-				"treasureLikeZone" : 1
-			},
-			"26" : {
-				"type" : "treasure",
-				"size" : 20,
-				"monsters" : "normal",
-				"matchTerrainToTown" : false,
-				"minesLikeZone" : 12,
-				"treasureLikeZone" : 1
-			},
-			"27" : {
 				"type" : "playerStart",
 				"owner" : 8,
 				"size" : 20,
@@ -281,9 +281,55 @@
 				"minesLikeZone" : 1,
 				"treasureLikeZone" : 1
 			},
-			"28" : {
+			"24" : {
 				"type" : "playerStart",
 				"owner" : 6,
+				"size" : 20,
+				"monsters" : "normal",
+				"playerTowns" : {
+					"castles" : 1
+				},
+				"matchTerrainToTown" : true,
+				"minesLikeZone" : 1,
+				"treasureLikeZone" : 1
+			},
+			"25" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "strong",
+				"neutralTowns" : {
+					"castles" : 1
+				},
+				"matchTerrainToTown" : true,
+				"minesLikeZone" : 1,
+				"treasureLikeZone" : 3
+			},
+			"26" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "strong",
+				"neutralTowns" : {
+					"castles" : 1
+				},
+				"matchTerrainToTown" : true,
+				"minesLikeZone" : 1,
+				"treasureLikeZone" : 3
+			},
+			"27" : {
+				"type" : "playerStart",
+				"owner" : 4,
+				"size" : 20,
+				"monsters" : "normal",
+				"playerTowns" : {
+					"castles" : 1
+				},
+				"matchTerrainToTown" : true,
+				"minesLikeZone" : 1,
+				"treasureLikeZone" : 1
+			},
+			"28" : {
+				"type" : "playerStart",
+				"owner" : 2,
 				"size" : 20,
 				"monsters" : "normal",
 				"playerTowns" : {
@@ -316,175 +362,134 @@
 				"treasureLikeZone" : 3
 			},
 			"31" : {
-				"type" : "playerStart",
-				"owner" : 4,
+				"type" : "treasure",
 				"size" : 20,
-				"monsters" : "normal",
-				"playerTowns" : {
-					"castles" : 1
+				"monsters" : "strong",
+				"neutralTowns" : {
+					"towns" : 1
 				},
-				"matchTerrainToTown" : true,
-				"minesLikeZone" : 1,
-				"treasureLikeZone" : 1
+				"matchTerrainToTown" : false,
+				"mineslikeZone" : 9,
+				"treasureLikeZone" : 3
 			},
 			"32" : {
-				"type" : "playerStart",
-				"owner" : 2,
+				"type" : "treasure",
 				"size" : 20,
-				"monsters" : "normal",
-				"playerTowns" : {
-					"castles" : 1
+				"monsters" : "strong",
+				"neutralTowns" : {
+					"towns" : 1
 				},
-				"matchTerrainToTown" : true,
-				"minesLikeZone" : 1,
-				"treasureLikeZone" : 1
+				"matchTerrainToTown" : false,
+				"mineslikeZone" : 10,
+				"treasureLikeZone" : 3
 			},
 			"33" : {
 				"type" : "treasure",
 				"size" : 20,
-				"monsters" : "strong",
-				"neutralTowns" : {
-					"castles" : 1
-				},
-				"matchTerrainToTown" : true,
-				"minesLikeZone" : 1,
-				"treasureLikeZone" : 3
+				"monsters" : "normal",
+				"matchTerrainToTown" : false,
+				"mineslikeZone" : 9,
+				"treasureLikeZone" : 1
 			},
 			"34" : {
 				"type" : "treasure",
 				"size" : 20,
+				"monsters" : "normal",
+				"matchTerrainToTown" : false,
+				"mineslikeZone" : 10,
+				"treasureLikeZone" : 1
+			},
+			"35" : {
+				"type" : "treasure",
+				"size" : 10,
 				"monsters" : "strong",
-				"neutralTowns" : {
-					"castles" : 1
-				},
-				"matchTerrainToTown" : true,
-				"minesLikeZone" : 1,
-				"treasureLikeZone" : 3
+				"matchTerrainToTown" : false,
+				"treasurelikeZone" : 13
+			},
+			"36" : {
+				"type" : "treasure",
+				"size" : 10,
+				"monsters" : "strong",
+				"matchTerrainToTown" : false,
+				"treasurelikeZone" : 13
 			},
 			"37" : {
 				"type" : "treasure",
 				"size" : 20,
-				"monsters" : "strong",
-				"neutralTowns" : {
-					"towns" : 1
-				},
+				"monsters" : "normal",
 				"matchTerrainToTown" : false,
-				"minesLikeZone" : 11,
-				"treasureLikeZone" : 3
+				"mineslikeZone" : 9,
+				"treasureLikeZone" : 1
 			},
 			"38" : {
 				"type" : "treasure",
 				"size" : 20,
-				"monsters" : "strong",
-				"neutralTowns" : {
-					"towns" : 1
-				},
+				"monsters" : "normal",
 				"matchTerrainToTown" : false,
-				"minesLikeZone" : 12,
-				"treasureLikeZone" : 3
+				"mineslikeZone" : 10,
+				"treasureLikeZone" : 1
+			},
+			"39" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "normal",
+				"matchTerrainToTown" : false,
+				"mineslikeZone" : 9,
+				"treasureLikeZone" : 1
+			},
+			"40" : {
+				"type" : "treasure",
+				"size" : 20,
+				"monsters" : "normal",
+				"matchTerrainToTown" : false,
+				"mineslikeZone" : 10,
+				"treasureLikeZone" : 1
 			},
 			"41" : {
 				"type" : "treasure",
-				"size" : 20,
-				"monsters" : "normal",
+				"size" : 10,
+				"monsters" : "strong",
 				"matchTerrainToTown" : false,
-				"minesLikeZone" : 11,
-				"treasureLikeZone" : 1
+				"treasurelikeZone" : 13
 			},
 			"42" : {
 				"type" : "treasure",
-				"size" : 20,
-				"monsters" : "normal",
+				"size" : 10,
+				"monsters" : "strong",
 				"matchTerrainToTown" : false,
-				"minesLikeZone" : 12,
-				"treasureLikeZone" : 1
+				"treasurelikeZone" : 13
 			},
 			"43" : {
 				"type" : "treasure",
-				"size" : 10,
-				"monsters" : "strong",
+				"size" : 20,
+				"monsters" : "normal",
 				"matchTerrainToTown" : false,
-				"treasureLikeZone" : 17
+				"mineslikeZone" : 9,
+				"treasureLikeZone" : 1
 			},
 			"44" : {
 				"type" : "treasure",
-				"size" : 10,
-				"monsters" : "strong",
-				"matchTerrainToTown" : false,
-				"treasureLikeZone" : 17
-			},
-			"45" : {
-				"type" : "treasure",
 				"size" : 20,
 				"monsters" : "normal",
 				"matchTerrainToTown" : false,
-				"minesLikeZone" : 11,
-				"treasureLikeZone" : 1
-			},
-			"46" : {
-				"type" : "treasure",
-				"size" : 20,
-				"monsters" : "normal",
-				"matchTerrainToTown" : false,
-				"minesLikeZone" : 12,
-				"treasureLikeZone" : 1
-			},
-			"47" : {
-				"type" : "treasure",
-				"size" : 20,
-				"monsters" : "normal",
-				"matchTerrainToTown" : false,
-				"minesLikeZone" : 11,
-				"treasureLikeZone" : 1
-			},
-			"48" : {
-				"type" : "treasure",
-				"size" : 20,
-				"monsters" : "normal",
-				"matchTerrainToTown" : false,
-				"minesLikeZone" : 12,
-				"treasureLikeZone" : 1
-			},
-			"49" : {
-				"type" : "treasure",
-				"size" : 10,
-				"monsters" : "strong",
-				"matchTerrainToTown" : false,
-				"treasureLikeZone" : 17
-			},
-			"50" : {
-				"type" : "treasure",
-				"size" : 10,
-				"monsters" : "strong",
-				"matchTerrainToTown" : false,
-				"treasureLikeZone" : 17
-			},
-			"51" : {
-				"type" : "treasure",
-				"size" : 20,
-				"monsters" : "normal",
-				"matchTerrainToTown" : false,
-				"minesLikeZone" : 11,
-				"treasureLikeZone" : 1
-			},
-			"52" : {
-				"type" : "treasure",
-				"size" : 20,
-				"monsters" : "normal",
-				"matchTerrainToTown" : false,
-				"minesLikeZone" : 12,
+				"mineslikeZone" : 10,
 				"treasureLikeZone" : 1
 			}
 		},
 		"connections" : [
 			{
 				"a" : "1",
-				"b" : "15",
+				"b" : "11",
 				"guard" : 6000
 			},
 			{
 				"a" : "1",
-				"b" : "19",
+				"b" : "15",
+				"guard" : 6000
+			},
+			{
+				"a" : "2",
+				"b" : "12",
 				"guard" : 6000
 			},
 			{
@@ -493,8 +498,8 @@
 				"guard" : 6000
 			},
 			{
-				"a" : "2",
-				"b" : "20",
+				"a" : "3",
+				"b" : "11",
 				"guard" : 6000
 			},
 			{
@@ -504,13 +509,13 @@
 			},
 			{
 				"a" : "3",
-				"b" : "19",
-				"guard" : 6000
+				"b" : "25",
+				"guard" : 12500
 			},
 			{
-				"a" : "3",
-				"b" : "29",
-				"guard" : 12500
+				"a" : "4",
+				"b" : "12",
+				"guard" : 6000
 			},
 			{
 				"a" : "4",
@@ -519,93 +524,98 @@
 			},
 			{
 				"a" : "4",
-				"b" : "20",
+				"b" : "26",
+				"guard" : 12500
+			},
+			{
+				"a" : "5",
+				"b" : "17",
 				"guard" : 6000
 			},
 			{
-				"a" : "4",
+				"a" : "5",
+				"b" : "21",
+				"guard" : 6000
+			},
+			{
+				"a" : "6",
+				"b" : "18",
+				"guard" : 6000
+			},
+			{
+				"a" : "6",
+				"b" : "22",
+				"guard" : 6000
+			},
+			{
+				"a" : "7",
+				"b" : "17",
+				"guard" : 6000
+			},
+			{
+				"a" : "7",
+				"b" : "21",
+				"guard" : 6000
+			},
+			{
+				"a" : "7",
+				"b" : "29",
+				"guard" : 12500
+			},
+			{
+				"a" : "8",
+				"b" : "18",
+				"guard" : 6000
+			},
+			{
+				"a" : "8",
+				"b" : "22",
+				"guard" : 6000
+			},
+			{
+				"a" : "8",
 				"b" : "30",
 				"guard" : 12500
 			},
 			{
-				"a" : "5",
-				"b" : "21",
-				"guard" : 6000
+				"a" : "9",
+				"b" : "15",
+				"guard" : 9000
 			},
 			{
-				"a" : "5",
-				"b" : "25",
-				"guard" : 6000
+				"a" : "9",
+				"b" : "16",
+				"guard" : 9000
 			},
 			{
-				"a" : "6",
-				"b" : "22",
-				"guard" : 6000
+				"a" : "9",
+				"b" : "18",
+				"guard" : 9000
 			},
 			{
-				"a" : "6",
-				"b" : "26",
-				"guard" : 6000
+				"a" : "10",
+				"b" : "15",
+				"guard" : 9000
 			},
 			{
-				"a" : "7",
-				"b" : "21",
-				"guard" : 6000
+				"a" : "10",
+				"b" : "17",
+				"guard" : 9000
 			},
 			{
-				"a" : "7",
-				"b" : "25",
-				"guard" : 6000
+				"a" : "10",
+				"b" : "18",
+				"guard" : 9000
 			},
 			{
-				"a" : "7",
-				"b" : "33",
+				"a" : "13",
+				"b" : "15",
 				"guard" : 12500
 			},
 			{
-				"a" : "8",
-				"b" : "22",
-				"guard" : 6000
-			},
-			{
-				"a" : "8",
-				"b" : "26",
-				"guard" : 6000
-			},
-			{
-				"a" : "8",
-				"b" : "34",
+				"a" : "14",
+				"b" : "16",
 				"guard" : 12500
-			},
-			{
-				"a" : "11",
-				"b" : "19",
-				"guard" : 9000
-			},
-			{
-				"a" : "11",
-				"b" : "20",
-				"guard" : 9000
-			},
-			{
-				"a" : "11",
-				"b" : "22",
-				"guard" : 9000
-			},
-			{
-				"a" : "12",
-				"b" : "19",
-				"guard" : 9000
-			},
-			{
-				"a" : "12",
-				"b" : "21",
-				"guard" : 9000
-			},
-			{
-				"a" : "12",
-				"b" : "22",
-				"guard" : 9000
 			},
 			{
 				"a" : "17",
@@ -618,143 +628,133 @@
 				"guard" : 12500
 			},
 			{
-				"a" : "21",
-				"b" : "23",
-				"guard" : 12500
+				"a" : "23",
+				"b" : "33",
+				"guard" : 6000
 			},
 			{
-				"a" : "22",
-				"b" : "24",
-				"guard" : 12500
+				"a" : "23",
+				"b" : "37",
+				"guard" : 6000
 			},
 			{
-				"a" : "27",
-				"b" : "41",
+				"a" : "24",
+				"b" : "34",
+				"guard" : 6000
+			},
+			{
+				"a" : "24",
+				"b" : "38",
+				"guard" : 6000
+			},
+			{
+				"a" : "25",
+				"b" : "33",
+				"guard" : 6000
+			},
+			{
+				"a" : "25",
+				"b" : "37",
+				"guard" : 6000
+			},
+			{
+				"a" : "26",
+				"b" : "34",
+				"guard" : 6000
+			},
+			{
+				"a" : "26",
+				"b" : "38",
 				"guard" : 6000
 			},
 			{
 				"a" : "27",
-				"b" : "45",
+				"b" : "39",
+				"guard" : 6000
+			},
+			{
+				"a" : "27",
+				"b" : "43",
 				"guard" : 6000
 			},
 			{
 				"a" : "28",
-				"b" : "42",
+				"b" : "40",
 				"guard" : 6000
 			},
 			{
 				"a" : "28",
-				"b" : "46",
+				"b" : "44",
 				"guard" : 6000
 			},
 			{
 				"a" : "29",
+				"b" : "39",
+				"guard" : 6000
+			},
+			{
+				"a" : "29",
+				"b" : "43",
+				"guard" : 6000
+			},
+			{
+				"a" : "30",
+				"b" : "40",
+				"guard" : 6000
+			},
+			{
+				"a" : "30",
+				"b" : "44",
+				"guard" : 6000
+			},
+			{
+				"a" : "31",
+				"b" : "37",
+				"guard" : 9000
+			},
+			{
+				"a" : "31",
+				"b" : "38",
+				"guard" : 9000
+			},
+			{
+				"a" : "31",
+				"b" : "40",
+				"guard" : 9000
+			},
+			{
+				"a" : "32",
+				"b" : "37",
+				"guard" : 9000
+			},
+			{
+				"a" : "32",
+				"b" : "39",
+				"guard" : 9000
+			},
+			{
+				"a" : "32",
+				"b" : "40",
+				"guard" : 9000
+			},
+			{
+				"a" : "35",
+				"b" : "37",
+				"guard" : 12500
+			},
+			{
+				"a" : "36",
+				"b" : "38",
+				"guard" : 12500
+			},
+			{
+				"a" : "39",
 				"b" : "41",
-				"guard" : 6000
+				"guard" : 12500
 			},
 			{
-				"a" : "29",
-				"b" : "45",
-				"guard" : 6000
-			},
-			{
-				"a" : "30",
+				"a" : "40",
 				"b" : "42",
-				"guard" : 6000
-			},
-			{
-				"a" : "30",
-				"b" : "46",
-				"guard" : 6000
-			},
-			{
-				"a" : "31",
-				"b" : "47",
-				"guard" : 6000
-			},
-			{
-				"a" : "31",
-				"b" : "51",
-				"guard" : 6000
-			},
-			{
-				"a" : "32",
-				"b" : "48",
-				"guard" : 6000
-			},
-			{
-				"a" : "32",
-				"b" : "52",
-				"guard" : 6000
-			},
-			{
-				"a" : "33",
-				"b" : "47",
-				"guard" : 6000
-			},
-			{
-				"a" : "33",
-				"b" : "51",
-				"guard" : 6000
-			},
-			{
-				"a" : "34",
-				"b" : "48",
-				"guard" : 6000
-			},
-			{
-				"a" : "34",
-				"b" : "52",
-				"guard" : 6000
-			},
-			{
-				"a" : "37",
-				"b" : "45",
-				"guard" : 9000
-			},
-			{
-				"a" : "37",
-				"b" : "46",
-				"guard" : 9000
-			},
-			{
-				"a" : "37",
-				"b" : "48",
-				"guard" : 9000
-			},
-			{
-				"a" : "38",
-				"b" : "45",
-				"guard" : 9000
-			},
-			{
-				"a" : "38",
-				"b" : "47",
-				"guard" : 9000
-			},
-			{
-				"a" : "38",
-				"b" : "48",
-				"guard" : 9000
-			},
-			{
-				"a" : "43",
-				"b" : "45",
-				"guard" : 12500
-			},
-			{
-				"a" : "44",
-				"b" : "46",
-				"guard" : 12500
-			},
-			{
-				"a" : "47",
-				"b" : "49",
-				"guard" : 12500
-			},
-			{
-				"a" : "48",
-				"b" : "50",
 				"guard" : 12500
 			}
 		]

--- a/mods/templates/content/config/hotaDoubled8mm6.json
+++ b/mods/templates/content/config/hotaDoubled8mm6.json
@@ -166,7 +166,7 @@
 				"size" : 20,
 				"monsters" : "normal",
 				"matchTerrainToTown" : false,
-				"mineslikeZone" : 9,
+				"minesLikeZone" : 9,
 				"treasureLikeZone" : 1
 			},
 			"12" : {
@@ -174,7 +174,7 @@
 				"size" : 20,
 				"monsters" : "normal",
 				"matchTerrainToTown" : false,
-				"mineslikeZone" : 10,
+				"minesLikeZone" : 10,
 				"treasureLikeZone" : 1
 			},
 			"13" : {
@@ -205,14 +205,14 @@
 				"size" : 10,
 				"monsters" : "strong",
 				"matchTerrainToTown" : false,
-				"treasurelikeZone" : 13
+				"treasureLikeZone" : 13
 			},
 			"15" : {
 				"type" : "treasure",
 				"size" : 20,
 				"monsters" : "normal",
 				"matchTerrainToTown" : false,
-				"mineslikeZone" : 9,
+				"minesLikeZone" : 9,
 				"treasureLikeZone" : 1
 			},
 			"16" : {
@@ -220,7 +220,7 @@
 				"size" : 20,
 				"monsters" : "normal",
 				"matchTerrainToTown" : false,
-				"mineslikeZone" : 10,
+				"minesLikeZone" : 10,
 				"treasureLikeZone" : 1
 			},
 			"17" : {
@@ -228,7 +228,7 @@
 				"size" : 20,
 				"monsters" : "normal",
 				"matchTerrainToTown" : false,
-				"mineslikeZone" : 9,
+				"minesLikeZone" : 9,
 				"treasureLikeZone" : 1
 			},
 			"18" : {
@@ -236,7 +236,7 @@
 				"size" : 20,
 				"monsters" : "normal",
 				"matchTerrainToTown" : false,
-				"mineslikeZone" : 10,
+				"minesLikeZone" : 10,
 				"treasureLikeZone" : 1
 			},
 			"19" : {
@@ -244,21 +244,21 @@
 				"size" : 10,
 				"monsters" : "strong",
 				"matchTerrainToTown" : false,
-				"treasurelikeZone" : 13
+				"treasureLikeZone" : 13
 			},
 			"20" : {
 				"type" : "treasure",
 				"size" : 10,
 				"monsters" : "strong",
 				"matchTerrainToTown" : false,
-				"treasurelikeZone" : 13
+				"treasureLikeZone" : 13
 			},
 			"21" : {
 				"type" : "treasure",
 				"size" : 20,
 				"monsters" : "normal",
 				"matchTerrainToTown" : false,
-				"mineslikeZone" : 9,
+				"minesLikeZone" : 9,
 				"treasureLikeZone" : 1
 			},
 			"22" : {
@@ -266,7 +266,7 @@
 				"size" : 20,
 				"monsters" : "normal",
 				"matchTerrainToTown" : false,
-				"mineslikeZone" : 10,
+				"minesLikeZone" : 10,
 				"treasureLikeZone" : 1
 			},
 			"23" : {
@@ -369,7 +369,7 @@
 					"towns" : 1
 				},
 				"matchTerrainToTown" : false,
-				"mineslikeZone" : 9,
+				"minesLikeZone" : 9,
 				"treasureLikeZone" : 3
 			},
 			"32" : {
@@ -380,7 +380,7 @@
 					"towns" : 1
 				},
 				"matchTerrainToTown" : false,
-				"mineslikeZone" : 10,
+				"minesLikeZone" : 10,
 				"treasureLikeZone" : 3
 			},
 			"33" : {
@@ -388,7 +388,7 @@
 				"size" : 20,
 				"monsters" : "normal",
 				"matchTerrainToTown" : false,
-				"mineslikeZone" : 9,
+				"minesLikeZone" : 9,
 				"treasureLikeZone" : 1
 			},
 			"34" : {
@@ -396,7 +396,7 @@
 				"size" : 20,
 				"monsters" : "normal",
 				"matchTerrainToTown" : false,
-				"mineslikeZone" : 10,
+				"minesLikeZone" : 10,
 				"treasureLikeZone" : 1
 			},
 			"35" : {
@@ -404,21 +404,21 @@
 				"size" : 10,
 				"monsters" : "strong",
 				"matchTerrainToTown" : false,
-				"treasurelikeZone" : 13
+				"treasureLikeZone" : 13
 			},
 			"36" : {
 				"type" : "treasure",
 				"size" : 10,
 				"monsters" : "strong",
 				"matchTerrainToTown" : false,
-				"treasurelikeZone" : 13
+				"treasureLikeZone" : 13
 			},
 			"37" : {
 				"type" : "treasure",
 				"size" : 20,
 				"monsters" : "normal",
 				"matchTerrainToTown" : false,
-				"mineslikeZone" : 9,
+				"minesLikeZone" : 9,
 				"treasureLikeZone" : 1
 			},
 			"38" : {
@@ -426,7 +426,7 @@
 				"size" : 20,
 				"monsters" : "normal",
 				"matchTerrainToTown" : false,
-				"mineslikeZone" : 10,
+				"minesLikeZone" : 10,
 				"treasureLikeZone" : 1
 			},
 			"39" : {
@@ -434,7 +434,7 @@
 				"size" : 20,
 				"monsters" : "normal",
 				"matchTerrainToTown" : false,
-				"mineslikeZone" : 9,
+				"minesLikeZone" : 9,
 				"treasureLikeZone" : 1
 			},
 			"40" : {
@@ -442,7 +442,7 @@
 				"size" : 20,
 				"monsters" : "normal",
 				"matchTerrainToTown" : false,
-				"mineslikeZone" : 10,
+				"minesLikeZone" : 10,
 				"treasureLikeZone" : 1
 			},
 			"41" : {
@@ -450,21 +450,21 @@
 				"size" : 10,
 				"monsters" : "strong",
 				"matchTerrainToTown" : false,
-				"treasurelikeZone" : 13
+				"treasureLikeZone" : 13
 			},
 			"42" : {
 				"type" : "treasure",
 				"size" : 10,
 				"monsters" : "strong",
 				"matchTerrainToTown" : false,
-				"treasurelikeZone" : 13
+				"treasureLikeZone" : 13
 			},
 			"43" : {
 				"type" : "treasure",
 				"size" : 20,
 				"monsters" : "normal",
 				"matchTerrainToTown" : false,
-				"mineslikeZone" : 9,
+				"minesLikeZone" : 9,
 				"treasureLikeZone" : 1
 			},
 			"44" : {
@@ -472,7 +472,7 @@
 				"size" : 20,
 				"monsters" : "normal",
 				"matchTerrainToTown" : false,
-				"mineslikeZone" : 10,
+				"minesLikeZone" : 10,
 				"treasureLikeZone" : 1
 			}
 		},


### PR DESCRIPTION
Missing zone ids apparently cause a crash on water maps but not on land maps. Should probably be reported.