### PR TITLE
Description update

### DIFF
--- a/mods/artifacts/Content/config/hotaArtifacts/capeOfSilence.json
+++ b/mods/artifacts/Content/config/hotaArtifacts/capeOfSilence.json
@@ -20,7 +20,7 @@
 		},
 		"text" : {
 			"name" : "Cape of Silence",
-			"description" : "{Cape of Silence}\r\n\r\nWhile wearing this cape, neither you nor your opponent will be able to cast level 1-2 spells during combat.",
+			"description" : "{Cape of Silence}\n\nWhile wearing this cape, neither you nor your opponent will be able to cast level 1-2 spells during combat.",
 			"event" : "As you pass the graveyard, you notice an old man mourning over his wife. As you approach him, the old man falls dead. After burying him, you decide to take his cape."
 		}
 	}

--- a/mods/artifacts/Content/config/hotaArtifacts/charmOfEclipse.json
+++ b/mods/artifacts/Content/config/hotaArtifacts/charmOfEclipse.json
@@ -26,7 +26,7 @@
 		},
 		"text" : {
 			"name" : "Charm of Eclipse",
-			"description" : "{Charm Of Eclipse}\r\n\r\nThis item reduces the Power skill of enemy hero by 10% during combat.",
+			"description" : "{Charm of Eclipse}\n\nThis item reduces the Power skill of enemy hero by 10% during combat.",
 			"event" : "While messing around with a curious trinket that you managed to trade something equally unneeded for at a peddler, you find that, although it's made of metal, it doesn't reflect the sun rays, but rather absorbs them readily."
 		}
 	}

--- a/mods/artifacts/Content/config/hotaArtifacts/crownOfTheFiveSeas.json
+++ b/mods/artifacts/Content/config/hotaArtifacts/crownOfTheFiveSeas.json
@@ -21,7 +21,7 @@
 		},
 		"text" : {
 			"name" : "Crown of the Five Seas",
-			"description" : "{Crown of the Five Seas}\r\n\r\nWorn on the head, this item increases your Knowledge skill by 6.",
+			"description" : "{Crown of the Five Seas}\n\nWorn on the head, this item increases your Knowledge skill by +6.",
 			"event" : "You hardly set a camp, leaving the saddle for the first time for the day, as some critter sneaked up on you and pulled one of your boots in his hole. Swearing silently, you search the hole with your hand. Instead of a boot, you touch something sharp. Amazed, you pull out a crown."
 		}
 	}

--- a/mods/artifacts/Content/config/hotaArtifacts/demonsHorseshoe.json
+++ b/mods/artifacts/Content/config/hotaArtifacts/demonsHorseshoe.json
@@ -24,7 +24,7 @@
 		},
 		"text" : {
 			"name" : "Demon's Horseshoe",
-			"description" : "{Demon's Horseshoe}\r\n\r\nDecreases enemy's Luck by 1.",
+			"description" : "{Demon's Horseshoe}\n\nDecreases enemy's Luck by 1.",
 			"event" : "During your overnight stay you hear hooves clatter nearby. You look around in darkness and notice a demon's figure, ready to stab you with its horns. You barely survive the attack and keep his horseshoe as a trophy."
 		}
 	}

--- a/mods/artifacts/Content/config/hotaArtifacts/diplomatsCloak.json
+++ b/mods/artifacts/Content/config/hotaArtifacts/diplomatsCloak.json
@@ -18,7 +18,7 @@
 		},
 		"text" : {
 			"name" : "Diplomat's Cloak",
-			"description" : "{Diplomat's Cloak}\r\n\r\nAllows your hero to retreat or surrender when battling neutral monsters or defending a town. Multiplies your hero army strength by 3 (for neutral armies and Thieves guild). **NOT IMPLEMENTED in VCMI yet**",
+			"description" : "{Diplomat's Cloak}\n\nCounting component effects this cloak reduces the cost of surrendering by 30% and allows your hero to surrender when battling enemy without a hero. Allows to retreat or surrender when defending a town or attacking and casting a spell in the first round of a combat. Multiplies your hero army strength by 3 for neutral armies (when determining their desire to join hero or run away) and Thieves Guild.\n\n{THESE EFFECTS ARE NOT IMPLEMENTED!!!}",
 			"event" : "You met an unusual scarecrow today. Instead of scaring the, well, crows, it was intelligently persuading them to leave the field. You agreed to help the scarecrow to find the closest seer in exchange for the secret. The scarecrow gives you its cloak."
 		}
 	}

--- a/mods/artifacts/Content/config/hotaArtifacts/goldenGoose.json
+++ b/mods/artifacts/Content/config/hotaArtifacts/goldenGoose.json
@@ -26,7 +26,7 @@
 		},
 		"text" : {
 			"name" : "Golden Goose",
-			"description" : "{Golden Goose}\r\n\r\nWhen equipped, the Golden Goose increases your income by a total of 7000 gold per day.",
+			"description" : "{Golden Goose}\n\nCounting component effects the Golden Goose increases your income by 7000 gold per day.",
 			"event" : "You wander on an abandoned house of a collector in search for a camp place. Most of the goods were long stolen by the marauders, but you were able to find a couple of dusty pet statues. You vaguely recognize one of them. You rub the dust off one of them, and discover a golden goose."
 		}
 	}

--- a/mods/artifacts/Content/config/hotaArtifacts/hideousMask.json
+++ b/mods/artifacts/Content/config/hotaArtifacts/hideousMask.json
@@ -24,7 +24,7 @@
 		},
 		"text" : {
 			"name" : "Hideous Mask",
-			"description" : "{Hideous Mask}\r\n\r\nDecreases enemy's Morale by 1.",
+			"description" : "{Hideous Mask}\n\nDecreases enemy's Morale by 1.",
 			"event" : "You meet a traveling circus on your way. One of the artists had such a deft disguise that you have drawn a sword, ready to defend yourself. It appeared that a pretty actress was hiding behind the mask. Laughing, she gifts you the mask."
 		}
 	}

--- a/mods/artifacts/Content/config/hotaArtifacts/ironfistOfTheOgre.json
+++ b/mods/artifacts/Content/config/hotaArtifacts/ironfistOfTheOgre.json
@@ -44,7 +44,7 @@
 		},
 		"text" : {
 			"name" : "Ironfist Of The Ogre",
-			"description" : "{Ironfist Of The Ogre}\r\n\r\nAt the beginning of every combat casts Haste, Bloodlust, Fire Shield and Counterstrike spells on expert level on all of your creatures for fifty rounds.",
+			"description" : "{Ironfist of the Ogre}\n\nCounting component effects the Ironfist of the Ogre gives hero +5 Attack, +5 Defence, +4 Power, and +4 Knowledge. Casts these spells on expert level at the beginning of combat on all of your creatures for 50 rounds: Haste, Bloodlust, Fire Shield, and Counterstrike.",
 			"event" : "On passing by a small cave you hear deep thumping. You enter the cave and see a juvenile Cyclops cracking nuts with an enormous hammer. Every strike ends in shells and nut pieces being scattered all over the cave. You teach the Cyclops to crack nuts more sparingly by crushing them against each other. Overjoyed with this dicovery, the youth gifts you the hammer."
 		}
 	}

--- a/mods/artifacts/Content/config/hotaArtifacts/pendantOfDownfall.json
+++ b/mods/artifacts/Content/config/hotaArtifacts/pendantOfDownfall.json
@@ -24,7 +24,7 @@
 		},
 		"text" : {
 			"name" : "Pendant of Downfall",
-			"description" : "{Pendant of Downfall}\r\n\r\nWorn about the neck, this item decreases enemy's Morale by 2.",
+			"description" : "{Pendant of Downfall}\n\nWorn about the neck, this item decreases enemy's Morale by 2.",
 			"event" : "You visit the jeweler's shop. You land your eyes on a bracelet, but the shopkeeper immediately warns you that it is cursed. You fear no curses, and put the bracelet on immediately. The bracelet vanishes in a flash. Enraged, you are about to kill the shopkeeper, but he offers you Pendant of Downfall in return. You agree."
 		}
 	}

--- a/mods/artifacts/Content/config/hotaArtifacts/pendantOfReflection.json
+++ b/mods/artifacts/Content/config/hotaArtifacts/pendantOfReflection.json
@@ -25,7 +25,7 @@
 		},
 		"text" : {
 			"name" : "Pendant of Reflection",
-			"description" : "{Pendant of Reflection}\r\n\r\nIncreases your Magic Resistance additionally by 20%.",
+			"description" : "{Pendant of Reflection}\n\nCounting component effects this item increases your chance to resist a hostile spell by 50%.",
 			"event" : "Soldiers approach you with talks about a miracle. You are intrigued and follow them. You see a strange sight indeed; a wanderer sitting on top of the fire trap, without any harm. You offer him money in exchange for the secret, but he laughs and vanishes in the air. You see a strange pendant left in the middle of the trap."
 		}
 	}

--- a/mods/artifacts/Content/config/hotaArtifacts/plateofDyingLight.json
+++ b/mods/artifacts/Content/config/hotaArtifacts/plateofDyingLight.json
@@ -26,7 +26,7 @@
 		},
 		"text" : {
 			"name" : "Plate of Dying Light",
-			"description" : "{Plate of Dying Light}\r\n\r\nWorn on a torso, this item reduces the Power skill of enemy hero by 25% during combat.",
+			"description" : "{Plate of Dying Light}\n\nWorn on a torso, this item reduces the Power skill of enemy hero by 25% during combat.",
 			"event" : "The goblin you met at the tavern is acting incredibly brazenly, and the reason for that is obviously the luxurious armor on his chest. It becomes apparent quickly that the armor offers poor protection from a good kick in the ass, yet it still is good for something — but how would a dumb goblin know that?"
 		}
 	}

--- a/mods/artifacts/Content/config/hotaArtifacts/ringOfOblivion.json
+++ b/mods/artifacts/Content/config/hotaArtifacts/ringOfOblivion.json
@@ -44,7 +44,7 @@
 		},
 		"text" : {
 			"name" : "Ring of Oblivion",
-			"description" : "{Ring of Oblivion}\r\n\r\nWhen worn, makes all losses in the battle irrevocable.",
+			"description" : "{Ring of Oblivion}\n\nWorn on a finger, this item makes all losses in the battle irrevocable:  lost creatures in a unit cannot be restored by any means, and corpses disappear right after the unit's death.",
 			"event" : "You stand on a field, where a large battle was fought not so long ago. You are troubled by the complete absence of corpses. Amongst the broken swords and armors you discover a ring."
 		}
 	}

--- a/mods/artifacts/Content/config/hotaArtifacts/ringOfSuppression.json
+++ b/mods/artifacts/Content/config/hotaArtifacts/ringOfSuppression.json
@@ -24,7 +24,7 @@
 		},
 		"text" : {
 			"name" : "Ring of Suppression",
-			"description" : "{Ring of Suppression}\r\n\r\nWorn on the finger, this ring decreases enemy's Morale by 1.",
+			"description" : "{Ring of Suppression}\n\nWorn on the finger, this ring decreases enemy's Morale by 1.",
 			"event" : "You ordered fried eggs for breakfast. The cook managed to find the eggs for you. He also found a ring in the bird's nest that he passed to you."
 		}
 	}

