### PR TITLE
Fix bonus of Necromancy Amplifier

### DIFF
--- a/mods/gameBalance/mods/factions/content/config/hotaGameBalance/factions.json
+++ b/mods/gameBalance/mods/factions/content/config/hotaGameBalance/factions.json
@@ -116,6 +116,14 @@
 					"cost" : {
 						"sulfur" : 4
 					}
+				},
+				"special2" : {
+					"bonuses" : {
+						"modify@1" : {
+							"val" : 5
+						}
+					},
+					"description" : "The Necromancy Amplifier increases the Necromancy skill of all heroes you control (with the Necromancy skill) by 5%."
 				}
 			}
 		}


### PR DESCRIPTION
I erroneously changed the Necromancy Amplifier back to 10%, I thought 1.8.0 changed that too, but it's still 5%.