### PR TITLE
Fix necropolis puzzle piece alignment

### DIFF
--- a/mods/heroes3DataPatch/content/config/heroes3DataPatch/necropolisPuzzle.json
+++ b/mods/heroes3DataPatch/content/config/heroes3DataPatch/necropolisPuzzle.json
@@ -1,0 +1,14 @@
+{
+	"core:necropolis" : {
+		"puzzleMap" : {
+			"pieces" : {
+				"modify@11" : {
+					"y" : 270
+				},
+				"modify@12" : {
+					"x" : 70
+				}
+			}
+		}
+	}
+}

--- a/mods/heroes3DataPatch/mod.json
+++ b/mods/heroes3DataPatch/mod.json
@@ -44,6 +44,7 @@
 	},
 	"factions" : [
 		"config/heroes3DataPatch/confluxTerrain.json",
+		"config/heroes3DataPatch/necropolisPuzzle.json",
 		"config/heroes3DataPatch/structures.json",
 		"config/heroes3DataPatch/boats.json"
 	],


### PR DESCRIPTION
Opening order did not change, as far as I am aware.

Fixes vcmi/vcmi#6964

Screen after fix:

<img width="2326" height="1454" alt="screenshot-20260223T182304" src="https://github.com/user-attachments/assets/488da767-10e2-4c7a-8215-fdfeddb60992" />
