### PR TITLE
Resolved z-index issues in towns

### DIFF
--- a/mods/bulwark/content/config/hota/bulwark/town/structures.json
+++ b/mods/bulwark/content/config/hota/bulwark/town/structures.json
@@ -92,7 +92,7 @@
 					"campaignBonus" : "hota/bulwark/town/icons/campaignBonuses/marketplace",
 					"x" : 397,
 					"y" : 249,
-					"z" : 0
+					"z" : -1
 				},
 				"resourceSilo" : {
 					"animation" : "hota/bulwark/town/buildings/TBBuSilo",
@@ -129,7 +129,7 @@
 					"campaignBonus" : "hota/bulwark/town/icons/campaignBonuses/special1",
 					"x" : 464,
 					"y" : 281,
-					"z" : 1
+					"z" : 2
 				},
 				"special2" : {
 					"animation" : "hota/bulwark/town/buildings/TBBuSpc1",
@@ -138,7 +138,7 @@
 					"campaignBonus" : "hota/bulwark/town/icons/campaignBonuses/special2",
 					"x" : 489,
 					"y" : 170,
-					"z" : 1
+					"z" : 2
 				},
 				"special3" : {
 					"animation" : "hota/bulwark/town/buildings/TBBuS201",
@@ -147,7 +147,7 @@
 					"campaignBonus" : "hota/bulwark/town/icons/campaignBonuses/special3",
 					"x" : 489,
 					"y" : 140,
-					"z" : 1
+					"z" : 2
 				},
 				"horde1" : {
 					"animation" : "hota/bulwark/town/buildings/TBBuH101",
@@ -193,7 +193,7 @@
 					"campaignBonus" : "hota/bulwark/town/icons/campaignBonuses/mageGuild1",
 					"x" : 558,
 					"y" : 112,
-					"z" : 1
+					"z" : 3
 				},
 				"mageGuild2" : {
 					"animation" : "hota/bulwark/town/buildings/TBBuM201",
@@ -202,7 +202,7 @@
 					"campaignBonus" : "hota/bulwark/town/icons/campaignBonuses/mageGuild2",
 					"x" : 558,
 					"y" : 81,
-					"z" : 1
+					"z" : 3
 				},
 				"mageGuild3" : {
 					"animation" : "hota/bulwark/town/buildings/TBBuM301",
@@ -211,7 +211,7 @@
 					"campaignBonus" : "hota/bulwark/town/icons/campaignBonuses/mageGuild3",
 					"x" : 558,
 					"y" : 55,
-					"z" : 1
+					"z" : 3
 				},
 				"mageGuild4" : {
 					"animation" : "hota/bulwark/town/buildings/TBBuM401",
@@ -220,7 +220,7 @@
 					"campaignBonus" : "hota/bulwark/town/icons/campaignBonuses/mageGuild4",
 					"x" : 558,
 					"y" : 33,
-					"z" : 1
+					"z" : 3
 				},
 
 				"dwellingLvl1" : {
@@ -230,7 +230,7 @@
 					"campaignBonus" : "hota/bulwark/town/icons/campaignBonuses/dwellingLvl1",
 					"x" : 0,
 					"y" : 140,
-					"z" : 1
+					"z" : 2
 				},
 				"dwellingLvl2" : {
 					"animation" : "hota/bulwark/town/buildings/TBBuDw_1",
@@ -266,7 +266,7 @@
 					"campaignBonus" : "hota/bulwark/town/icons/campaignBonuses/dwellingLvl5",
 					"x" : 447,
 					"y" : 167,
-					"z" : 0
+					"z" : 1
 				},
 				"dwellingLvl6" : {
 					"animation" : "hota/bulwark/town/buildings/TBBuD501",
@@ -284,7 +284,7 @@
 					"campaignBonus" : "hota/bulwark/town/icons/campaignBonuses/dwellingLvl7",
 					"x" : 380,
 					"y" : 35,
-					"z" : 0
+					"z" : 1
 				},
 
 				"dwellingUpLvl1" : {
@@ -294,7 +294,7 @@
 					"campaignBonus" : "hota/bulwark/town/icons/campaignBonuses/dwellingUpLvl1",
 					"x" : 0,
 					"y" : 94,
-					"z" : 1
+					"z" : 2
 				},
 				"dwellingUpLvl2" : {
 					"animation" : "hota/bulwark/town/buildings/TBBuU101",
@@ -330,7 +330,7 @@
 					"campaignBonus" : "hota/bulwark/town/icons/campaignBonuses/dwellingUpLvl5",
 					"x" : 444,
 					"y" : 163,
-					"z" : 0
+					"z" : 1
 				},
 				"dwellingUpLvl6" : {
 					"animation" : "hota/bulwark/town/buildings/TBBuU501",
@@ -348,7 +348,7 @@
 					"campaignBonus" : "hota/bulwark/town/icons/campaignBonuses/dwellingUpLvl7",
 					"x" : 380,
 					"y" : 13,
-					"z" : 0
+					"z" : 1
 				}
 			}
 		}