--- a/mods/artifacts/Content/config/hotaArtifacts/royalArmorOfNix.json
+++ b/mods/artifacts/Content/config/hotaArtifacts/royalArmorOfNix.json
@@ -21,7 +21,7 @@
 		},
 		"text" : {
 			"name" : "Royal Armor of Nix",
-			"description" : "{Royal Armor of Nix}\r\n\r\nWorn on the torso, this item increases your Power skill by +6.",
+			"description" : "{Royal Armor of Nix}\n\nWorn on the torso, this item increases your Power skill by +6.",
 			"event" : "You see a fight on a hill nearby. As you get closer, you see two nix. One is winning, and as he is about to land a finishing blow, you intervene. The defeated nix thanks you for your help, and gifts you with his armor. He believes you deserve it more than he does."
 		}
 	}

--- a/mods/artifacts/Content/config/hotaArtifacts/runesOfImminency.json
+++ b/mods/artifacts/Content/config/hotaArtifacts/runesOfImminency.json
@@ -24,7 +24,7 @@
 		},
 		"text" : {
 			"name" : "Runes of Imminency",
-			"description" : "{Runes of Imminency}\r\n\r\nDecrease enemy's Luck by 1.",
+			"description" : "{Runes of Imminency}\n\nDecrease enemy's Luck by 1.",
 			"event" : "Close by, on a mountain edge you see a mage trying to cast a  Fiery symbols are already flashing in the sky, when he, while blinded by the light, trips and falls down. The mage perishes, and you gather the chain of mysterious stones in your backpack."
 		}
 	}

--- a/mods/artifacts/Content/config/hotaArtifacts/sealOfSunset.json
+++ b/mods/artifacts/Content/config/hotaArtifacts/sealOfSunset.json
@@ -26,7 +26,7 @@
 		},
 		"text" : {
 			"name" : "Seal of Sunset",
-			"description" : "{Seal of Sunset}\r\n\r\nWorn on a finger, this item reduces the Power skill of enemy hero by 10% during combat.",
+			"description" : "{Seal of Sunset}\n\nWorn on a finger, this item reduces the Power skill of enemy hero by 10% during combat.",
 			"event" : "It's never nice to get hit in the noggin by a fist with a heavy ring on the finger. Still, that's what happened to you in a friendly sparring with an old hero acquaintance, and after that, you couldn't manage the simplest spell to relieve dizziness for quite a while. During the booze-up after the sparring, the ring migrated over to your digit."
 		}
 	}

--- a/mods/artifacts/Content/config/hotaArtifacts/shamansPuppet.json
+++ b/mods/artifacts/Content/config/hotaArtifacts/shamansPuppet.json
@@ -24,7 +24,7 @@
 		},
 		"text" : {
 			"name" : "Shaman's Puppet",
-			"description" : "{Shaman's Puppet}\r\n\r\nDecreases enemy's Luck by 2.",
+			"description" : "{Shaman's Puppet}\n\nDecreases enemy's Luck by 2.",
 			"event" : "The day looked not so great from the beginning. You walked under the ladder, met a woman with an empty bucket and stepped on a black cat. Apparently, it is not your misfortune, but the guy in rugs who has been following you. You order to seize the loser, but he runs away. As he vanishes, you notice a strange doll that he dropped."
 		}
 	}

--- a/mods/artifacts/Content/config/hotaArtifacts/shieldOfNavalGlory.json
+++ b/mods/artifacts/Content/config/hotaArtifacts/shieldOfNavalGlory.json
@@ -21,7 +21,7 @@
 		},
 		"text" : {
 			"name" : "Shield of Naval Glory",
-			"description" : "{Shield of Naval Glory}\r\n\r\nThis left-handed item increases your Defense skill by 7.",
+			"description" : "{Shield of Naval Glory}\n\nThis left-handed item increases your Defense skill by +7.",
 			"event" : "You meet an old admiral at the tavern. After a couple of hours full of tales about glorious battles and days long passed he gifts you his parade shield."
 		}
 	}

--- a/mods/artifacts/Content/config/hotaArtifacts/sleepkeeper.json
+++ b/mods/artifacts/Content/config/hotaArtifacts/sleepkeeper.json
@@ -19,7 +19,7 @@
 			"scenarioBonus" : "hota/artifactsCampaignBonuses/sleepkeeper"
 		},
 		"text" : {
-			"description" : "{Sleepkeeper}\r\n\r\nWhile equipped, the artifact provides the hero's creatures with immunity to Mind spells.",
+			"description" : "{Sleepkeeper}\n\nGives your units mind spells immunity.",
 			"event" : "You are seeing the same dream for the third night already. A stranger begs you to buy an enchanted broom. You refuse every time, but the dream repeats night by night. You ask the first witch doctor you meet for help, but instead of a potion he gives you a plain statuette, ensuring that it will solve your problem. Having bought the statuette, you suddenly realize the witch doctor is sinisterly similar to the stranger from your dreams.",
 			"name" : "Sleepkeeper"
 		}

--- a/mods/artifacts/Content/config/hotaArtifacts/tridentOfDominion.json
+++ b/mods/artifacts/Content/config/hotaArtifacts/tridentOfDominion.json
@@ -21,7 +21,7 @@
 		},
 		"text" : {
 			"name" : "Trident of Dominion",
-			"description" : "{Trident of Dominion}\r\n\r\nThis right-handed weapon increases your Attack skill by 7.",
+			"description" : "{Trident of Dominion}\n\nThis right-handed weapon increases your Attack skill by +7.",
 			"event" : "You finally found a well after a long search. Your soldiers could not get the bucket of water out, however. Something was preventing it from coming out. Your banner carrier had to descend in the well himself. It appeared that a trident was blocking the way."
 		}
 	}

--- a/mods/artifacts/Content/config/hotaArtifacts/wayfarerBoots.json
+++ b/mods/artifacts/Content/config/hotaArtifacts/wayfarerBoots.json
@@ -20,7 +20,7 @@
 		},
 		"text" : {
 			"name" : "Wayfarer's Boots",
-			"description" : "{Wayfarer's Boots}\r\n\r\nWorn on the feet, these boots allow your hero to move over rough terrain without penalty.",
+			"description" : "{Wayfarer's Boots}\n\nWorn on the feet, these boots remove movement penalty on rough terrains, allowing to move at 100% cost on any terrain.",
 			"event" : "You meet a wanderer in rugs on a shallow path. He offers you to exchange your cape for his old boots. You agree without much of enthusiasm. As he disappears over the horizon you realize the advantage of the transaction."
 		}
 	}

--- a/mods/cannon/Content/config/hotaCannon/cannonArtifact.json
+++ b/mods/cannon/Content/config/hotaCannon/cannonArtifact.json
@@ -9,7 +9,7 @@
 		"value" : 4000,
 		"text" : {
 			"name" : "Cannon",
-			"description" : "{Cannon}\r\n\r\nUse this war machine to target your enemy troops and fortifications in combat.",
+			"description" : "{Cannon}\n\nUse this war machine to target your enemy troops and fortifications in combat.",
 			"event" : "Lucky you, you've found a shiny and unused cannon :)"
 		},
 		"graphics" : {

--- a/mods/gameBalance/mods/artifacts/content/config/hotaGameBalance/artifacts.json
+++ b/mods/gameBalance/mods/artifacts/content/config/hotaGameBalance/artifacts.json
@@ -1,52 +1,55 @@
 {
 	// 1.8.0
 	// [-] 5/10/15/30% Necromancy boost values are back for the Amulet of the Undertaker, Vampire's Cowl, Dead Man's Boots, and Cloak of the Undead King (instead of 2.5/5/7.5/15%)
-	//	"core:amuletOfTheUndertaker" : {
-	//		"text" : {
-	//			"description" : "{Amulet of the Undertaker}\n\nWorn about the neck, this amulet increases your Necromancy skill by 3%."
-	//		},
-	//		"bonuses" : {
-	//			"necromancy" : {
-	//				"type" : "UNDEAD_RAISE_PERCENTAGE",
-	//				"val" : 3, // NOTE: should be 2.5%
-	//				"valueType" : "ADDITIVE_VALUE"
-	//			}
-	//		}
-	//	},
-	//	"core:vampiresCowl" : {
-	//		"text" : {
-	//			"description" : "{Vampire's Cowl}\n\nWorn about the shoulders, this cowl increases your Necromancy skill by 5%."
-	//		},
-	//		"bonuses" : {
-	//			"necromancy" : {
-	//				"type" : "UNDEAD_RAISE_PERCENTAGE",
-	//				"val" : 5,
-	//				"valueType" : "ADDITIVE_VALUE"
-	//			}
-	//		}
-	//	},
-	//	"core:deadMansBoots" : {
-	//		"text" : {
-	//			"description" : "{Dead Man's Boots}\n\nWorn on the feet, these boots increase your Necromancy skill by 7%."
-	//		},
-	//		"bonuses" : {
-	//			"necromancy" : {
-	//				"type" : "UNDEAD_RAISE_PERCENTAGE",
-	//				"val" : 7, // NOTE: should be 7.5%
-	//				"valueType" : "ADDITIVE_VALUE"
-	//			}
-	//		}
-	//	},
-	"core:cloakOfTheUndeadKing" : {
-		"text" : {
-			"description" : "{Cloak of the Undead King}\n\n30% of battlefield dead are resurrected as Skeletons. If hero already has the Necromancy skill then the percentages are added to the skill and the level of skill determines what type is resurrected.\nBasic: Zombies\nAdvanced: Wights\nExpert: Liches"
-		}
-	},
+//	"core:amuletOfTheUndertaker" : {
+//		"text" : {
+//			"description" : "{Amulet of the Undertaker}\n\nWorn about the neck, this amulet increases your Necromancy skill by 3%."
+//		},
+//		"bonuses" : {
+//			"necromancy" : {
+//				"type" : "UNDEAD_RAISE_PERCENTAGE",
+//				"val" : 3, // NOTE: should be 2.5%
+//				"valueType" : "ADDITIVE_VALUE"
+//			}
+//		}
+//	},
+//	"core:vampiresCowl" : {
+//		"text" : {
+//			"description" : "{Vampire's Cowl}\n\nWorn about the shoulders, this cowl increases your Necromancy skill by 5%."
+//		},
+//		"bonuses" : {
+//			"necromancy" : {
+//				"type" : "UNDEAD_RAISE_PERCENTAGE",
+//				"val" : 5,
+//				"valueType" : "ADDITIVE_VALUE"
+//			}
+//		}
+//	},
+//	"core:deadMansBoots" : {
+//		"text" : {
+//			"description" : "{Dead Man's Boots}\n\nWorn on the feet, these boots increase your Necromancy skill by 7%."
+//		},
+//		"bonuses" : {
+//			"necromancy" : {
+//				"type" : "UNDEAD_RAISE_PERCENTAGE",
+//				"val" : 7, // NOTE: should be 7.5%
+//				"valueType" : "ADDITIVE_VALUE"
+//			}
+//		}
+//	},
+//	"core:cloakOfTheUndeadKing" : {
+//		"text" : {
+//			"description" : "{Cloak of the Undead King}\n\n15% of battlefield dead are resurrected as Skeletons. If hero already has the Necromancy skill then the percentages are added to the skill and the level of skill determines what type is resurrected.\nBasic: Zombies\nAdvanced: Wights\nExpert: Liches"
+//		}
+//	},
 	"core:bootsOfSpeed" : {
 		"bonuses" : {
 			"movement" : {
 				"val" : 400
 			}
+		},
+		"text" : {
+			"description" : "{Boots of Speed}\n\nWorn on the feet, these boots increase your hero's movement rate over land by 400 points."
 		}
 	},
 	"core:equestriansGloves" : {
@@ -54,6 +57,9 @@
 			"movement" : {
 				"val" : 200
 			}
+		},
+		"text" : {
+			"description" : "{Equestrian's Gloves}\n\nWorn on the hands, these gloves increase your hero's movement rate over land by 200 points."
 		}
 	},
 	"core:badgeOfCourage" : {
@@ -76,7 +82,7 @@
 			}
 		},
 		"text" : {
-			"description" : "{Angelic Alliance}\n\nAllows Castle, Rampart, Tower, Fortress, Stronghold, Conflux, Cove, Factory, and Bulwark creatures to be mixed without a morale penalty.\nCasts Expert Prayer for 10 rounds at the start of combat.\nIf there are any evil creatures in the hero's army, morale is reduced by 1."
+			"description" : "{Angelic Alliance}\n\nCounting component effects the Angelic Alliance gives hero +21 to all primary skills and grants each army of player to mix good and neutral town creatures without morale penalty. At the beginning of each combat the Angelic Alliance will cast Expert Prayer for 10 rounds."
 		}
 	},
 	// 1.7.2:

