### PR TITLE
Fix Luna Fire Wall tooltip

### DIFF
--- a/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/conflux/luna.json
+++ b/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/conflux/luna.json
@@ -4,6 +4,9 @@
 			"bonuses" : {
 				"fireWall" : {
 					"val" : 25
+				},
+				"fireWallTooltip" : {
+					"val" : 25
 				}
 			}
 		},


### PR DESCRIPTION
Latest beta fixed the spell damage display in the spell book, so needs to be adjusted here as well.