--- a/mods/confluxVaultofAshes/content/config/hotaConfluxVaultOfAshes/confluxTown.json
+++ b/mods/confluxVaultofAshes/content/config/hotaConfluxVaultOfAshes/confluxTown.json
@@ -9,7 +9,7 @@
 					"campaignBonus" : "hota/campaignBonuses/BoEHRD3.png",
 					"x" : 685,
 					"y" : 105,
-					"z" : 1
+					"z" : 3
 				},
 				"hordePhoenixUpgr" : {
 					"animation" : "hota/TBELHrd4.def",
@@ -18,7 +18,7 @@
 					"campaignBonus" : "hota/campaignBonuses/BoEHRD4.png",
 					"x" : 685,
 					"y" : 105,
-					"z" : 1
+					"z" : 3
 				}
 			},
 			"horde" : [

--- a/mods/cove/Content/config/hota/cove/town/structures.json
+++ b/mods/cove/Content/config/hota/cove/town/structures.json
@@ -46,7 +46,8 @@
 					"border" : "hota/cove/town/border/TBCVCSTL",
 					"campaignBonus" : "hota/cove/town/icons/campaignBonuses/BoCvcstl",
 					"x" : 438,
-					"y" : 109
+					"y" : 109,
+					"z" : 2
 				},
 				"citadel" : {
 					"animation" : "hota/cove/town/buildings/TBCVCAS2",
@@ -54,7 +55,8 @@
 					"border" : "hota/cove/town/border/TBCVCAS2",
 					"campaignBonus" : "hota/cove/town/icons/campaignBonuses/BoCvcas2",
 					"x" : 438,
-					"y" : 109
+					"y" : 109,
+					"z" : 2
 				},
 				"castle" : {
 					"animation" : "hota/cove/town/buildings/TBCVCAS3",
@@ -134,7 +136,8 @@
 					"border" : "hota/cove/town/border/TBCVGROT",
 					"campaignBonus" : "hota/cove/town/icons/campaignBonuses/BoCvgrot",
 					"x" : 236,
-					"y" : 147
+					"y" : 147,
+					"z" : -1
 				},
 				"horde1" : {
 					"animation" : "hota/cove/town/buildings/TBCVSA1P",
@@ -187,7 +190,7 @@
 					"animation" : "hota/cove/town/buildings/TBCVWHTR",
 					"x" : 0,
 					"y" : 211,
-					"z" : -1
+					"z" : -2
 				},
 
 				"mageGuild1" : {
@@ -251,7 +254,7 @@
 					"campaignBonus" : "hota/cove/town/icons/campaignBonuses/BoCvPIR1",
 					"x" : 588,
 					"y" : 191,
-					"z" : 2
+					"z" : 3
 				},
 				"dwellingLvl4" : {
 					"animation" : "hota/cove/town/buildings/TBCVASS1",
@@ -312,7 +315,7 @@
 					"campaignBonus" : "hota/cove/town/icons/campaignBonuses/BoCvPIR2",
 					"x" : 588,
 					"y" : 64,
-					"z" : 2
+					"z" : 3
 				},
 				"dwellingUpLvl4" : {
 					"animation" : "hota/cove/town/buildings/TBCVASS2",
@@ -356,7 +359,7 @@
 					"campaignBonus" : "hota/cove/town/icons/campaignBonuses/BoCvPGR3",
 					"x" : 588,
 					"y" : 64,
-					"z" : 2
+					"z" : 3
 				}
 			}
 		}

--- a/mods/factory/content/config/hota/factory/town/town.json
+++ b/mods/factory/content/config/hota/factory/town/town.json
@@ -759,7 +759,7 @@
 					"animation" : "hota/factory/town/buildings/TBFaExt1",
 					"x" : 245,
 					"y" : 201,