--- a/mods/gameBalance/mods/spells/content/config/hotaGameBalance/spells.json
+++ b/mods/gameBalance/mods/spells/content/config/hotaGameBalance/spells.json
@@ -9,7 +9,14 @@
 					}
 				}
 			},
+			"none" : {
+				"description" : "{Protection from Air}\n\nProtects the selected friendly unit, reducing damage received from Air spells by 50%. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Protection from Air}\n\nProtects the selected friendly unit, reducing damage received from Air spells by 50%. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
 			"advanced" : {
+				"description" : "{Advanced Protection from Air}\n\nProtects the selected friendly unit, reducing damage received from Air spells by 75%. Spell is active for number of rounds equal to hero Spell Power.\n",
 				"effects" : {
 					"spellDamageReduction" : {
 						"val" : 75
@@ -17,6 +24,7 @@
 				}
 			},
 			"expert" : {
+				"description" : "{Expert Protection from Air}\n\nProtects all friendly units, reducing damage received from Air spells by 75%. Spell is active for number of rounds equal to hero Spell Power.\n",
 				"effects" : {
 					"spellDamageReduction" : {
 						"val" : 75
@@ -34,7 +42,14 @@
 					}
 				}
 			},
+			"none" : {
+				"description" : "{Protection from Earth}\n\nProtects the selected friendly unit, reducing damage received from Earth spells by 50%. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Protection from Earth}\n\nProtects the selected friendly unit, reducing damage received from Earth spells by 50%. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
 			"advanced" : {
+				"description" : "{Advanced Protection from Earth}\n\nProtects the selected friendly unit, reducing damage received from Earth spells by 75%. Spell is active for number of rounds equal to hero Spell Power.\n",
 				"effects" : {
 					"spellDamageReduction" : {
 						"val" : 75
@@ -42,6 +57,7 @@
 				}
 			},
 			"expert" : {
+				"description" : "{Expert Protection from Earth}\n\nProtects all friendly units, reducing damage received from Earth spells by 75%. Spell is active for number of rounds equal to hero Spell Power.\n",
 				"effects" : {
 					"spellDamageReduction" : {
 						"val" : 75
@@ -59,7 +75,14 @@
 					}
 				}
 			},
+			"none" : {
+				"description" : "{Protection from Fire}\n\nProtects the selected friendly unit, reducing damage received from Fire spells by 50%. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Protection from Fire}\n\nProtects the selected friendly unit, reducing damage received from Fire spells by 50%. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
 			"advanced" : {
+				"description" : "{Advanced Protection from Fire}\n\nProtects the selected friendly unit, reducing damage received from Fire spells by 75%. Spell is active for number of rounds equal to hero Spell Power.\n",
 				"effects" : {
 					"spellDamageReduction" : {
 						"val" : 75
@@ -67,6 +90,7 @@
 				}
 			},
 			"expert" : {
+				"description" : "{Expert Protection from Fire}\n\nProtects all friendly units, reducing damage received from Fire spells by 75%. Spell is active for number of rounds equal to hero Spell Power.\n",
 				"effects" : {
 					"spellDamageReduction" : {
 						"val" : 75
@@ -84,7 +108,14 @@
 					}
 				}
 			},
+			"none" : {
+				"description" : "{Protection from Water}\n\nProtects the selected friendly unit, reducing damage received from Water spells by 50%. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Protection from Water}\n\nProtects the selected friendly unit, reducing damage received from Water spells by 50%. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
 			"advanced" : {
+				"description" : "{Advanced Protection from Water}\n\nProtects the selected friendly unit, reducing damage received from Water spells by 75%. Spell is active for number of rounds equal to hero Spell Power.\n",
 				"effects" : {
 					"spellDamageReduction" : {
 						"val" : 75
@@ -92,6 +123,7 @@
 				}
 			},
 			"expert" : {
+				"description" : "{Expert Protection from Water}\n\nProtects all friendly units, reducing damage received from Water spells by 75%. Spell is active for number of rounds equal to hero Spell Power.\n",
 				"effects" : {
 					"spellDamageReduction" : {
 						"val" : 75
@@ -102,7 +134,21 @@
 	},
 	// The damage of Armageddon spell reduced form 50*(spell power) + 30/30/60/120 to 40*(spell power) + 30/30/60/120
 	"core:armageddon" : {
-		"power" : 40
+		"power" : 40,
+		"levels" : {
+			"none" : {
+				"description" : "{Armageddon}\n\nRains fire down upon the battlefield, damaging all units for (Spell Power x 40 + 30) hit points.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Armageddon}\n\nRains fire down upon the battlefield, damaging all units for (Spell Power x 40 + 30) hit points.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Armageddon}\n\nRains fire down upon the battlefield, damaging all units for (Spell Power x 40 + 60) hit points.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Armageddon}\n\nRains fire down upon the battlefield, damaging all units for (Spell Power x 40 + 120) hit points.\n"
+			}
+		}
 	},
 
 	"core:slow" : {
@@ -128,8 +174,14 @@
 					}
 				}
 			},
-
+			"none" : {
+				"description" : "{Slow}\n\nReduces the speed of the selected enemy unit by the formula (old speed x 0.75). Removes Haste effect. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Slow}\n\nReduces the speed of the selected enemy unit by the formula (old speed x 0.75). Removes Haste effect. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
 			"advanced" : {
+				"description" : "{Advanced Slow}\n\nReduces the speed of the selected enemy unit by the formula (old speed x 0.5 + 1). Removes Haste effect. Spell is active for number of rounds equal to hero Spell Power.\n",
 				"effects" : {
 					"stacksSpeed" : {
 						"val" : -50
@@ -141,6 +193,7 @@
 			},
 
 			"expert" : {
+				"description" : "{Expert Slow}\n\nReduces the speed of all enemy units by the formula (old speed x 0.5 + 1). Removes Haste effect. Spell is active for number of rounds equal to hero Spell Power.\n",
 				"range" : "X",
 				"effects" : {
 					"stacksSpeed" : {
@@ -167,16 +220,20 @@
 				}
 			},
 			"none" : {
-				"power" : 70
+				"power" : 70,
+				"description" : "{Summon Fire Elemental}\n\nAllows you to summon (Spell Power x 2) fire elementals on the random position of your edge of the battlefield. Elementals will serve you until the end of the battle.\n"
 			},
 			"basic" : {
-				"power" : 70
+				"power" : 70,
+				"description" : "{Basic Summon Fire Elemental}\n\nAllows you to summon (Spell Power x 2) fire elementals on the random position of your edge of the battlefield. Elementals will serve you until the end of the battle.\n"
 			},
 			"advanced" : {
-				"power" : 88
+				"power" : 88,
+				"description" : "{Advanced Summon Fire Elemental}\n\nAllows you to summon (Spell Power x 2.5) fire elementals on the random position of your edge of the battlefield. Elementals will serve you until the end of the battle.\n"
 			},
 			"expert" : {
-				"power" : 105
+				"power" : 105,
+				"description" : "{Expert Summon Fire Elemental}\n\nAllows you to summon (Spell Power x 3) fire elementals on the random position of your edge of the battlefield. Elementals will serve you until the end of the battle.\n"
 			}
 		}
 	},
@@ -191,16 +248,20 @@
 				}
 			},
 			"none" : {
-				"power" : 80
+				"power" : 80,
+				"description" : "{Summon Earth Elemental}\n\nAllows you to summon (Spell Power x 2) earth elementals on the random position of your edge of the battlefield. Elementals will serve you until the end of the battle.\n"
 			},
 			"basic" : {
-				"power" : 80
+				"power" : 80,
+				"description" : "{Basic Summon Earth Elemental}\n\nAllows you to summon (Spell Power x 2) earth elementals on the random position of your edge of the battlefield. Elementals will serve you until the end of the battle.\n"
 			},
 			"advanced" : {
-				"power" : 100
+				"power" : 100,
+				"description" : "{Advanced Summon Earth Elemental}\n\nAllows you to summon (Spell Power x 2.5) earth elementals on the random position of your edge of the battlefield. Elementals will serve you until the end of the battle.\n"
 			},
 			"expert" : {
-				"power" : 120
+				"power" : 120,
+				"description" : "{Expert Summon Earth Elemental}\n\nAllows you to summon (Spell Power x 3) earth elementals on the random position of your edge of the battlefield. Elementals will serve you until the end of the battle.\n"
 			}
 		}
 	},
@@ -212,6 +273,18 @@
 						"exclusive" : false
 					}
 				}
+			},
+			"none" : {
+				"description" : "{Summon Water Elemental}\n\nAllows you to summon (Spell Power x 2) water elementals on the random position of your edge of the battlefield. Elementals will serve you until the end of the battle.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Summon Water Elemental}\n\nAllows you to summon (Spell Power x 2) water elementals on the random position of your edge of the battlefield. Elementals will serve you until the end of the battle.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Summon Water Elemental}\n\nAllows you to summon (Spell Power x 3) water elementals on the random position of your edge of the battlefield. Elementals will serve you until the end of the battle.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Summon Water Elemental}\n\nAllows you to summon (Spell Power x 4) water elementals on the random position of your edge of the battlefield. Elementals will serve you until the end of the battle.\n"
 			}
 		}
 	},
@@ -223,6 +296,18 @@
 						"exclusive" : false
 					}
 				}
