### PR TITLE
Remove unnecessary adventure map filters for town sprites

### DIFF
--- a/mods/bulwark/content/config/hota/bulwark/town/town.json
+++ b/mods/bulwark/content/config/hota/bulwark/town/town.json
@@ -156,18 +156,6 @@
 
 			"mapObject" : {
 				"filters" : {
-					"fort" : [
-						"allOf",
-						[
-							"fort"
-						],
-						[
-							"noneOf",
-							[
-								"citadel"
-							]
-						]
-					],
 					"citadel" : [
 						"allOf",
 						[
@@ -194,6 +182,9 @@
 					]
 				},
 				"templates" : {
+					"village" : {
+						"animation" : "hota/bulwark/town/adventureMap/AVCBlwr0.def"
+					},
 					"fort" : {
 						"animation" : "hota/bulwark/town/adventureMap/AVCBulF0.def"
 					},
@@ -202,9 +193,6 @@
 					},
 					"castle" : {
 						"animation" : "hota/bulwark/town/adventureMap/AVCbulX0.def"
-					},
-					"village" : {
-						"animation" : "hota/bulwark/town/adventureMap/AVCBlwr0.def"
 					},
 					"capitol" : {
 						"animation" : "hota/bulwark/town/adventureMap/AVCbulZ0.def"

--- a/mods/cove/Content/config/hota/cove/town/town.json
+++ b/mods/cove/Content/config/hota/cove/town/town.json
@@ -163,18 +163,6 @@
 
 			"mapObject" : {
 				"filters" : {
-					"fort" : [
-						"allOf",
-						[
-							"fort"
-						],
-						[
-							"noneOf",
-							[
-								"citadel"
-							]
-						]
-					],
 					"citadel" : [
 						"allOf",
 						[
@@ -201,6 +189,9 @@
 					]
 				},
 				"templates" : {
+					"village" : {
+						"animation" : "hota/cove/town/adventureMap/AVCCOVE0.def"
+					},
 					"fort" : {
 						"animation" : "hota/cove/town/adventureMap/AVCcovf0.def"
 					},
@@ -209,9 +200,6 @@
 					},
 					"castle" : {
 						"animation" : "hota/cove/town/adventureMap/AVCCOVX0.def"
-					},
-					"village" : {
-						"animation" : "hota/cove/town/adventureMap/AVCCOVE0.def"
 					},
 					"capitol" : {
 						"animation" : "hota/cove/town/adventureMap/AVCcovz0.def"

--- a/mods/factory/content/config/hota/factory/town/town.json
+++ b/mods/factory/content/config/hota/factory/town/town.json
@@ -608,35 +608,23 @@
 								"castle"
 							]
 						]
-					],
-					"fort" : [
-						"allOf",
-						[
-							"fort"
-						],
-						[
-							"noneOf",
-							[
-								"citadel"
-							]
-						]
 					]
 				},
 				"templates" : {
-					"capitol" : {
-						"animation" : "hota/factory/town/adventureMap/AVCfacZ0.def"
-					},
-					"castle" : {
-						"animation" : "hota/factory/town/adventureMap/AVCfacX0.def"
-					},
-					"citadel" : {
-						"animation" : "hota/factory/town/adventureMap/AVCfacC0.def"
+					"village" : {
+						"animation" : "hota/factory/town/adventureMap/AVCfacE0.def"
 					},
 					"fort" : {
 						"animation" : "hota/factory/town/adventureMap/AVCfacF0.def"
 					},
-					"village" : {
-						"animation" : "hota/factory/town/adventureMap/AVCfacE0.def"
+					"citadel" : {
+						"animation" : "hota/factory/town/adventureMap/AVCfacC0.def"
+					},
+					"castle" : {
+						"animation" : "hota/factory/town/adventureMap/AVCfacX0.def"
+					},
+					"capitol" : {
+						"animation" : "hota/factory/town/adventureMap/AVCfacZ0.def"
 					}
 				}
 			},

--- a/mods/newGraphics/Content/config/hota/newGraphics/newTownAnimations.json
+++ b/mods/newGraphics/Content/config/hota/newGraphics/newTownAnimations.json
@@ -3,18 +3,6 @@
 		"town" : {
 			"mapObject" : {
 				"filters" : {
-					"fort" : [
-						"allOf",
-						[
-							"fort"
-						],
-						[
-							"noneOf",
-							[
-								"citadel"
-							]
-						]
-					],
 					"citadel" : [
 						"allOf",
 						[
@@ -61,18 +49,6 @@
 		"town" : {
 			"mapObject" : {
 				"filters" : {
-					"fort" : [
-						"allOf",
-						[
-							"fort"
-						],
-						[
-							"noneOf",
-							[
-								"citadel"
-							]
-						]
-					],
 					"citadel" : [
 						"allOf",
 						[
@@ -119,18 +95,6 @@
 		"town" : {
 			"mapObject" : {
 				"filters" : {
-					"fort" : [
-						"allOf",
-						[
-							"fort"
-						],
-						[
-							"noneOf",
-							[
-								"citadel"
-							]
-						]
-					],
 					"citadel" : [
 						"allOf",
 						[
@@ -177,18 +141,6 @@
 		"town" : {
 			"mapObject" : {
 				"filters" : {
-					"fort" : [
-						"allOf",
-						[
-							"fort"
-						],
-						[
-							"noneOf",
-							[
-								"citadel"
-							]
-						]
-					],
 					"citadel" : [
 						"allOf",
 						[
@@ -235,18 +187,6 @@
 		"town" : {
 			"mapObject" : {
 				"filters" : {
-					"fort" : [
-						"allOf",
-						[
-							"fort"
-						],
-						[
-							"noneOf",
-							[
-								"citadel"
-							]
-						]
-					],
 					"citadel" : [
 						"allOf",
 						[
@@ -293,18 +233,6 @@
 		"town" : {
 			"mapObject" : {
 				"filters" : {
-					"fort" : [
-						"allOf",
-						[
-							"fort"
-						],
-						[
-							"noneOf",
-							[
-								"citadel"
-							]
-						]
-					],
 					"citadel" : [
 						"allOf",
 						[
@@ -351,18 +279,6 @@
 		"town" : {
 			"mapObject" : {
 				"filters" : {
-					"fort" : [
-						"allOf",
-						[
-							"fort"
-						],
-						[
-							"noneOf",
-							[
-								"citadel"
-							]
-						]
-					],
 					"citadel" : [
 						"allOf",
 						[
@@ -409,18 +325,6 @@
 		"town" : {
 			"mapObject" : {
 				"filters" : {
-					"fort" : [
-						"allOf",
-						[
-							"fort"
-						],
-						[
-							"noneOf",
-							[
-								"citadel"
-							]
-						]
-					],
 					"citadel" : [
 						"allOf",
 						[
@@ -467,18 +371,6 @@
 		"town" : {
 			"mapObject" : {
 				"filters" : {
-					"fort" : [
-						"allOf",
-						[
-							"fort"
-						],
-						[
-							"noneOf",
-							[
-								"citadel"
-							]
-						]
-					],
 					"citadel" : [
 						"allOf",
 						[
@@ -520,63 +412,51 @@
 				}
 			}
 		}
-	},
-	"core:randomTown" : {
-		"town" : {
-			"mapObject" : {
-				"filters" : {
-					"fort" : [
-						"allOf",
-						[
-							"fort"
-						],
-						[
-							"noneOf",
-							[
-								"citadel"
-							]
-						]
-					],
-					"citadel" : [
-						"allOf",
-						[
-							"citadel"
-						],
-						[
-							"noneOf",
-							[
-								"castle"
-							]
-						]
-					],
-					"castle" : [
-						"allOf",
-						[
-							"castle"
-						],
-						[
-							"noneOf",
-							[
-								"capitol"
-							]
-						]
-					]
-				},
-				"templates" : {
-					"fort" : {
-						"animation" : "hota/random/adventureMap/town/AVCranf0.def"
-					},
-					"citadel" : {
-						"animation" : "hota/random/adventureMap/town/AVCRAND0.def"
-					},
-					"castle" : {
-						"animation" : "hota/random/adventureMap/town/avcranx0.def"
-					},
-					"capitol" : {
-						"animation" : "hota/random/adventureMap/town/avcranz0.def"
-					}
-				}
-			}
-		}
 	}
+//	"core:randomTown" : {
+//		"town" : {
+//			"mapObject" : {
+//				"filters" : {
+//					"citadel" : [
+//						"allOf",
+//						[
+//							"citadel"
+//						],
+//						[
+//							"noneOf",
+//							[
+//								"castle"
+//							]
+//						]
+//					],
+//					"castle" : [
+//						"allOf",
+//						[
+//							"castle"
+//						],
+//						[
+//							"noneOf",
+//							[
+//								"capitol"
+//							]
+//						]
+//					]
+//				},
+//				"templates" : {
+//					"fort" : {
+//						"animation" : "hota/random/adventureMap/town/AVCranf0.def"
+//					},
+//					"citadel" : {
+//						"animation" : "hota/random/adventureMap/town/AVCRAND0.def"
+//					},
+//					"castle" : {
+//						"animation" : "hota/random/adventureMap/town/avcranx0.def"
+//					},
+//					"capitol" : {
+//						"animation" : "hota/random/adventureMap/town/avcranz0.def"
+//					}
+//				}
+//			}
+//		}
+//	}
 }


### PR DESCRIPTION
"fort" is a predefined filter and can just be discarded, citadel and castle ones are necessary.
Tested it with all factions, they show up correctly in all cases.

I've also commented out the intended map-editor only changes to random town adventure, all that does is log a warning. It has no effect.