### PR TITLE
Ban "Thatched Hut" from spawning randomly

### DIFF
--- a/mods/factory/content/config/hota/factory/dwellings.json
+++ b/mods/factory/content/config/hota/factory/dwellings.json
@@ -1,6 +1,9 @@
 {
 	"core:creatureGeneratorCommon" : {
 		"types" : {
+			"thatchedHut" : {
+				"bannedForRandomDwelling" : true
+			},
 			"factoryLevel1" : {
 				"name" : "Halfling Adobe",
 				"creatures" : [


### PR DESCRIPTION
Noticed this during one of my test matches:

Factory creature generators could spawn Thatched Hut instead of Halfling Adobe (they both allow to recruit Halflings - so it's just the sprite), but Thatched Hut is supposed to be map-editor only.

This PR bans Thatched Hut from spawning randomly, so it will always be replaced by Halfling Adobe unless specifically set in the map editor.