+			},
+			"none" : {
+				"description" : "{Summon Air Elemental}\n\nAllows you to summon (Spell Power x 2) air elementals on the random position of your edge of the battlefield. Elementals will serve you until the end of the battle.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Summon Air Elemental}\n\nAllows you to summon (Spell Power x 2) air elementals on the random position of your edge of the battlefield. Elementals will serve you until the end of the battle.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Summon Air Elemental}\n\nAllows you to summon (Spell Power x 3) air elementals on the random position of your edge of the battlefield. Elementals will serve you until the end of the battle.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Summon Air Elemental}\n\nAllows you to summon (Spell Power x 4) air elementals on the random position of your edge of the battlefield. Elementals will serve you until the end of the battle.\n"
 			}
 		}
 	},
@@ -238,6 +323,22 @@
 	// HotA 1.7.0: [+] Wall of Fire: Power damage multiplier increased from 10 to 15
 	"core:fireWallTrigger" : {
 		"power" : 15
+	},
+	"core:fireWall" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Fire Wall}\n\nPlaces a 2-hex wildfire on the battlefield at a point specified by the caster for 2 rounds. Any units passing through the wall take (Spell Power x 15 + 10) damage.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Fire Wall}\n\nPlaces a 2-hex wildfire on the battlefield at a point specified by the caster for 2 rounds.  Any units passing through the wall take (Spell Power x 15 + 10) damage.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Fire Wall}\n\nPlaces a 3-hex wildfire on the battlefield at a point specified by the caster for 2 rounds.  Any units passing through the wall take (Spell Power x 15 + 20) damage.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Fire Wall}\n\nPlaces a 3-hex wildfire on the battlefield at a point specified by the caster for 2 rounds.  Any units passing through the wall take (Spell Power x 15 + 50) damage.\n"
+			}
+		}
 	},
 	"core:forgetfulness" : {
 		"levels" : {

--- a/mods/gameBalance/mods/spells/mod.json
+++ b/mods/gameBalance/mods/spells/mod.json
@@ -4,7 +4,7 @@
 	"modType" : "Mechanics",
 	"author" : "Kuririn, avatar, wnukos",
 	"contact" : "http://forum.df2.ru/index.php?showtopic=32286",
-	"version" : "1.3.12",
+	"version" : "1.3.13",
 	"settings" : {
 		"spells" : {
 			"dimensionDoorTriggersGuards" : true

--- a/mods/heroes3DataPatch/content/config/heroes3DataPatch/artifactDescriptions.json
+++ b/mods/heroes3DataPatch/content/config/heroes3DataPatch/artifactDescriptions.json
@@ -1,0 +1,172 @@
+{
+	"core:centaurAxe" : {
+		"text": {
+			"description" : "{Centaur's Axe}\n\nThis right-handed weapon increases your Attack skill by +2."
+		}
+	},
+	"core:blackshardOfTheDeadKnight" : {
+		"text": {
+			"description" : "{Blackshard of the Dead Knight}\n\nThis right-handed weapon increases your Attack skill by +3."
+		}
+	},
+	"core:greaterGnollsFlail" : {
+		"text": {
+			"description" : "{Greater Gnoll's Flail}\n\nThis right-handed weapon increases your Attack skill by +4."
+		}
+	},
+	"core:ogresClubOfHavoc" : {
+		"text": {
+			"description" : "{Ogre's Club of Havoc}\n\nThis right-handed weapon increases your Attack skill by +5."
+		}
+	},
+	"core:swordOfHellfire" : {
+		"text": {
+			"description" : "{Sword of Hellfire}\n\nThis right-handed weapon increases your Attack skill by +6."
+		}
+	},
+	"core:shieldOfTheDwarvenLords" : {
+		"text": {
+			"description" : "{Shield of the Dwarven Lords}\n\nThis left-handed item increases your Defense skill by +2."
+		}
+	},
+	"core:shieldOfTheYawningDead" : {
+		"text": {
+			"description" : "{Shield of the Yawning Dead}\n\nThis left-handed item increases your Defense skill by +3."
+		}
+	},
+	"core:bucklerOfTheGnollKing" : {
+		"text": {
+			"description" : "{Buckler of the Gnoll King}\n\nThis left-handed item increases your Defense skill by +4."
+		}
+	},
+	"core:targOfTheRampagingOgre" : {
+		"text": {
+			"description" : "{Targ of the Rampaging Ogre}\n\nThis left-handed item increases your Defense skill by +5."
+		}
+	},
+	"core:shieldOfTheDamned" : {
+		"text": {
+			"description" : "{Shield of the Damned}\n\nThis left-handed item increases your Defense skill by +6."
+		}
+	},
+	"core:garnitureOfInterference" : {
+		"text": {
+			"description" : "{Garniture of Interference}\n\nWorn about the neck, this item increases your chance to resist a hostile spell by 5%."
+		}
+	},
+	"core:surcoatOfCounterpoise" : {
+		"text": {
+			"description" : "{Surcoat of Counterpoise}\n\nWorn about the shoulders, this item increases your chance to resist a hostile spell by 10%."
+		}
+	},
+	"core:bootsOfPolarity" : {
+		"text": {
+			"description" : "{Boots of Polarity}\n\nWorn on the feet, these boots increases your chance to resist a hostile spell by 15%."
+		}
+	},
+	"core:statesmansMedal" : {
+		"text": {
+			"description" : "{Statesman's Medal}\n\nWorn about the neck, the Statesman's Medal reduces the cost of surrendering by 10%."
+		}
+	},
+	"core:diplomatsRing" : {
+		"text": {
+			"description" : "{Diplomat's Ring}\n\nWorn on the finger, the Diplomat's Ring reduces the cost of surrendering by 10%."
+		}
+	},
+	"core:ambassadorsSash" : {
+		"text": {
+			"description" : "{Ambassador's Sash}\n\nWorn about the shoulders, the Ambassador's Sash reduces the cost of surrendering by 10%."
+		}
+	},
+	"core:necklaceOfOceanGuidance" : {
+		"text": {
+			"description" : "{Necklace of Ocean Guidance}\n\nWorn about the neck, this necklace increases your hero's movement rate at sea by 1000 points."
+		}
+	},
+	"core:spiritOfOppression" : {
+		"text": {
+			"description" : "{Spirit of Oppression}\n\nThis item negates positive morale during combat for both you and your opponent."
+		}
+	},
+	"core:hourglassOfTheEvilHour" : {
+		"text": {
+			"description" : "{Hourglass of the Evil Hour}\n\nThis item negates positive luck during combat for both you and your opponent."
+		}
+	},
+	"core:orbOfVulnerability" : {
+		"text": {
+			"description" : "{Orb of Vulnerability}\n\nDuring combat, this orb negates natural magic immunities and chances to resist spells of all creatures on the battlefield. Does not affect the limitations on applicability stated in spell descriptions as well as the immunities given by artifacts."
+		}
+	},
+	"core:seaCaptainsHat" : {
+		"text": {
+			"description" : "{Sea Captain's Hat}\n\nWhen worn, this hat increases your movement at sea by 500 points, allows you to summon and destroy boats, and protects you from whirlpools."
+		}
+	},
+	"core:shacklesOfWar" : {
+		"text": {
+			"description" : "{Shackles of War}\n\nWhen these shackles are wielded in combat between two heroes, neither you nor your opponent may retreat or surrender."
+		}
+	},
+	"core:armageddonsBlade" : {
+		"text": {
+			"description" : "{Armageddon's Blade}\n\n+3 Attack. +3 Defense. +3 Power. +6 Knowledge. Places Expert Armageddon Spell in your hero's spell book. All allied creatures become immune to Armageddon."
+		}
+	},
+	"core:cloakOfTheUndeadKing" : {
+		"text" : {
+			"description" : "{Cloak of the Undead King}\n\nIf hero does not have the Necromancy skill the Cloak of the Undead King will raise 30% of the battlefield dead enemies as Skeletons. If hero already has the Necromancy skill then, counting component effects, this cloak  increases the Necromancy skill by 30% and allows to raise stronger undead units. The level of skill determines what type is resurrected.\nBasic: Zombies\nAdvanced: Wights\nExpert: Liches"
+		}
+	},
+	"core:elixirOfLife" : {
+		"text": {
+			"description" : "{Elixir of Life}\n\nCounting component effects the Elixir of Life increases health of all units in the Hero's ranks by +4 and additionally gives all living creatures a 25% bonus to their health and gain the ability to regenerate 50 hit points each round."
+		}
+	},
+	"core:armorOfTheDamned" : {
+		"text": {
+			"description" : "{Armor of the Damned}\n\nCounting component effects the Armor of the Damned gives hero +3 Attack, +3 Defence, +2 Power, and +2 Knowledge. Casts these spells on expert level at the beginning of combat on all of your opponent's creatures for 50 rounds: Slow, Curse, Weakness, and Misfortune."
+		}
+	},
+	"core:statueOfLegion" : {
+		"text": {
+			"description" : "{Statue of Legion}\n\nCounting component effects the Statue of Legion increases the growth of level 2/3/4/5/6 creatures by 5/4/3/2/1 correspondingly for the town hero is currently located. Moreover, the statue gives you +50% creature growth for all towns (this counts Castle growth bonus, but does not include flagged structures or other like bonuses)."
+		}
+	},
+	"core:powerOfTheDragonFather" : {
+		"text": {
+			"description" : "{Power of the Dragon Father}\n\nCounting component effects the Power of the Dragon Father gives hero +16 to all primary skills, and +1 to morale and luck. The hero's troops become immune to all level 1-4 spells except Dispel."
+		}
+	},
+	"core:titansThunder" : {
+		"text": {
+			"description" : "{Titan's Thunder}\n\nCounting component effects the Titan's Thunder gives hero +9 Attack, +9 Defence, +8 Power, and +8 Knowledge. Gives the hero the Titan's Lightning Bolt spell that causes 600 points of damage and does not cost any spell points. If the hero does not have a spell book, then one will be permanently added."
+		}
+	},
+	"core:admiralsHat" : {
+		"text": {
+			"description" : "{Admiral's Hat}\n\nCounting component effects Admiral's Hat increases your movement at sea by 1500 points, allows you to summon and destroy boats, and protects you from whirlpools. Moreover, the hat will remove the Boarding and Unboarding ship penalty, converting the hero’s movement points between Land and Water."
+		}
+	},
+	"core:bowOfTheSharpshooter" : {
+		"text": {
+			"description" : "{Bow of the Sharpshooter}\n\nCounting component effects the Bow of the Sharpshooter increases hero Archery skill by 30%. Allows ranged shooters fire projectiles while adjacent to an enemy creature. Removes archery penalty for range or obstacle."
+		}
+	},
+	"core:wizardsWell" : {
+		"text": {
+			"description" : "{Wizard's Well}\n\nRegenerates all spell points each day."
+		}
+	},
+	"core:ringOfTheMagi" : {
+		"text": {
+			"description" : "{Ring of the Magi}\n\nCounting component effects this ring adds 56 rounds to spell duration."
+		}
+	},
+	"core:cornucopia" : {
+		"text": {
+			"description" : "{Cornucopia}\n\nCounting component effects this item generates +5 Mercury, Sulfur, Crystals, and Gems, each day."
+		}
+	}
+}

--- a/mods/heroes3DataPatch/content/config/heroes3DataPatch/spellDescriptions.json
+++ b/mods/heroes3DataPatch/content/config/heroes3DataPatch/spellDescriptions.json
@@ -1,0 +1,930 @@
+{
+	"core:summonBoat" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Summon Boat}\n\nSummons an existing, neutral or own, unoccupied boat from anywhere in the world to your location.\n\nChances for success are 50%.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Summon Boat}\n\nSummons an existing, neutral or own, unoccupied boat from anywhere in the world to your location.\n\nChances for success are 50%.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Summon Boat}\n\nSummons an existing, neutral or own, unoccupied boat from anywhere in the world to your location.  If no such boats exist, one is created.\n\nChances for success are 75%.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Summon Boat}\n\nSummons an existing, neutral or own, unoccupied boat from anywhere in the world to your location.  If no such boats exist, one is created.\n"
+			}
+		}
+	},
+	"core:scuttleBoat" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Scuttle Boat}\n\nDestroys a boat of caster's choice in hero visibility zone.  Use with caution, the effects are permanent.\n\nChances for success are 50%.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Scuttle Boat}\n\nDestroys a boat of caster's choice in hero visibility zone.  Use with caution, the effects are permanent.\n\nChances for success are 50%.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Scuttle Boat}\n\nDestroys a boat of caster's choice in hero visibility zone.  Use with caution, the effects are permanent.\n\nChances for success are 75%.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Scuttle Boat}\n\nDestroys a boat of caster's choice in hero visibility zone.  Use with caution, the effects are permanent.\n"
+			}
+		}
+	},
+	"core:visions" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Visions}\n\nProvides you with exact numbers of wandering monsters and tells you if they would be willing to join your hero, flee or be acquired via Diplomacy skill (exact fee will be revealed). Range is equal to Spell Power or three, whichever is greater. Valid for 1 turn.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Visions}\n\nProvides you with exact numbers of wandering monsters and tells you if they would be willing to join your hero, flee or be acquired via Diplomacy skill (exact fee will be revealed). Range is equal to Spell Power or three, whichever is greater. Valid for 1 turn.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Visions}\n\nProvides you with exact numbers of wandering monsters and tells you if they would be willing to join your hero, flee or be acquired via Diplomacy skill (exact fee will be revealed).  Allows you to view a nearby enemy hero's general statistics, creature type and quantity, as if the hero was part of your kingdom. Range is (Spell Power x 2) or three, whichever is greater. Valid for 1 turn.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Visions}\n\nProvides you with exact numbers of wandering monsters and tells you if they would be willing to join your hero, flee or be acquired via Diplomacy skill (exact fee will be revealed).  Allows you to view a nearby enemy hero's general statistics, creature type and quantity, as if the hero was part of your kingdom, as well as a nearby town's statistics, garrison creatures and quantity. Range is (Spell Power x 3) or three, whichever is greater. Valid for 1 turn.\n"
+			}
+		}
+	},
+	"core:viewEarth" : {
+		"levels" : {
+			"none" : {
+				"description" : "{View Earth}\n\nReveals the location of all resources to the caster. After casting, the information can be accessed through View World window until the end of the turn.\n"
+			},
+			"basic" : {
+				"description" : "{Basic View Earth}\n\nReveals the location of all resources to the caster. After casting, the information can be accessed through View World window until the end of the turn.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced View Earth}\n\nReveals the location of all resources and mines to the caster. After casting, the information can be accessed through View World window until the end of the turn.\n"
+			},
+			"expert" : {
+				"description" : "{Expert View Earth}\n\nReveals the location of all resources and mines and reveals all terrain to the caster. After casting, the information can be accessed through View World window until the end of the turn.\n"
+			}
+		}
+	},
+	"core:disguise" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Disguise}\n\nMakes all units in your hero army look like your most powerful unit to enemies trying to view your hero for 1 turn.  Numbers in each group are unchanged.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Disguise}\n\nMakes all units in your hero army look like your most powerful unit to enemies trying to view your hero for 1 turn.  Numbers in each group are unchanged.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Disguise}\n\nMakes all units in your hero army look like your most powerful unit to enemies trying to view your hero for 1 turn.  Numbers in each group appear as zero.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Disguise}\n\nMakes all units in your hero army look like the most powerful unit affiliated to player starting town to enemies trying to view your hero for 1 turn.  Numbers in each group appear as zero.\n"
+			}
+		}
+	},
+	"core:viewAir" : {
+		"levels" : {
+			"none" : {
+				"description" : "{View Air}\n\nReveals the location of all unclaimed artifacts to the caster. After casting, the information can be accessed through View World window until the end of the turn.\n"
+			},
+			"basic" : {
+				"description" : "{Basic View Air}\n\nReveals the location of all unclaimed artifacts to the caster. After casting, the information can be accessed through View World window until the end of the turn.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced View Air}\n\nReveals the location of all unclaimed artifacts, plus enemy heroes to the caster. After casting, the information can be accessed through View World window until the end of the turn.\n"
+			},
+			"expert" : {
+				"description" : "{Expert View Air}\n\nReveals the location of all unclaimed artifacts, plus enemy heroes and all towns to the caster. After casting, the information can be accessed through View World window until the end of the turn.\n"
+			}
+		}
+	},
+	"core:fly" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Fly}\n\nAllows your army to fly over obstacles and rough terrain with 40% penalty to movement cost. Valid for 1 turn. You must land at the end of the turn.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Fly}\n\nAllows your army to fly over obstacles and rough terrain with 40% penalty to movement cost. Valid for 1 turn. You must land at the end of the turn.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Fly}\n\nAllows your army to fly over obstacles and rough terrain with 20% penalty to movement cost. Valid for 1 turn. You must land at the end of the turn.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Fly}\n\nAllows your army to fly over obstacles and rough terrain without any penalty. Valid for 1 turn. You must land at the end of the turn.\n"
+			}
+		}
+	},
+	"core:waterWalk" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Water Walk}\n\nAllows your army to walk across bodies of water with 40% penalty to movement cost. Valid for 1 turn. You must end your movement on dry land.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Water Walk}\n\nAllows your army to walk across bodies of water with 40% penalty to movement cost. Valid for 1 turn. You must end your movement on dry land.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Water Walk}\n\nAllows your army to walk across bodies of water with 20% penalty to movement cost. Valid for 1 turn. You must end your movement on dry land.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Water Walk}\n\nAllows your army to walk across bodies of water without any penalty. Valid for 1 turn. You must end your movement on dry land.\n"
+			}
+		}
+	},
+	"core:dimensionDoor" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Dimension Door}\n\nOnce per day (for each hero), you may teleport your hero to an unoccupied location on the adventure map in hero visibility zone. This spends 300 movement points.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Dimension Door}\n\nTwice per day (for each hero), you may teleport your hero to an unoccupied location on the adventure map in hero visibility zone. This spends 300 movement points.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Dimension Door}\n\nThree times per day (for each hero), you may teleport your hero to an unoccupied location on the adventure map in hero visibility zone. This spends 300 movement points.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Dimension Door}\n\nFour times per day (for each hero), you may teleport your hero to an unoccupied location on the adventure map in hero visibility zone. This spends 200 movement points.\n"
+			}
+		}
+	},
+	"core:townPortal" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Town Portal}\n\nTeleports your hero to the nearest friendly town. Requires 300 movement points. The town must be unoccupied.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Town Portal}\n\nTeleports your hero to the nearest friendly town. Requires 300 movement points. The town must be unoccupied.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Town Portal}\n\nTeleports your hero to any chosen friendly town. Requires 300 movement points. The town must be unoccupied.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Town Portal}\n\nTeleports your hero to any chosen friendly town. Requires 200 movement points. The town must be unoccupied.\n"
+			}
+		}
+	},
+	"core:quicksand" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Quicksand}\n\nRandomly places four small patches of quicksand on the battlefield which are only visible to the caster and creatures native to the terrain.  Walking into quicksand ends a non-flying unit's movement for the turn and makes quicksand visible to all. Quicksand duration is unlimited.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Quicksand}\n\nRandomly places four small patches of quicksand on the battlefield which are only visible to the caster and creatures native to the terrain.  Walking into quicksand ends a non-flying unit's movement for the turn and makes quicksand visible to all. Quicksand duration is unlimited.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Quicksand}\n\nRandomly places six small patches of quicksand on the battlefield which are only visible to the caster and creatures native to the terrain.  Walking into quicksand ends a non-flying unit's movement for the turn and makes quicksand visible to all. Quicksand duration is unlimited.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Quicksand}\n\nRandomly places eight small patches of quicksand on the battlefield which are only visible to the caster and creatures native to the terrain.  Walking into quicksand ends a non-flying unit's movement for the turn and makes quicksand visible to all. Quicksand duration is unlimited.\n"
+			}
+		}
+	},
+	"core:landMine" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Land Mine}\n\nRandomly places four small areas of landmines on the battlefield which are only visible to the caster and creatures native to the terrain.  It inflicts (Spell Power x 10 + 25) damage to any unit walking over it, which doesn’t see it, and disappears. Otherwise landmine duration is unlimited.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Land Mine}\n\nRandomly places four small areas of landmines on the battlefield which are only visible to the caster and creatures native to the terrain.  It inflicts (Spell Power x 10 + 25) damage to any unit walking over it, which doesn’t see it, and disappears. Otherwise landmine duration is unlimited.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Land Mine}\n\nRandomly places six small areas of landmines on the battlefield which are only visible to the caster and creatures native to the terrain.  It inflicts (Spell Power x 10 + 50) damage to any unit walking over it, which doesn’t see it, and disappears. Otherwise landmine duration is unlimited.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Land Mine}\n\nRandomly places eight small areas of landmines on the battlefield which are only visible to the caster and creatures native to the terrain.  It inflicts (Spell Power x 10 + 100) damage to any unit walking over it, which doesn’t see it, and disappears. Otherwise landmine duration is unlimited.\n"
+			}
+		}
+	},
+	"core:forceField" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Force Field}\n\nPlaces a 2-hex Force Field on the battlefield at a point specified by the caster for 2 rounds. Movement through these hexes is blocked.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Force Field}\n\nPlaces a 2-hex Force Field on the battlefield at a point specified by the caster for 2 rounds. Movement through these hexes is blocked.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Force Field}\n\nPlaces a 3-hex Force Field on the battlefield at a point specified by the caster for 2 rounds. Movement through these hexes is blocked.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Force Field}\n\nPlaces a 3-hex Force Field on the battlefield at a point specified by the caster for 2 rounds. Movement through these hexes is blocked.\n"
+			}
+		}
+	},
+	"core:earthquake" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Earthquake}\n\nRandomly damages two sections of castle wall, gate or tower in combat.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Earthquake}\n\nRandomly damages two sections of castle wall, gate or tower in combat.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Earthquake}\n\nRandomly damages three sections of castle wall, gate or tower in combat.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Earthquake}\n\nRandomly damages four sections of castle wall, gate or tower in combat.\n"
+			}
+		}
+	},
+	"core:magicArrow" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Magic Arrow}\n\nCauses a bolt of magical energy to strike the selected enemy unit. Inflicts (Spell Power x 10 + 10) damage.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Magic Arrow}\n\nCauses a bolt of magical energy to strike the selected enemy unit. Inflicts (Spell Power x 10 + 10) damage.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Magic Arrow}\n\nCauses a bolt of magical energy to strike the selected enemy unit. Inflicts (Spell Power x 10 + 20) damage.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Magic Arrow}\n\nCauses a bolt of magical energy to strike the selected enemy unit. Inflicts (Spell Power x 10 + 30) damage.\n"
+			}
+		}
+	},
+	"core:iceBolt" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Ice Bolt}\n\nIce drains the body heat from the selected enemy unit. Inflicts (Spell Power x 20 + 10) damage.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Ice Bolt}\n\nIce drains the body heat from the selected enemy unit. Inflicts (Spell Power x 20 + 10) damage.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Ice Bolt}\n\nIce drains the body heat from the selected enemy unit. Inflicts (Spell Power x 20 + 20) damage.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Ice Bolt}\n\nIce drains the body heat from the selected enemy unit. Inflicts (Spell Power x 20 + 50) damage.\n"
+			}
+		}
+	},
+	"core:lightningBolt" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Lightning Bolt}\n\nCauses a bolt of lightning to strike the selected enemy unit. It takes (Spell Power x 25 + 10) damage.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Lightning Bolt}\n\nCauses a bolt of lightning to strike the selected enemy unit. It takes (Spell Power x 25 + 10) damage.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Lightning Bolt}\n\nCauses a bolt of lightning to strike the selected enemy unit. It takes (Spell Power x 25 + 20) damage.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Lightning Bolt}\n\nCauses a bolt of lightning to strike the selected enemy unit. It takes (Spell Power x 25 + 50) damage.\n"
+			}
+		}
+	},
+	"core:implosion" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Implosion}\n\nInflicts (Spell Power x 75 + 100) damage to a single enemy creature stack. Does not affect War Machines.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Implosion}\n\nInflicts (Spell Power x 75 + 100) damage to a single enemy creature stack. Does not affect War Machines.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Implosion}\n\nInflicts (Spell Power x 75 + 200) damage to a single enemy creature stack. Does not affect War Machines.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Implosion}\n\nInflicts (Spell Power x 75 + 300) damage to a single enemy creature stack. Does not affect War Machines.\n"
+			}
+		}
+	},
+	"core:chainLightning" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Chain Lightning}\n\nFires a bolt of lightning at the selected enemy unit for (Spell Power x 40 + 25) damage which then travels to the nearest adjacent unit, inflicting half damage before traveling to the next adjacent unit, again inflicting half of previous target damage, etc.  Strikes four units.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Chain Lightning}\n\nFires a bolt of lightning at the selected enemy unit for (Spell Power x 40 + 25) damage which then travels to the nearest adjacent unit, inflicting half damage before traveling to the next adjacent unit, again inflicting half of previous target damage, etc.  Strikes four units.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Chain Lightning}\n\nFires a bolt of lightning at the selected enemy unit for (Spell Power x 40 + 50) damage which then travels to the nearest adjacent unit, inflicting half damage before traveling to the next adjacent unit, again inflicting half of previous target damage, etc.  Strikes five units.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Chain Lightning}\n\nFires a bolt of lightning at the selected enemy unit for (Spell Power x 40 + 100) damage which then travels to the nearest adjacent unit, inflicting half damage before traveling to the next adjacent unit, again inflicting half of previous target damage, etc.  Strikes five units.\n"
+			}
+		}
+	},
+	"core:frostRing" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Frost Ring}\n\nIce drains the body heat of any units adjacent to the target location. Each unit takes (Spell Power x 10 + 15) damage. Target hex is unaffected.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Frost Ring}\n\nIce drains the body heat of any units adjacent to the target location. Each unit takes (Spell Power x 10 + 15) damage. Target hex is unaffected.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Frost Ring}\n\nIce drains the body heat of any units adjacent to the target location. Each unit takes (Spell Power x 10 + 30) damage. Target hex is unaffected.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Frost Ring}\n\nIce drains the body heat of any units adjacent to the target location. Each unit takes (Spell Power x 10 + 60) damage. Target hex is unaffected.\n"
+			}
+		}
+	},
+	"core:fireball" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Fireball}\n\nCauses the selected target to burst into flames, inflicting (Spell Power x 10 + 15) fire damage to the target and any units adjacent to target location.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Fireball}\n\nCauses the selected target to burst into flames, inflicting (Spell Power x 10 + 15) fire damage to the target and any units adjacent to target location.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Fireball}\n\nCauses the selected target to burst into flames, inflicting (Spell Power x 10 + 30) fire damage to the target and any units adjacent to target location.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Fireball}\n\nCauses the selected target to burst into flames, inflicting (Spell Power x 10 + 60) fire damage to the target and any units adjacent to target location.\n"
+			}
+		}
+	},
+	"core:inferno" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Inferno}\n\nCauses a huge blast of fire to strike the selected target and any units 1 and 2 hexes away from target location. Each unit takes (Spell Power x 10 + 20) damage.  Don't be near this when it goes off!\n"
+			},
+			"basic" : {
+				"description" : "{Basic Inferno}\n\nCauses a huge blast of fire to strike the selected target and any units 1 and 2 hexes away from target location. Each unit takes (Spell Power x 10 + 20) damage.  Don't be near this when it goes off!\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Inferno}\n\nCauses a huge blast of fire to strike the selected target and any units 1 and 2 hexes away from target location. Each unit takes (Spell Power x 10 + 40) damage.  Don't be near this when it goes off!\n"
+			},
+			"expert" : {
+				"description" : "{Expert Inferno}\n\nCauses a huge blast of fire to strike the selected target and any units 1 and 2 hexes away from target location. Each unit takes (Spell Power x 10 + 80) damage.  Don't be near this when it goes off!\n"
+			}
+		}
+	},
+	"core:meteorShower" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Meteor Shower}\n\nCauses a meteor shower to rain down on the selected target and any units adjacent to target location. Each unit takes (Spell Power x 25 + 25) damage.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Meteor Shower}\n\nCauses a meteor shower to rain down on the selected target and any units adjacent to target location. Each unit takes (Spell Power x 25 + 25) damage.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Meteor Shower}\n\nCauses a meteor shower to rain down on the selected target and any units adjacent to target location. Each unit takes (Spell Power x 25 + 50) damage.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Meteor Shower}\n\nCauses a meteor shower to rain down on the selected target and any units adjacent to target location. Each unit takes (Spell Power x 25 + 100) damage.\n"
+			}
+		}
+	},
+	"core:deathRipple" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Death Ripple}\n\nSends a wave of death across the battlefield which damages all units except undead and War Mañhines for (Spell Power x 5 + 10) hit points.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Death Ripple}\n\nSends a wave of death across the battlefield which damages all units except undead and War Mañhines for (Spell Power x 5 + 10) hit points.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Death Ripple}\n\nSends a wave of death across the battlefield which damages all units except undead and War Mañhines for (Spell Power x 5 + 20) hit points.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Death Ripple}\n\nSends a wave of death across the battlefield which damages all units except undead and War Mañhines for (Spell Power x 5 + 30) hit points.\n"
+			}
+		}
+	},
+	"core:destroyUndead" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Destroy Undead}\n\nAttempts to destroy any undead creatures on the battlefield. Each undead unit takes (Spell Power x 10 + 10) damage.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Destroy Undead}\n\nAttempts to destroy any undead creatures on the battlefield. Each undead unit takes (Spell Power x 10 + 10) damage.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Destroy Undead}\n\nAttempts to destroy any undead creatures on the battlefield. Each undead unit takes (Spell Power x 10 + 20) damage.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Destroy Undead}\n\nAttempts to destroy any undead creatures on the battlefield. Each undead unit takes (Spell Power x 10 + 50) damage.\n"
+			}
+		}
+	},
+	"core:shield" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Shield}\n\nShields a selected friendly unit, reducing the amount of damage received from hand-to-hand attacks by 15%. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Shield}\n\nShields a selected friendly unit, reducing the amount of damage received from hand-to-hand attacks by 15%. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Shield}\n\nShields a selected friendly unit, reducing the amount of damage received from hand-to-hand attacks by 30%. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Shield}\n\nShields all friendly units, reducing the amount of damage received from hand-to-hand attacks by 30%. Spell is active for number of rounds equal to hero Spell Power.\n"
+			}
+		}
+	},
+	"core:airShield" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Air Shield}\n\nShields a selected friendly unit, reducing the amount of damage received from ranged attacks by 25%. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Air Shield}\n\nShields a selected friendly unit, reducing the amount of damage received from ranged attacks by 25%. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Air Shield}\n\nShields a selected friendly unit, reducing the amount of damage received from ranged attacks by 50%. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Air Shield}\n\nShields all friendly units, reducing the amount of damage received from ranged attacks by 50%. Spell is active for number of rounds equal to hero Spell Power.\n"
+			}
+		}
+	},
+	"core:fireShield" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Fire Shield}\n\nCast on a friendly unit, it does not provide any additional protection, but any enemy making hand-by-hand attack through the fire shield will suffer damage equal to 20% of what it inflicts. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Fire Shield}\n\nCast on a friendly unit, it does not provide any additional protection, but any enemy making hand-by-hand attack through the fire shield will suffer damage equal to 20% of what it inflicts. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Fire Shield}\n\nCast on a friendly unit, it does not provide any additional protection, but any enemy making hand-by-hand attack through the fire shield will suffer damage equal to 25% of what it inflicts. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Fire Shield}\n\nCast on a friendly unit, it does not provide any additional protection, but any enemy making hand-by-hand attack through the fire shield will suffer damage equal to 30% of what it inflicts. Spell is active for number of rounds equal to hero Spell Power.\n"
+			}
+		}
+	},
+	"core:antiMagic" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Anti-magic}\n\nProtects the selected friendly unit from all 1-3 level spells except Dispel. Removes negative spells level 1-3 except Disrupting Ray. Does not affect duplicates created with Clone spell. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Anti-magic}\n\nProtects the selected friendly unit from all 1-3 level spells except Dispel. Removes negative spells level 1-3 except Disrupting Ray. Does not affect duplicates created with Clone spell. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Anti-magic}\n\nProtects the selected friendly unit from all 1-4 level spells except Dispel. Removes negative spells level 1-4 except Disrupting Ray. Does not affect duplicates created with Clone spell. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Anti-magic}\n\nProtects the selected friendly unit from all spells except Dispel. Removes all negative spells except Disrupting Ray. Does not affect duplicates created with Clone spell. Spell is active for number of rounds equal to hero Spell Power.\n"
+			}
+		}
+	},
+	"core:dispel" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Dispel}\n\nRemoves all spells and effects except Disrupting Ray and poison from a friendly unit. Ignores target creature natural immunities to magic.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Dispel}\n\nRemoves all spells and effects except Disrupting Ray and poison from a friendly unit. Ignores target creature natural immunities to magic.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Dispel}\n\nRemoves all spells and effects except Disrupting Ray and poison from a friendly or hostile unit. Ignores target creature chances to resist a spell and natural immunities.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Dispel}\n\nRemoves all spells and effects except Disrupting Ray and poison from all units on the battlefield and destroys all magic obstacles. Ignores target creature chances to resist a spell and natural immunities.\n"
+			}
+		}
+	},
+	"core:magicMirror" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Magic Mirror}\n\nReflects hostile spells from selected friendly unit towards a random enemy creature 20% of the time. Protects from Hypnotize spell. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Magic Mirror}\n\nReflects hostile spells from selected friendly unit towards a random enemy creature 20% of the time. Protects from Hypnotize spell. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Magic Mirror}\n\nReflects hostile spells from selected friendly unit towards a random enemy creature 30% of the time. Protects from Hypnotize spell. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Magic Mirror}\n\nReflects hostile spells from selected friendly unit towards a random enemy creature 40% of the time. Protects from Hypnotize spell. Spell is active for number of rounds equal to hero Spell Power.\n"
+			}
+		}
+	},
+	"core:cure" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Cure}\n\nRemoves all negative spells and effects except Disrupting Ray and dendroid binding and heals (Spell Power x 5 + 10) hit points on the selected friendly unit. Restores health decremented with poison.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Cure}\n\nRemoves all negative spells and effects except Disrupting Ray and dendroid binding and heals (Spell Power x 5 + 10) hit points on the selected friendly unit. Restores health decremented with poison.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Cure}\n\nRemoves all negative spells and effects except Disrupting Ray and dendroid binding and heals (Spell Power x 5 + 20) hit points on the selected friendly unit. Restores health decremented with poison.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Cure}\n\nRemoves all negative spells and effects except Disrupting Ray and dendroid binding and heals (Spell Power x 5 + 30) hit points on all friendly units. Restores health decremented with poison.\n"
+			}
+		}
+	},
+	"core:resurrection" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Resurrection}\n\nResurrects units in the selected friendly group of living creatures until the end of the battle by restoring (Spell Power x 50 + 40) hit points to the target.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Resurrection}\n\nResurrects units in the selected friendly group of living creatures until the end of the battle by restoring (Spell Power x 50 + 40) hit points to the target.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Resurrection}\n\nResurrects units in the selected friendly group of living creatures permanently by restoring (Spell Power x 50 + 80) hit points to the target.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Resurrection}\n\nResurrects units in the selected friendly group of living creatures permanently by restoring (Spell Power x 50 + 160) hit points to the target.\n"
+			}
+		}
+	},
+	"core:animateDead" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Animate Dead}\n\nRe-animates any destroyed undead in the selected friendly group by restoring (Spell Power x 50 + 30) hit points to the target.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Animate Dead}\n\nRe-animates any destroyed undead in the selected friendly group by restoring (Spell Power x 50 + 30) hit points to the target.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Animate Dead}\n\nRe-animates any destroyed undead in the selected friendly group by restoring (Spell Power x 50 + 60) hit points to the target.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Animate Dead}\n\nRe-animates any destroyed undead in the selected friendly group by restoring (Spell Power x 50 + 160) hit points to the target.\n"
+			}
+		}
+	},
+	"core:sacrifice" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Sacrifice}\n\nPermanently destroys a friendly living creature group in order to resurrect another friendly living creature group.  Resurrection power is ((Spell Power + Sacrificed Troop's Creature Base Health + 3) x Number of Creatures Sacrificed) hit points.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Sacrifice}\n\nPermanently destroys a friendly living creature group in order to resurrect another friendly living creature group.  Resurrection power is ((Spell Power + Sacrificed Troop's Creature Base Health + 3) x Number of Creatures Sacrificed) hit points.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Sacrifice}\n\nPermanently destroys a friendly living creature group in order to resurrect another friendly living creature group.  Resurrection power is ((Spell Power + Sacrificed Troop's Creature Base Health + 6) x Number of Creatures Sacrificed) hit points.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Sacrifice}\n\nPermanently destroys a friendly living creature group in order to resurrect another friendly living creature group.  Resurrection power is ((Spell Power + Sacrificed Troop's Creature Base Health + 10) x Number of Creatures Sacrificed) hit points.\n"
+			}
+		}
+	},
+	"core:bless" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Bless}\n\nCauses the selected friendly unit to inflict maximum damage in combat. Removes Curse effect. Does not affect undead. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Bless}\n\nCauses the selected friendly unit to inflict maximum damage in combat. Removes Curse effect. Does not affect undead. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Bless}\n\nCauses the selected friendly unit to inflict damage, greater than their normal maximum damage in combat by 1. Removes Curse effect. Does not affect undead. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Bless}\n\nCauses all friendly units to inflict damage, greater than their normal maximum damage in combat by 1. Removes Curse effect. Does not affect undead. Spell is active for number of rounds equal to hero Spell Power.\n"
+			}
+		}
+	},
+	"core:curse" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Curse}\n\nCauses the selected enemy unit to inflict minimum damage in combat. Removes Bless effect. Does not affect undead. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Curse}\n\nCauses the selected enemy unit to inflict minimum damage in combat. Removes Bless effect. Does not affect undead. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Curse}\n\nCauses the selected enemy unit to inflict damage, less than their normal minimum damage in combat by 1. Removes Bless effect. Does not affect undead. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Curse}\n\nCauses all enemy units to inflict damage, less than their normal minimum damage in combat by 1. Removes Bless effect. Does not affect undead. Spell is active for number of rounds equal to hero Spell Power.\n"
+			}
+		}
+	},
+	"core:bloodlust" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Bloodlust}\n\nIncreases the hand-to-hand attack strength of the selected friendly unit by 3. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Bloodlust}\n\nIncreases the hand-to-hand attack strength of the selected friendly unit by 3. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Bloodlust}\n\nIncreases the hand-to-hand attack strength of the selected friendly unit by 6. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Bloodlust}\n\nIncreases the hand-to-hand attack strength of all friendly units by 6. Spell is active for number of rounds equal to hero Spell Power.\n"
+			}
+		}
+	},
+	"core:precision" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Precision}\n\nIncreases the attack strength of the selected friendly unit ranged attack by 3. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Precision}\n\nIncreases the attack strength of the selected friendly unit ranged attack by 3. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Precision}\n\nIncreases the attack strength of the selected friendly unit ranged attack by 6. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Precision}\n\nIncreases the attack strength of any friendly units ranged attack by 6. Spell is active for number of rounds equal to hero Spell Power.\n"
+			}
+		}
+	},
+	"core:weakness" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Weakness}\n\nReduces the selected enemy unit's attack strength by 3. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Weakness}\n\nReduces the selected enemy unit's attack strength by 3. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Weakness}\n\nReduces the selected enemy unit's attack strength by 6. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Weakness}\n\nReduces the attack strength of all enemy units by 6. Spell is active for number of rounds equal to hero Spell Power.\n"
+			}
+		}
+	},
+	"core:stoneSkin" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Stone Skin}\n\nIncreases the selected friendly unit's defense strength by 3. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Stone Skin}\n\nIncreases the selected friendly unit's defense strength by 3. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Stone Skin}\n\nIncreases the selected friendly unit's defense strength by 6. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Stone Skin}\n\nIncreases the defense strength of all friendly units by 6. Spell is active for number of rounds equal to hero Spell Power.\n"
+			}
+		}
+	},
+	"core:disruptingRay" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Disrupting Ray}\n\nReduces the selected enemy unit's defense strength by 3.  A single enemy may be targeted multiple times by this spell. Undispellable. The effect persists through death and resurrection of a unit. Disrupting Ray duration is unlimited.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Disrupting Ray}\n\nReduces the selected enemy unit's defense strength by 3.  A single enemy may be targeted multiple times by this spell. Undispellable. The effect persists through death and resurrection of a unit. Disrupting Ray duration is unlimited.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Disrupting Ray}\n\nReduces the selected enemy unit's defense strength by 4.  A single enemy may be targeted multiple times by this spell. Undispellable. The effect persists through death and resurrection of a unit. Disrupting Ray duration is unlimited.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Disrupting Ray}\n\nReduces the selected enemy unit's defense strength by 5.  A single enemy may be targeted multiple times by this spell. Undispellable. The effect persists through death and resurrection of a unit. Disrupting Ray duration is unlimited.\n"
+			}
+		}
+	},
+	"core:prayer" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Prayer}\n\nBestows a +2 bonus to the attack strength, defense strength and speed of the selected friendly unit. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Prayer}\n\nBestows a +2 bonus to the attack strength, defense strength and speed of the selected friendly unit. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Prayer}\n\nBestows a +4 bonus to the attack strength, defense strength and speed of the selected friendly unit. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Prayer}\n\nBestows a +4 bonus to the attack strength, defense strength and speed of all friendly units. Spell is active for number of rounds equal to hero Spell Power.\n"
+			}
+		}
+	},
+	"core:mirth" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Mirth}\n\nMind spell. Increases the selected friendly unit's morale by 1. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Mirth}\n\nMind spell. Increases the selected friendly unit's morale by 1. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Mirth}\n\nMind spell. Increases the selected friendly unit's morale by 2. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Mirth}\n\nMind spell. Increases the morale of all friendly units by 2. Spell is active for number of rounds equal to hero Spell Power.\n"
+			}
+		}
+	},
+	"core:sorrow" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Sorrow}\n\nMind spell. Reduces the morale of the selected enemy unit by 1. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Sorrow}\n\nMind spell. Reduces the morale of the selected enemy unit by 1. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Sorrow}\n\nMind spell. Reduces the morale of the selected enemy unit by 2. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Sorrow}\n\nMind spell. Reduces the morale of all enemy units by 2. Spell is active for number of rounds equal to hero Spell Power.\n"
+			}
+		}
+	},
+	"core:fortune" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Fortune}\n\nIncreases the selected friendly unit's luck by 1. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Fortune}\n\nIncreases the selected friendly unit's luck by 1. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Fortune}\n\nIncreases the selected friendly unit's luck by 2. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Fortune}\n\nIncreases the luck of all friendly units by 2. Spell is active for number of rounds equal to hero Spell Power.\n"
+			}
+		}
+	},
+	"core:misfortune" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Misfortune}\n\nReduces the luck of the selected enemy unit by 1. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Misfortune}\n\nReduces the luck of the selected enemy unit by 1. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Misfortune}\n\nReduces the luck of the selected enemy unit by 2. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Misfortune}\n\nReduces the luck of all enemy units by 2. Spell is active for number of rounds equal to hero Spell Power.\n"
+			}
+		}
+	},
+	"core:haste" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Haste}\n\nIncreases the speed of the selected friendly unit by 3. Removes Slow effect. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Haste}\n\nIncreases the speed of the selected friendly unit by 3. Removes Slow effect. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Haste}\n\nIncreases the speed of the selected friendly unit by 5. Removes Slow effect. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Haste}\n\nIncreases the speed of all friendly units by 5. Removes Slow effect. Spell is active for number of rounds equal to hero Spell Power.\n"
+			}
+		}
+	},
+	"core:slayer" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Slayer}\n\nIncreases the selected friendly unit's attack strength against Dragons, Behemoths, Hydras, Firebirds, Sea Serpents and Couatls by 8. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Slayer}\n\nIncreases the selected friendly unit's attack strength against Dragons, Behemoths, Hydras, Firebirds, Sea Serpents and Couatls by 8. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Slayer}\n\nIncreases the selected friendly unit's attack strength against Dragons, Behemoths, Hydras, Firebirds, Sea Serpents, Couatls, Devils and Angels by 8. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Slayer}\n\nIncreases the selected friendly unit's attack strength against Dragons, Behemoths, Hydras, Firebirds, Sea Serpents, Couatls, Dreadnoughts, Jotunns, Devils, Angels and Titans by 8. Spell is active for number of rounds equal to hero Spell Power.\n"
+			}
+		}
+	},
+	"core:frenzy" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Frenzy}\n\nMind spell. Selected friendly troop intentionally lowers its defenses to 0 to increase the ferocity of its attack. Bonus to attack strength is equal to unit’s former defense. The spell takes effect immediately and lasts during the closest turn of the target. After that, the spell effect lasts until the beginning of the target next turn.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Frenzy}\n\nMind spell. Selected friendly troop intentionally lowers its defenses to 0 to increase the ferocity of its attack. Bonus to attack strength is equal to unit’s former defense. The spell takes effect immediately and lasts during the closest turn of the target. After that, the spell effect lasts until the beginning of the target next turn.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Frenzy}\n\nMind spell. Selected friendly troop intentionally lowers its defenses to 0 to increase the ferocity of its attack. Bonus to attack strength is 1.5 times more than unit’s former defense. The spell takes effect immediately and lasts during the closest turn of the target. After that, the spell effect lasts until the beginning of the target next turn.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Frenzy}\n\nMind spell. Selected friendly troop intentionally lowers its defenses to 0 to increase the ferocity of its attack. Bonus to attack strength is 2 times more than unit’s former defense. The spell takes effect immediately and lasts during the closest turn of the target. After that, the spell effect lasts until the beginning of the target next turn.\n"
+			}
+		}
+	},
+	"core:counterstrike" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Counterstrike}\n\nThe selected friendly unit gains one additional retaliation attack immediately and will gain one additional retaliation attack at the beginning of each round. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Counterstrike}\n\nThe selected friendly unit gains one additional retaliation attack immediately and will gain one additional retaliation attack at the beginning of each round. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Counterstrike}\n\nThe selected friendly unit gains two additional retaliation attacks immediately and will gain two additional retaliations attack at the beginning of each round. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Counterstrike}\n\nAll friendly units gain two additional retaliation attacks immediately and will gain two additional retaliations attack at the beginning of each round. Spell is active for number of rounds equal to hero Spell Power.\n"
+			}
+		}
+	},
+	"core:berserk" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Berserk}\n\nMind spell. The targeted unit will randomly attack the nearest unit, be it friend or foe. Hypnotize effect is dispelled from target. Spell effect is valid until target make an attack, otherwise Berserk duration is unlimited.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Berserk}\n\nMind spell. The targeted unit will randomly attack the nearest unit, be it friend or foe. Hypnotize effect is dispelled from target. Spell effect is valid until target make an attack, otherwise Berserk duration is unlimited.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Berserk}\n\nMind spell. The targeted unit as well as units adjacent to the target location will randomly attack the nearest units, be they friends or foes. Hypnotize effect is dispelled from targets. Spell effect is valid until target make an attack, otherwise Berserk duration is unlimited.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Berserk}\n\nMind spell. The targeted unit as well as any units 1 and 2 hexes away from target location will randomly attack the nearest units, be they friends or foes. Hypnotize effect is dispelled from targets. Spell effect is valid until target make an attack, otherwise Berserk duration is unlimited.\n"
+			}
+		}
+	},
+	"core:hypnotize" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Hypnotize}\n\nMind spell. Puts the selected enemy unit of not more than (Spell Power x 25 + 10) Health temporarily under your control. Removes Berserk effect. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Hypnotize}\n\nMind spell. Puts the selected enemy unit of not more than (Spell Power x 25 + 10) Health temporarily under your control. Removes Berserk effect. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Hypnotize}\n\nMind spell. Puts the selected enemy unit of not more than (Spell Power x 25 + 20) Health temporarily under your control. Removes Berserk effect. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Hypnotize}\n\nMind spell. Puts the selected enemy unit of not more than (Spell Power x 25 + 50) Health temporarily under your control. Removes Berserk effect. Spell is active for number of rounds equal to hero Spell Power.\n"
+			}
+		}
+	},
+	"core:forgetfulness" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Forgetfulness}\n\nMind spell. Half of the selected enemy ranged unit forgets to use its attack. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Forgetfulness}\n\nMind spell. Half of the selected enemy ranged unit forgets to use its attack. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Forgetfulness}\n\nMind spell. Causes the selected enemy ranged unit to forget to use its ranged attack in combat. Half of unit also forget to use hand-to-hand attack. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Forgetfulness}\n\nMind spell. Causes all enemy ranged troops to forget to use their ranged attack in combat. Half of each unit also forget to use hand-to-hand attack. Spell is active for number of rounds equal to hero Spell Power.\n"
+			}
+		}
+	},
+	"core:blind" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Blind}\n\nMind spell. Temporary blinds the selected enemy unit so that it cannot move and causes it to counterattack at half its normal damage.  Blindness persists until the unit is attacked or dispelled. Does not affect undead. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Blind}\n\nMind spell. Temporary blinds the selected enemy unit so that it cannot move and causes it to counterattack at half its normal damage.  Blindness persists until the unit is attacked or dispelled. Does not affect undead. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Blind}\n\nMind spell. Temporary blinds the selected enemy unit so that it cannot move and causes it to counterattack at one-quarter of its normal damage.  Blindness persists until the unit is attacked or dispelled. Does not affect undead. Spell is active for number of rounds equal to hero Spell Power.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Blind}\n\nMind spell. Temporary blinds the selected enemy unit so that it cannot move or counterattack.  Blindness persists until the unit is attacked or dispelled. Does not affect undead. Spell is active for number of rounds equal to hero Spell Power.\n"
+			}
+		}
+	},
+	"core:teleport" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Teleport}\n\nTeleports any friendly unit to any unoccupied spot on the battlefield. Removes dendroid binding effect.\n\nTroop cannot teleport over walls or moats.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Teleport}\n\nTeleports any friendly unit to an unoccupied spot on the battlefield. Removes dendroid binding effect.\n\nTroop cannot teleport over walls or moats.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Teleport}\n\nTeleports any friendly unit to an unoccupied spot on the battlefield. Removes dendroid binding effect.\n\nTroop cannot teleport over walls.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Teleport}\n\nTeleports any friendly unit to any unoccupied spot on the battlefield. Removes dendroid binding effect.\n"
+			}
+		}
+	},
+	"core:removeObstacle" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Remove Obstacle}\n\nRemoves any normal non-integrated obstacle (trees, rocks, etc.) of the caster's choice from the battlefield.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Remove Obstacle}\n\nRemoves any normal non-integrated obstacle (trees, rocks, etc.) of the caster's choice from the battlefield.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Remove Obstacle}\n\nRemoves any normal non-integrated obstacle (trees, rocks, etc.) or Fire Wall of the caster's choice from the battlefield.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Remove Obstacle}\n\nRemoves any normal non-integrated or magical obstacle of the caster's choice from the battlefield.\n"
+			}
+		}
+	},
+	"core:clone" : {
+		"levels" : {
+			"none" : {
+				"description" : "{Clone}\n\nCreates a temporary duplicate of the selected friendly unit stack.  The image is dispelled if it is damaged or if prototype dies. Each unit may have only one clone. Does not affect War Machines. Clone is alive for number of rounds equal to hero Spell Power.\n\nClones creatures of levels 1-5.\n"
+			},
+			"basic" : {
+				"description" : "{Basic Clone}\n\nCreates a temporary duplicate of the selected friendly unit stack.  The image is dispelled if it is damaged or if prototype dies. Each unit may have only one clone. Does not affect War Machines. Clone is alive for number of rounds equal to hero Spell Power.\n\nClones creatures of levels 1-5.\n"
+			},
+			"advanced" : {
+				"description" : "{Advanced Clone}\n\nCreates a temporary duplicate of the selected friendly unit stack.  The image is dispelled if it is damaged or if prototype dies. Each unit may have only one clone. Does not affect War Machines. Clone is alive for number of rounds equal to hero Spell Power.\n\nClones creatures of levels 1-6.\n"
+			},
+			"expert" : {
+				"description" : "{Expert Clone}\n\nCreates a temporary duplicate of the selected friendly unit stack.  The image is dispelled if it is damaged or if prototype dies. Each unit may have only one clone. Does not affect War Machines. Clone is alive for number of rounds equal to hero Spell Power.\n\nClones creatures of any level.\n"
+			}
+		}
+	}
+}

