### PR TITLE
Fixed crash on loading Seafaring Academy on maps with banned Navigation

### DIFF
--- a/mods/mapObjects/content/config/hotaMapObjects/seafaringAcademy.json
+++ b/mods/mapObjects/content/config/hotaMapObjects/seafaringAcademy.json
@@ -9,11 +9,7 @@
 					"resource-skill"
 				],
 				"offer" : [
-					{
-						"anyOf" : [
-							"navigation"
-						]
-					},
+					"navigation",
 					{
 						"noneOf" : [
 							"necromancy"


### PR DESCRIPTION
NOTE: not bumping version in case if there other planned changes, like rest of currently open PR's

While these two configs appear to have same logic, there is one important distinction:
```json
    "anyOf" : [
        "navigation"
    ]
```
This means: out of skills available on map, select one of the following skills: navigation.
```js
    "navigation"
```
While this means, "select navigation"

Normally, these are identical. But if map has Navigation banned, first code will fail since there are no skill available on map that satisfy this logic.

- Fixes https://github.com/vcmi/vcmi/issues/6909