-					"z" : -1
+					"z" : -2
 				},
 				"decorationHouse" : {
 					"animation" : "hota/factory/town/buildings/TBFaExt2",
@@ -911,7 +911,8 @@
 					"border" : "hota/factory/town-screen/buildings-border/TOFaBLAK",
 					"campaignBonus" : "hota/factory/town/icons/campaignBonuses/BOFCsmth",
 					"x" : 347,
-					"y" : 189
+					"y" : 189,
+					"z" : 1
 				},
 				"horde1" : {
 					"animation" : "hota/factory/town/buildings/TBFaHRD1",
@@ -920,7 +921,7 @@
 					"campaignBonus" : "hota/factory/town/icons/campaignBonuses/BOFCrn1H",
 					"x" : 187,
 					"y" : 162,
-					"z" : -2,
+					"z" : -3,
 					"hidden" : true
 				},
 				"horde1Upgr" : {
@@ -930,7 +931,7 @@
 					"campaignBonus" : "hota/factory/town/icons/campaignBonuses/BOFCrn2H",
 					"x" : 187,
 					"y" : 95,
-					"z" : -2,
+					"z" : -3,
 					"hidden" : true
 				},
 				"special1" : {
@@ -991,7 +992,7 @@
 					"campaignBonus" : "hota/factory/town/icons/campaignBonuses/BOFCran1",
 					"x" : 187,
 					"y" : 174,
-					"z" : -2
+					"z" : -3
 				},
 				"dwellingLvl4" : {
 					"animation" : "hota/factory/town/buildings/TBFadw_3",
@@ -1000,7 +1001,7 @@
 					"campaignBonus" : "hota/factory/town/icons/campaignBonuses/BOFCman1",
 					"x" : 516,
 					"y" : 211,
-					"z" : 1
+					"z" : 3
 				},
 				"dwellingLvl5" : {
 					"animation" : "hota/factory/town/buildings/TBFadw_4",
@@ -1032,7 +1033,8 @@
 					"border" : "hota/factory/town-screen/buildings-border/TOFadw_7",
 					"campaignBonus" : "hota/factory/town/icons/campaignBonuses/BOFCgnt1",
 					"x" : 427,
-					"y" : 181
+					"y" : 181,
+					"z" : 2
 				},
 				"dwellingUpLvl1" : {
 					"animation" : "hota/factory/town/buildings/TBFaup_0",
@@ -1057,7 +1059,7 @@
 					"campaignBonus" : "hota/factory/town/icons/campaignBonuses/BOFCran2",
 					"x" : 187,
 					"y" : 95,
-					"z" : -2
+					"z" : -3
 				},
 				"dwellingUpLvl4" : {
 					"animation" : "hota/factory/town/buildings/TBFaup_3",
@@ -1066,7 +1068,7 @@
 					"campaignBonus" : "hota/factory/town/icons/campaignBonuses/BOFCman2",
 					"x" : 516,
 					"y" : 211,
-					"z" : 1
+					"z" : 3
 				},
 				"dwellingUpLvl5" : {
 					"animation" : "hota/factory/town/buildings/TBFaup_4",
@@ -1098,7 +1100,8 @@
 					"border" : "hota/factory/town-screen/buildings-border/TOFaup_7",
 					"campaignBonus" : "hota/factory/town/icons/campaignBonuses/BOFCgnt1",
 					"x" : 427,
-					"y" : 162
+					"y" : 162,
+					"z" : 2
 				}
 			},
 			"tavernVideo" : "TAVERN.BIK",

--- a/mods/heroes3DataPatch/content/config/heroes3DataPatch/structures.json
+++ b/mods/heroes3DataPatch/content/config/heroes3DataPatch/structures.json
@@ -37,7 +37,7 @@
 				"special3" : {
 					"x" : 208,
 					"y" : 143,
-					"z" : -2
+					"z" : -3
 				},
 				"dwellingUpLvl4" : {
 					"x" : 414,
@@ -74,6 +74,12 @@
 				"extraCityHall" : {
 					"x" : 486,
 					"y" : 203
+				},
+				"dwellingLvl6" : {
+					"z" : 10
+				},
+				"dwellingUpLvl6" : {
+					"z" : 10
 				},
 				"dwellingUpLvl7" : {
 					"x" : 43


### PR DESCRIPTION
This PR resolves the z-indices of overlapping buildings or changing z-indices in building upgrades throughout towns modified or introduced by HotA. Doing so fixed the display of the Castle Gate (now properly blends into background) and the Vault of Ashes (resolved the clipping of the decorative waterfall). I did not notice any visual changes in the other towns, so maybe we got lucky there.

I did not move any buildings (don't think there is anything wrong there), only adjusted z-indices.

@by003 you have a keen eye for details, can you check if I overlooked something?

Inferno: 

before:
<img width="1296" height="838" alt="infernobefore" src="https://github.com/user-attachments/assets/830af721-aa81-4841-99b9-25676b42b762" />

after: 

<img width="1296" height="838" alt="infernoafter" src="https://github.com/user-attachments/assets/ad95eae1-a3e9-417d-9dd6-79181fd01935" />

Conflux:

before:
<img width="1296" height="838" alt="confluxbefore" src="https://github.com/user-attachments/assets/10b3cbb1-5370-4e2a-b3a3-5f59e31f64b7" />

after:

<img width="1296" height="838" alt="confluxafter" src="https://github.com/user-attachments/assets/a70994fb-3d86-48bb-9e39-8a658d23ec4d" />

Cove:

before:
<img width="1296" height="838" alt="covebefore" src="https://github.com/user-attachments/assets/15dd0d65-0142-476d-951c-ab86286872e4" />

after: 
<img width="1296" height="838" alt="coveafter" src="https://github.com/user-attachments/assets/940478fc-8af1-4ed1-ac3a-78113045c7e3" />


Factory:

before:
<img width="1296" height="838" alt="factorybefore" src="https://github.com/user-attachments/assets/27accd17-f448-4c79-999c-449bba776e6d" />

after: 
<img width="1296" height="838" alt="factoryafter" src="https://github.com/user-attachments/assets/344f9687-4f5c-4890-b557-14e98843bc6d" />


Bulwark:

before:
<img width="1296" height="838" alt="bulwarkbefore" src="https://github.com/user-attachments/assets/cda09ca2-4d25-4ec7-a436-efc27f32044b" />

after: 

<img width="1296" height="838" alt="bulwarkafter" src="https://github.com/user-attachments/assets/9c9b8041-e232-447e-af18-263c9a48143a" />