--- a/mods/heroes3DataPatch/mod.json
+++ b/mods/heroes3DataPatch/mod.json
@@ -42,6 +42,9 @@
 		"name" : "Oprava grafiky pro Heroes 3",
 		"description" : "Opravy grafiky a zvuků pro některé herní prvky z Heroes 3."
 	},
+	"artifacts" : [
+		"config/heroes3DataPatch/artifactDescriptions.json"
+	],
 	"factions" : [
 		"config/heroes3DataPatch/confluxTerrain.json",
 		"config/heroes3DataPatch/structures.json",

--- a/mods/heroes3DataPatch/mod.json
+++ b/mods/heroes3DataPatch/mod.json
@@ -4,8 +4,12 @@
 	"modType" : "Graphical",
 	"author" : "Graphics and sounds: HotA Crew, mod: Kuririn & avatar",
 	"contact" : "http://forum.df2.ru/index.php?showtopic=32286",
-	"version" : "1.3.6",
+	"version" : "1.3.7",
 	"changelog" : {
+		"1.3.7" : [
+			"Added artifact descriptions",
+			"Added spell descriptions"
+		],
 		"1.3.6" : [
 			"Added all changed sounds"
 		]
@@ -44,6 +48,9 @@
 	},
 	"artifacts" : [
 		"config/heroes3DataPatch/artifactDescriptions.json"
+	],
+	"spells" : [
+		"config/heroes3DataPatch/spellDescriptions.json"
 	],
 	"factions" : [
 		"config/heroes3DataPatch/confluxTerrain.json",


### PR DESCRIPTION
Updates all artifact and spell descriptions to 1.8.0.

@GeorgeK1ng @kdmcser (tag others for other languages, idk who)

We need updated translations in 
+ artifacts 
+ gamebalance.artifacts (angelic alliance + 2 new: equestrian gloves and boots of speed)
    + don't forget to update the necromancy artis, they are back to 5/10/15% (you can just comment them out, their description is the same as in core)

and new translations in
+ gameBalance.spells (all spells that HotA changes - except forgetfulness because the description doesn't mention that change)
+ heroes3dataPatch (artifactDescription.json and spellDescription.json)
