### PR TITLE
English text fixes

### DIFF
--- a/mods/bulwark/content/config/hota/bulwark/mapObjects/interactive/trapperLodge.json
+++ b/mods/bulwark/content/config/hota/bulwark/mapObjects/interactive/trapperLodge.json
@@ -5,7 +5,7 @@
 		"types" : {
 			"trapperLodge" : {
 				"name" : "Trapper Lodge",
-				"description" : "50% chance of getting 300-500 Gold\n25% chance of getting 3-5 Gremlins.\n25% chance of getting 3-5 Kobolds.",
+				"description" : "(50% chance of getting 300-500 Gold; 25% chance of getting 3-5 Gremlins; 25% chance of getting 3-5 Kobolds)\n",
 				"visitMode" : "once",
 				"onVisitedMessage" : "{Trapper Lodge}\n\nSomeone has already been in the lodge. Nothing's left here.",
 				"canRefuse" : true,

--- a/mods/bulwark/content/config/hota/bulwark/runes/runesSkill.json
+++ b/mods/bulwark/content/config/hota/bulwark/runes/runesSkill.json
@@ -177,7 +177,7 @@
 			}
 		},
 		"basic" : {
-			"description" : "{Basic Runes}\n\nBasic Runes allows the hero's units to accumulate up to 3 Rune Levels in combat. Each rune Level gives bonuses to their creatures' stats:\n1: +2 Attack, 2: +2 Defense, 3: +1 Speed.",
+			"description" : "{Basic Runes}\n\nBasic Runes allow hero's units to accumulate up to 3 Rune Levels in combat. Each Rune Level gives bonuses to the creature stats:\n\n{1}: +2 attack, {2}: +2 defence, {3}: +1 speed.\n\nThe bonuses of all achieved Rune Levels are cumulative. The unit gains +1 Rune Level when it attacks; +2 Rune Levels when it takes damage; +3 Rune Levels when it takes a defensive stance.",
 			"effects" : {
 				"runesCap" : {
 					"val" : 3
@@ -191,7 +191,7 @@
 			}
 		},
 		"advanced" : {
-			"description" : "{Advanced Runes}\n\nAdvanced Runes allows the hero's units to accumulate up to 6 Rune Levels in combat. Each rune Level gives bonuses to their creatures' stats:\n1: +2 Attack, 2: +2 Defense, 3: +1 Speed.\n4: +2 Attack, 5: +2 Defense, 6: +1 Speed.",
+			"description" : "{Advanced Runes}\n\nAdvanced Runes allow hero's units to accumulate up to 6 Rune Levels in combat. Each Rune Level gives bonuses to the creature stats:\n\n{1}: +2 attack, {2}: +2 defence, {3}: +1 speed;\n{4}: +2 attack, {5}: +2 defence, {6}: +1 speed.\n\nThe bonuses of all achieved Rune Levels are cumulative. The unit gains +1 Rune Level when it attacks; +2 Rune Levels when it takes damage; +3 Rune Levels when it takes a defensive stance.",
 			"effects" : {
 				"runesCap" : {
 					"val" : 6
@@ -205,7 +205,7 @@
 			}
 		},
 		"expert" : {
-			"description" : "{Expert Runes}\n\nExpert Runes allows the hero's units to accumulate up to 9 Rune Levels in combat. Each rune Level gives bonuses to their creatures' stats:\n1: +2 Attack, 2: +2 Defense, 3: +1 Speed.\n4: +2 Attack, 5: +2 Defense, 6: +1 Speed.\n7: +2 Attack, 8: +2 Defense, 9: +1 Speed.",
+			"description" : "{Expert Runes}\n\nExpert Runes allow hero's units to accumulate up to 9 Rune Levels in combat. Each Rune Level gives bonuses to the creature stats:\n\n{1}: +2 attack, {2}: +2 defence, {3}: +1 speed;\n{4}: +2 attack, {5}: +2 defence, {6}: +1 speed;\n{7}: +2 attack, {8}: +2 defence, {9}: +1 speed.\n\nThe bonuses of all achieved Rune Levels are cumulative. The unit gains +1 Rune Level when it attacks; +2 Rune Levels when it takes damage; +3 Rune Levels when it takes a defensive stance.",
 			"effects" : {
 				"runesCap" : {
 					"val" : 9

--- a/mods/highlandsTerrain/content/config/hota/highlands/hotaInteractive/gazebo.json
+++ b/mods/highlandsTerrain/content/config/hota/highlands/hotaInteractive/gazebo.json
@@ -5,7 +5,7 @@
 		"types" : {
 			"gazebo" : {
 				"name" : "Gazebo",
-				"description" : "(+2000 experience for 1000 gold once per hero)",
+				"description" : "(+2000 experience for 1000 gold once per hero)\n",
 				"rmg" : {
 					"value" : 1500,
 					"rarity" : 50,
@@ -23,15 +23,15 @@
 								"gold" : 1000
 							}
 						},
-						"message" : "{Gazebo}\r\n\r\nAnd old Knight appears on the steps of gazebo. \"I will teach you all that I know to aid you in your travels. However, I'll let you know a small donation to the Retired Knights' League is required. A thousand gold will suffice.\"",
+						"message" : "{Gazebo}\n\nAn old Knight appears on the steps of the gazebo. \"I will teach you all that I know to aid you in your travels. However, I'll let you know a small donation to the Retired Knights' League is required. A thousand gold will suffice.\"",
 						"heroExperience" : 2000,
 						"resources" : {
 							"gold" : -1000
 						}
 					}
 				],
-				"onVisitedMessage" : "{Gazebo}\r\n\r\nYou can hear loud snoring coming from gazebo. Apparently, the League has already put your donation to good use.",
-				"onEmptyMessage" : "{Gazebo}\r\n\r\nAn old Knight appears on the steps of the gazebo. \"I will teach you all that I know to aid you in your travels. However, I'll let you know a small donation to the Retired Knights' League is required. Come back when you scrape up a thousand gold.\"",
+				"onVisitedMessage" : "{Gazebo}\n\nYou can hear loud snoring coming from the gazebo. Apparently, the League has already put your donation to good use.",
+				"onEmptyMessage" : "{Gazebo}\n\nAn old Knight appears on the steps of the gazebo. \"I will teach you all that I know to aid you in your travels. However, I'll let you know a small donation to the Retired Knights' League is required. Come back when you scrape up a thousand gold.\"",
 				"canRefuse" : true,
 				"visitMode" : "hero",
 				"templates" : {

--- a/mods/highlandsTerrain/content/config/hota/highlands/hotaInteractive/hermitsShack.json
+++ b/mods/highlandsTerrain/content/config/hota/highlands/hotaInteractive/hermitsShack.json
@@ -66,7 +66,7 @@
 						"secondary" : {
 							"pathfinding" : 1
 						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
+						"message" : "{Hermit's Shack}\n\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
@@ -87,7 +87,7 @@
 						"secondary" : {
 							"archery" : 1
 						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
+						"message" : "{Hermit's Shack}\n\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
@@ -108,7 +108,7 @@
 						"secondary" : {
 							"logistics" : 1
 						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
+						"message" : "{Hermit's Shack}\n\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
@@ -129,7 +129,7 @@
 						"secondary" : {
 							"scouting" : 1
 						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
+						"message" : "{Hermit's Shack}\n\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
@@ -150,7 +150,7 @@
 						"secondary" : {
 							"diplomacy" : 1
 						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
+						"message" : "{Hermit's Shack}\n\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
@@ -171,7 +171,7 @@
 						"secondary" : {
 							"navigation" : 1
 						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
+						"message" : "{Hermit's Shack}\n\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
@@ -192,7 +192,7 @@
 						"secondary" : {
 							"leadership" : 1
 						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
+						"message" : "{Hermit's Shack}\n\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
@@ -213,7 +213,7 @@
 						"secondary" : {
 							"wisdom" : 1
 						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
+						"message" : "{Hermit's Shack}\n\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
@@ -234,7 +234,7 @@
 						"secondary" : {
 							"mysticism" : 1
 						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
+						"message" : "{Hermit's Shack}\n\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
@@ -255,7 +255,7 @@
 						"secondary" : {
 							"luck" : 1
 						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
+						"message" : "{Hermit's Shack}\n\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
@@ -276,7 +276,7 @@
 						"secondary" : {
 							"ballistics" : 1
 						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
+						"message" : "{Hermit's Shack}\n\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
@@ -297,7 +297,7 @@
 						"secondary" : {
 							"eagleEye" : 1
 						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
+						"message" : "{Hermit's Shack}\n\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
@@ -318,7 +318,7 @@
 						"secondary" : {
 							"necromancy" : 1
 						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
+						"message" : "{Hermit's Shack}\n\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
@@ -339,7 +339,7 @@
 						"secondary" : {
 							"estates" : 1
 						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
+						"message" : "{Hermit's Shack}\n\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
@@ -360,7 +360,7 @@
 						"secondary" : {
 							"fireMagic" : 1
 						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
+						"message" : "{Hermit's Shack}\n\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
@@ -381,7 +381,7 @@
 						"secondary" : {
 							"airMagic" : 1
 						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
+						"message" : "{Hermit's Shack}\n\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
@@ -402,7 +402,7 @@
 						"secondary" : {
 							"waterMagic" : 1
 						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
+						"message" : "{Hermit's Shack}\n\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
@@ -423,7 +423,7 @@
 						"secondary" : {
 							"earthMagic" : 1
 						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
+						"message" : "{Hermit's Shack}\n\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
@@ -444,7 +444,7 @@
 						"secondary" : {
 							"scholar" : 1
 						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
+						"message" : "{Hermit's Shack}\n\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
@@ -465,7 +465,7 @@
 						"secondary" : {
 							"tactics" : 1
 						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
+						"message" : "{Hermit's Shack}\n\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
@@ -486,7 +486,7 @@
 						"secondary" : {
 							"artillery" : 1
 						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
+						"message" : "{Hermit's Shack}\n\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
@@ -507,7 +507,7 @@
 						"secondary" : {
 							"learning" : 1
 						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
+						"message" : "{Hermit's Shack}\n\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
@@ -528,7 +528,7 @@
 						"secondary" : {
 							"offence" : 1
 						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
+						"message" : "{Hermit's Shack}\n\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
@@ -549,7 +549,7 @@
 						"secondary" : {
 							"armorer" : 1
 						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
+						"message" : "{Hermit's Shack}\n\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
@@ -570,7 +570,7 @@
 						"secondary" : {
 							"intelligence" : 1
 						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
+						"message" : "{Hermit's Shack}\n\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
@@ -591,7 +591,7 @@
 						"secondary" : {
 							"sorcery" : 1
 						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
+						"message" : "{Hermit's Shack}\n\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
@@ -612,7 +612,7 @@
 						"secondary" : {
 							"resistance" : 1
 						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
+						"message" : "{Hermit's Shack}\n\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					},
 					{
 						"limiter" : {
@@ -633,7 +633,7 @@
 						"secondary" : {
 							"firstAid" : 1
 						},
-						"message" : "{Hermit's Shack}\r\n\r\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
+						"message" : "{Hermit's Shack}\n\nOn entering the shack you see nobody home, but the walls appear lined with pages from scholarly books. You copy some useful informations from a sheet near the fireplace."
 					}
 				]
 			}

--- a/mods/highlandsTerrain/content/config/hota/highlands/hotaInteractive/junkman.json
+++ b/mods/highlandsTerrain/content/config/hota/highlands/hotaInteractive/junkman.json
@@ -5,7 +5,7 @@
 		"types" : {
 			"junkman" : {
 				"name" : "Junkman",
-				"description" : "(Artifacts except Spell Scrolls may be sold to Junkman (at the efficiency of 7 markets))",
+				"description" : "(Artifacts except Spell Scrolls may be sold to Junkman (at the efficiency of 7 markets))\n",
 				"speech" : "",
 				"modes" : [
 					"artifact-resource"

--- a/mods/highlandsTerrain/content/config/hota/highlands/hotaInteractive/mineralSpring.json
+++ b/mods/highlandsTerrain/content/config/hota/highlands/hotaInteractive/mineralSpring.json
@@ -4,6 +4,7 @@
 		"name" : "Mineral Spring",
 		"types" : {
 			"mineralSpring" : {
+				"description" : "(+1 luck until next battle and +600 movement points for one day)\n",
 				"rmg" : {
 					"value" : 500,
 					"rarity" : 50,
@@ -16,7 +17,7 @@
 				},
 				"rewards" : [
 					{
-						"message" : "{Mineral Spring}\r\n\r\nHorses look less than thrilled to drink the salty water, but soon you notice them prancing around with new vigor. Rainbow forms in the droplets above the sparkling spring, and the sight brings everyone to a happy mood.",
+						"message" : "{Mineral Spring}\n\nHorses look less than thrilled to drink the salty water, but soon you notice them prancing around with new vigor. Rainbow forms in the droplets above the sparkling spring, and the sight brings everyone to a happy mood.",
 						"movePoints" : 600,
 						"bonuses" : [
 							{
@@ -27,7 +28,7 @@
 						]
 					}
 				],
-				"onVisitedMessage" : "{Mineral Spring}\r\n\r\nEverybody's belly is chock full of bubbly water. That's enough hydration for today.",
+				"onVisitedMessage" : "{Mineral Spring}\n\nEverybody's belly is chock full of bubbly water. That's enough hydration for today.",
 				"visitMode" : "bonus",
 				"templates" : {
 					"AVXmspr0" : {

--- a/mods/interference/content/config/hotaInterference/interference.json
+++ b/mods/interference/content/config/hotaInterference/interference.json
@@ -30,7 +30,7 @@
 			}
 		},
 		"basic" : {
-			"description" : "{Basic Interference}\n\nReduces enemy hero spell power during combat by 10%.",
+			"description" : "{Basic Interference}\n\nBasic Interference reduces the Power skill of enemy hero by 10% during combat.",
 			"effects" : {
 				"main" : {
 					"val" : -10
@@ -47,7 +47,7 @@
 			}
 		},
 		"advanced" : {
-			"description" : "{Advanced Interference}\n\nReduces enemy hero spell power during combat by 20%.",
+			"description" : "{Advanced Interference}\n\nAdvanced Interference reduces the Power skill of enemy hero by 20% during combat.",
 			"effects" : {
 				"main" : {
 					"val" : -20
@@ -64,7 +64,7 @@
 			}
 		},
 		"expert" : {
-			"description" : "{Expert Interference}\n\nReduces enemy hero spell power during combat by 30%.",
+			"description" : "{Expert Interference}\n\nExpert Interference reduces the Power skill of enemy hero by 30% during combat.",
 			"effects" : {
 				"main" : {
 					"val" : -30

--- a/mods/mapObjects/content/config/hotaMapObjects/altarOfMana.json
+++ b/mods/mapObjects/content/config/hotaMapObjects/altarOfMana.json
@@ -5,7 +5,7 @@
 		"types" : {
 			"altarOfMana" : {
 				"name" : "Altar of Mana",
-				"description" : "(Heroes may sacrifice creatures for spell points, up to 4x the normal cap).",
+				"description" : "(Heroes may sacrifice creatures for spell points, up to 4x the normal cap)\n",
 				"sounds" : {
 					"visit" : [
 						"MYSTERY"

--- a/mods/mapObjects/content/config/hotaMapObjects/ancientLamp.json
+++ b/mods/mapObjects/content/config/hotaMapObjects/ancientLamp.json
@@ -7,7 +7,7 @@
 				"blockedVisitable" : true,
 				"removable" : true,
 				"name" : "Ancient Lamp",
-				"description" : "Allows you to recruit 4-6 Master Genie once.",
+				"description" : "(Allows you to recruit 4-6 Master Genies once)\n",
 				"rmg" : {
 					"value" : 5000,
 					"rarity" : 200,
@@ -35,7 +35,7 @@
 								"gold" : 3600
 							}
 						},
-						"message" : "{Ancient Lamp}\r\n\r\nA battered turban emerges from the lamp, sitting atop his djinn owner's head. \"Oh, aren't these some employers. Again. Got money? We aren't going to work for magic beans again. And we will NOT grant any wishes. The rest, you can count on us.\"",
+						"message" : "{Ancient Lamp}\n\nA battered turban emerges from the lamp, sitting atop its genie owner's head. \"Oh, aren't these some employers. Again. Got money? We aren't going to work for magic beans again. And we will NOT grant any wishes. The rest, you can count on us.\"",
 						"creatures" : [
 							{
 								"type" : "masterGenie",
@@ -53,7 +53,7 @@
 								"gold" : 3000
 							}
 						},
-						"message" : "{Ancient Lamp}\r\n\r\nA battered turban emerges from the lamp, sitting atop his djinn owner's head. \"Oh, aren't these some employers. Again. Got money? We aren't going to work for magic beans again. And we will NOT grant any wishes. The rest, you can count on us.\"",
+						"message" : "{Ancient Lamp}\n\nA battered turban emerges from the lamp, sitting atop its genie owner's head. \"Oh, aren't these some employers. Again. Got money? We aren't going to work for magic beans again. And we will NOT grant any wishes. The rest, you can count on us.\"",
 						"creatures" : [
 							{
 								"type" : "masterGenie",
@@ -71,7 +71,7 @@
 								"gold" : 2400
 							}
 						},
-						"message" : "{Ancient Lamp}\r\n\r\nA battered turban emerges from the lamp, sitting atop his djinn owner's head. \"Oh, aren't these some employers. Again. Got money? We aren't going to work for magic beans again. And we will NOT grant any wishes. The rest, you can count on us.\"",
+						"message" : "{Ancient Lamp}\n\nA battered turban emerges from the lamp, sitting atop its genie owner's head. \"Oh, aren't these some employers. Again. Got money? We aren't going to work for magic beans again. And we will NOT grant any wishes. The rest, you can count on us.\"",
 						"creatures" : [
 							{
 								"type" : "masterGenie",
@@ -84,7 +84,7 @@
 						"removeObject" : true
 					}
 				],
-				"onEmptyMessage" : "{Ancient Lamp}\r\n\r\nA battered turban emerges from the lamp, sitting atop his djinn owner's head. \"Oh, aren't these some employers. Again. Got money? We aren't going to work for magic beans again. And we will NOT grant any wishes. Come back when you can find some gold to spare.\"",
+				"onEmptyMessage" : "{Ancient Lamp}\n\nA battered turban emerges from the lamp, sitting atop his djinn owner's head. \"Oh, aren't these some employers. Again. Got money? We aren't going to work for magic beans again. And we will NOT grant any wishes. Come back when you can find some gold to spare.\"",
 				"canRefuse" : true,
 				"visitMode" : "unlimited",
 				"compatibilityIdentifiers" : [

--- a/mods/mapObjects/content/config/hotaMapObjects/colosseum.json
+++ b/mods/mapObjects/content/config/hotaMapObjects/colosseum.json
@@ -1,11 +1,11 @@
 {
 	"colosseumOfTheMagi" : {
-		"name" : "Colosseum Of The Magi",
+		"name" : "Colosseum of the Magi",
 		"handler" : "configurable",
 		"types" : {
 			"colosseumOfTheMagi" : {
-				"name" : "Colosseum Of The Magi",
-				"description" : "(+2 spellpower or knowledge\nonce per hero)",
+				"name" : "Colosseum of the Magi",
+				"description" : "(+2 spell power or knowledge once per hero)\n",
 				"rmg" : {
 					"value" : 3000,
 					"rarity" : 50,
@@ -31,8 +31,8 @@
 						}
 					}
 				],
-				"onSelectMessage" : "{Colosseum Of The Magi}\r\n\r\nA big show is taking place at the Colosseum today. You enter the arena and hold the audience in awe with your magical prowess. Insatiable hunger for knowledge is what makes a true mage, so you gladly accept the first prize, which is one the newest academical handbooks.",
-				"onVisitedMessage" : "{Colosseum Of The Magi}\r\n\r\nModerator of the Colosseum instantly recognises you but respectfully denies entrance to the competitor zone. You probably should rather be featuring as a talent judge here!",
+				"onSelectMessage" : "{Colosseum Of The Magi}\n\nA big show is taking place at the Colosseum today. You enter the arena and hold the audience in awe with your magical prowess. Insatiable hunger for knowledge is what makes a true mage, so you gladly accept the first prize, which is one the newest academical handbooks.",
+				"onVisitedMessage" : "{Colosseum Of The Magi}\n\nModerator of the Colosseum instantly recognises you but respectfully denies entrance to the competitor zone. \"You probably should rather be featuring as a talent judge here!\"",
 				"visitMode" : "hero",
 				"selectMode" : "selectPlayer",
 				"templates" : {

--- a/mods/mapObjects/content/config/hotaMapObjects/hillFort.json
+++ b/mods/mapObjects/content/config/hotaMapObjects/hillFort.json
@@ -4,7 +4,7 @@
 		"name" : "Hill Fort",
 		"types" : {
 			"miniHillFort" : {
-				"description" : "Upgrade level 1-5 creatures at double the price from the associated town.",
+				"description" : "(Upgrade level 1-5 creatures for double the price)\n",
 				"unavailableUpgradeMessage" : "This building cannot upgrade creatures of level 5 and higher.",
 				"rmg" : {
 					"value" : 7000,

--- a/mods/mapObjects/content/config/hotaMapObjects/ivoryTower.json
+++ b/mods/mapObjects/content/config/hotaMapObjects/ivoryTower.json
@@ -43,8 +43,8 @@
 					"rarity" : 100
 				},
 				"blockedVisitable" : false,
-				"onGuardedMessage" : 32,
-				"onVisitedMessage" : 33,
+				"onGuardedMessage" : "You stand in front of an Ivory Tower. Mage foes keep the prisoners captured. Taking their side will allow you to gain valuable allies. Are you ready to test your fortune?",
+				"onVisitedMessage" : "You enter the Ivory Tower, however nobody is home.",
 				"visitMode" : "once",
 				"selectMode" : "selectFirst",
 				"guardsLayout" : "creatureBankNarrow",

--- a/mods/mapObjects/content/config/hotaMapObjects/jetsam.json
+++ b/mods/mapObjects/content/config/hotaMapObjects/jetsam.json
@@ -31,7 +31,7 @@
 							"max" : 25
 						},
 						"mapDice" : 0,
-						"message" : "{Jetsam}\r\n\r\nYou inspect the jettisoned cargo. Nothing of value can be found.",
+						"message" : "{Jetsam}\n\nYou inspect the jettisoned cargo. Nothing of value can be found.",
 						"removeObject" : true
 					},
 					{
@@ -43,7 +43,7 @@
 						"resources" : {
 							"ore" : 5
 						},
-						"message" : "{Jetsam}\r\n\r\nYou inspect the jettisoned cargo. Most of it is spoilt by sea water, but you are able to salvage some ore.",
+						"message" : "{Jetsam}\n\nYou inspect the jettisoned cargo. Most of it is spoilt by sea water, but you are able to salvage some ore.",
 						"removeObject" : true
 					},
 					{
@@ -56,7 +56,7 @@
 							"gold" : 200
 						},
 						"mapDice" : 2,
-						"message" : "{Jetsam}\r\n\r\nYou inspect the jettisoned cargo. Some ore and gold go into your coffers.",
+						"message" : "{Jetsam}\n\nYou inspect the jettisoned cargo. Some ore and gold go into your coffers.",
 						"removeObject" : true
 					},
 					{
@@ -69,7 +69,7 @@
 							"gold" : 500
 						},
 						"mapDice" : 3,
-						"message" : "{Jetsam}\r\n\r\nYou inspect the jettisoned cargo. Some ore and gold go into your coffers.",
+						"message" : "{Jetsam}\n\nYou inspect the jettisoned cargo. Considerable amounts of ore and gold are found within.",
 						"removeObject" : true
 					}
 				],

--- a/mods/mapObjects/content/config/hotaMapObjects/observatory.json
+++ b/mods/mapObjects/content/config/hotaMapObjects/observatory.json
@@ -4,6 +4,7 @@
 		"name" : "Observatory",
 		"types" : {
 			"observatory" : {
+				"description" : "(+2 scouting radius until the end of the week)\n",
 				"sounds" : {
 					"visit" : [
 						"LIGHTHOUSE"
@@ -16,7 +17,7 @@
 				},
 				"rewards" : [
 					{
-						"message" : "{Observatory}\r\n\r\nAn astronomer offers you to take his apprentice for a shipboy. You might find his lookout skill useful, while the youth could do with a break from studies. However, the astronomer will need him back in a week for the next round of planned observations.",
+						"message" : "{Observatory}\n\nAn astronomer offers you to take his apprentice for a shipboy. You might find his lookout skill useful, while the youth could do with a break from studies. However, the astronomer will need him back in a week for the next round of planned observations.",
 						"bonuses" : [
 							{
 								"type" : "SIGHT_RADIUS",
@@ -28,7 +29,7 @@
 					}
 				],
 				"blockedVisitable" : false,
-				"onVisitedMessage" : "{Observatory}\r\n\r\nThe astronomer is absent from his tower. A note posted on the door reads: \"Will be back in a week\".",
+				"onVisitedMessage" : "{Observatory}\n\nThe astronomer is absent from his tower. A note posted on the door reads: \"Will be back in a week.\"",
 				"canRefuse" : false,
 				"visitMode" : "bonus",
 				"selectMode" : "selectPlayer",

--- a/mods/mapObjects/content/config/hotaMapObjects/seaBarrel.json
+++ b/mods/mapObjects/content/config/hotaMapObjects/seaBarrel.json
@@ -49,7 +49,7 @@
 							"max" : 20
 						},
 						"mapDice" : 1,
-						"message" : "{Sea Barrel}\r\n\r\nThis barrel is full of sea water. You have no idea why it is still afloat.",
+						"message" : "{Sea Barrel}\n\nThis barrel is full of sea water. You have no idea why it is still afloat.",
 						"removeObject" : true
 					},
 					{
@@ -63,7 +63,7 @@
 								"amount" : "@gainedAmount"
 							}
 						],
-						"message" : "{Sea Barrel}\r\n\r\nThis barrel is holding neither water nor wine, but rather some smuggled goods.",
+						"message" : "{Sea Barrel}\n\nThis barrel is holding neither water nor wine, but rather some smuggled goods.",
 						"removeObject" : true
 					}
 				],

--- a/mods/mapObjects/content/config/hotaMapObjects/shrineOfMagicMystery.json
+++ b/mods/mapObjects/content/config/hotaMapObjects/shrineOfMagicMystery.json
@@ -12,7 +12,7 @@
 				},
 				"visitMode" : "limiter",
 				"visitedTooltip" : 354,
-				"description" : "(Learn 4th level spell)",
+				"description" : "(Learn 4th level spell)\n",
 				"showScoutedPreview" : true,
 				"variables" : {
 					"spell" : {
@@ -38,10 +38,10 @@
 							"@gainedSpell"
 						],
 						"description" : "@core.genrltxt.355",
-						"message" : "{Shrine of Magic Mystery}\r\n\r\nYou come across an ancient shrine attended by a group of ascetic hermits. In exchange for your protection, they agree to teach you a spell - {%s}."
+						"message" : "{Shrine of Magic Mystery}\n\nYou come across an ancient shrine attended by a group of ascetic hermits. In exchange for your protection, they agree to teach you a spell - {%s}."
 					}
 				],
-				"onVisitedMessage" : "{Shrine of Magic Mystery}\r\n\r\nYou come across an ancient shrine attended by a group of ascetic hermits. In exchange for your protection, they agree to teach you a spell - {%s}. Unfortunately, you already have knowledge of this spell, so there is nothing more for them to teach you.",
+				"onVisitedMessage" : "{Shrine of Magic Mystery}\n\nYou come across an ancient shrine attended by a group of ascetic hermits. In exchange for your protection, they agree to teach you a spell - {%s}. Unfortunately, you already have knowledge of this spell, so there is nothing more for them to teach you.",
 				"onEmpty" : [
 					{
 						"limiter" : {
@@ -51,10 +51,10 @@
 								}
 							]
 						},
-						"message" : "{Shrine of Magic Mystery}\r\n\r\nYou come across an ancient shrine attended by a group of ascetic hermits. In exchange for your protection, they agree to teach you a spell - {%s}. Unfortunately, you do not have the wisdom to understand the spell, and are unable to learn it."
+						"message" : "{Shrine of Magic Mystery}\n\nYou come across an ancient shrine attended by a group of ascetic hermits. In exchange for your protection, they agree to teach you a spell - {%s}. Unfortunately, you do not have the wisdom to understand the spell, and are unable to learn it."
 					},
 					{
-						"message" : "{Shrine of Magic Mystery}\r\n\r\nYou come across an ancient shrine attended by a group of ascetic hermits. In exchange for your protection, they agree to teach you a spell - {%s}. Unfortunately, you have no Spell Book to record the spell with."
+						"message" : "{Shrine of Magic Mystery}\n\nYou come across an ancient shrine attended by a group of ascetic hermits. In exchange for your protection, they agree to teach you a spell - {%s}. Unfortunately, you have no Spell Book to record the spell with."
 					}
 				],
 				"base" : {

--- a/mods/mapObjects/content/config/hotaMapObjects/templeOfTheSea.json
+++ b/mods/mapObjects/content/config/hotaMapObjects/templeOfTheSea.json
@@ -2,7 +2,7 @@
 	"core:creatureBank" : {
 		"types" : {
 			"templeOfTheSea" : {
-				"name" : "Temple Of The Sea",
+				"name" : "Temple of the Sea",
 				"templates" : {
 					"base" : {
 						"animation" : "hota/banks/AVSutopW.def",

--- a/mods/mapObjects/content/config/hotaMapObjects/townGate.json
+++ b/mods/mapObjects/content/config/hotaMapObjects/townGate.json
@@ -5,7 +5,7 @@
 		"types" : {
 			"townGate" : {
 				"name" : "Town Gate",
-				"description" : "(Teleport hero to any allied town)",
+				"description" : "(Teleport hero to any allied town)\n",
 				"rmg" : {
 					"value" : 10000,
 					"rarity" : 20,
@@ -17,7 +17,7 @@
 					]
 				},
 				"blockedVisitable" : true,
-				"onVisitedMessage" : "{Town Gate}\r\n\r\nSelect a destination", //TODO: In HoTA there is no extra message, but custom icon
+				"onVisitedMessage" : "{Town Gate}\n\nSelect a destination:", //TODO: In HoTA there is no extra message, but custom icon
 				"visitMode" : "unlimited",
 				"rewards" : [
 					{

--- a/mods/mapObjects/content/config/hotaMapObjects/vialOfMana.json
+++ b/mods/mapObjects/content/config/hotaMapObjects/vialOfMana.json
@@ -5,7 +5,7 @@
 		"types" : {
 			"vialOfMana" : {
 				"name" : "Vial of Mana",
-				"description" : "(grants 30-60 spell points)",
+				"description" : "(grants 30-60 spell points)\n",
 				"sounds" : {
 					"visit" : [
 						"hota/BOTTLVIS"
@@ -25,7 +25,7 @@
 						"mapDice" : 0,
 						"manaPoints" : 30,
 						"manaOverflowFactor" : 50,
-						"message" : "{Vial of Mana}\r\n\r\nYou get hold of the vial, but are disappointed to see it lacking any messsage. There's only water inside, suprisingly fresh though.",
+						"message" : "{Vial of Mana}\n\nYou get hold of the vial, but are disappointed to see it lacking any message. There's only water inside, surprizingly fresh though.",
 						"removeObject" : true
 					},
 					{
@@ -36,7 +36,7 @@
 						"mapDice" : 1,
 						"manaPoints" : 40,
 						"manaOverflowFactor" : 50,
-						"message" : "{Vial of Mana}\r\n\r\nYou get hold of the vial, but are disappointed to see it lacking any messsage. There's only water inside, suprisingly fresh though.",
+						"message" : "{Vial of Mana}\n\nYou get hold of the vial, but are disappointed to see it lacking any message. There's only water inside, surprizingly fresh though.",
 						"removeObject" : true
 					},
 					{
@@ -47,7 +47,7 @@
 						"mapDice" : 2,
 						"manaPoints" : 50,
 						"manaOverflowFactor" : 50,
-						"message" : "{Vial of Mana}\r\n\r\nYou get hold of the vial, but are disappointed to see it lacking any messsage. There's only water inside, suprisingly fresh though.",
+						"message" : "{Vial of Mana}\n\nYou get hold of the vial, but are disappointed to see it lacking any message. There's only water inside, surprizingly fresh though.",
 						"removeObject" : true
 					},
 					{
@@ -58,7 +58,7 @@
 						"mapDice" : 3,
 						"manaPoints" : 60,
 						"manaOverflowFactor" : 50,
-						"message" : "{Vial of Mana}\r\n\r\nYou get hold of the vial, but are disappointed to see it lacking any messsage. There's only water inside, suprisingly fresh though.",
+						"message" : "{Vial of Mana}\n\nYou get hold of the vial, but are disappointed to see it lacking any message. There's only water inside, surprizingly fresh though.",
 						"removeObject" : true
 					}
 				],

--- a/mods/mapObjects/content/config/hotaMapObjects/warehouse.json
+++ b/mods/mapObjects/content/config/hotaMapObjects/warehouse.json
@@ -44,10 +44,10 @@
 						"resources" : {
 							"crystal" : 6
 						},
-						"message" : "{Warehouse of Crystal}\r\n\r\nThe owner of the storage makes haste to tell you: 'My Lord, I`ve gathered all crystals from the nearby production points for you. Come next week for the new portion!'"
+						"message" : "{Warehouse of Crystal}\n\nThe owner of the storage makes haste to tell you: 'My Lord, I`ve gathered all crystals from the nearby production points for you. Come next week for the new portion!'"
 					}
 				],
-				"onVisitedMessage" : "{Warehouse of Crystal}\r\n\r\nThe owner of the storage is apologising: 'I am sorry Milord, no crystal here. Please, return next week!'",
+				"onVisitedMessage" : "{Warehouse of Crystal}\n\nThe owner of the storage is apologising: 'I am sorry Milord, no crystal here. Please, return next week!'",
 				"templates" : {
 					"avwrhscr" : {
 						"animation" : "hota/warehouses/avwrhscr"
@@ -66,10 +66,10 @@
 						"resources" : {
 							"gems" : 6
 						},
-						"message" : "{Warehouse of Gem}\r\n\r\nThe owner of the storage makes haste to tell you: 'My Lord, I`ve gathered all gems from the nearby production points for you. Come next week for the new portion!'"
+						"message" : "{Warehouse of Gem}\n\nThe owner of the storage makes haste to tell you: 'My Lord, I`ve gathered all gems from the nearby production points for you. Come next week for the new portion!'"
 					}
 				],
-				"onVisitedMessage" : "{Warehouse of Gem}\r\n\r\nThe owner of the storage is apologising: 'I am sorry Milord, no gems here. Please, return next week!'",
+				"onVisitedMessage" : "{Warehouse of Gem}\n\nThe owner of the storage is apologising: 'I am sorry Milord, no gems here. Please, return next week!'",
 				"templates" : {
 					"avwrhsgm" : {
 						"animation" : "hota/warehouses/avwrhsgm"
@@ -88,10 +88,10 @@
 						"resources" : {
 							"sulfur" : 6
 						},
-						"message" : "{Warehouse of Sulfur}\r\n\r\nThe owner of the storage makes haste to tell you: 'My Lord, I`ve gathered all sulfur from the nearby production points for you. Come next week for the new portion!'"
+						"message" : "{Warehouse of Sulfur}\n\nThe owner of the storage makes haste to tell you: 'My Lord, I`ve gathered all sulfur from the nearby production points for you. Come next week for the new portion!'"
 					}
 				],
-				"onVisitedMessage" : "{Warehouse of Sulfur}\r\n\r\nThe owner of the storage is apologising: 'I am sorry Milord, no sulfur here. Please, return next week!'",
+				"onVisitedMessage" : "{Warehouse of Sulfur}\n\nThe owner of the storage is apologising: 'I am sorry Milord, no sulfur here. Please, return next week!'",
 				"templates" : {
 					"avwrhssf" : {
 						"animation" : "hota/warehouses/avwrhssf"
@@ -110,10 +110,10 @@
 						"resources" : {
 							"mercury" : 6
 						},
-						"message" : "{Warehouse of Mercury}\r\n\r\nThe owner of the storage makes haste to tell you: 'My Lord, I`ve gathered all mercury from the nearby production points for you. Come next week for the new portion!'"
+						"message" : "{Warehouse of Mercury}\n\nThe owner of the storage makes haste to tell you: 'My Lord, I`ve gathered all mercury from the nearby production points for you. Come next week for the new portion!'"
 					}
 				],
-				"onVisitedMessage" : "{Warehouse of Mercury}\r\n\r\nThe owner of the storage is apologising: 'I am sorry Milord, no mercury here. Please, return next week!'",
+				"onVisitedMessage" : "{Warehouse of Mercury}\n\nThe owner of the storage is apologising: 'I am sorry Milord, no mercury here. Please, return next week!'",
 				"templates" : {
 					"avwrhsmc" : {
 						"animation" : "hota/warehouses/avwrhsmc"
@@ -136,10 +136,10 @@
 						"resources" : {
 							"wood" : 10
 						},
-						"message" : "{Warehouse of Wood}\r\n\r\nThe owner of the storage makes haste to tell you: 'My Lord, I`ve gathered all wood from the nearby production points for you. Come next week for the new portion!'"
+						"message" : "{Warehouse of Wood}\n\nThe owner of the storage makes haste to tell you: 'My Lord, I`ve gathered all wood from the nearby production points for you. Come next week for the new portion!'"
 					}
 				],
-				"onVisitedMessage" : "{Warehouse of Wood}\r\n\r\nThe owner of the storage is apologising: 'I am sorry Milord, no wood here. Please, return next week!'",
+				"onVisitedMessage" : "{Warehouse of Wood}\n\nThe owner of the storage is apologising: 'I am sorry Milord, no wood here. Please, return next week!'",
 				"templates" : {
 					"avwrhswd" : {
 						"animation" : "hota/warehouses/avwrhswd"
@@ -162,10 +162,10 @@
 						"resources" : {
 							"ore" : 10
 						},
-						"message" : "{Warehouse of Ore}\r\n\r\nThe owner of the storage makes haste to tell you: 'My Lord, I`ve gathered all ore from the nearby production points for you. Come next week for the new portion!'"
+						"message" : "{Warehouse of Ore}\n\nThe owner of the storage makes haste to tell you: 'My Lord, I`ve gathered all ore from the nearby production points for you. Come next week for the new portion!'"
 					}
 				],
-				"onVisitedMessage" : "{Warehouse of Ore}\r\n\r\nThe owner of the storage is apologising: 'I am sorry Milord, no ore here. Please, return next week!'",
+				"onVisitedMessage" : "{Warehouse of Ore}\n\nThe owner of the storage is apologising: 'I am sorry Milord, no ore here. Please, return next week!'",
 				"templates" : {
 					"avwrhsor" : {
 						"animation" : "hota/warehouses/avwrhsor"
@@ -188,10 +188,10 @@
 						"resources" : {
 							"gold" : 2000
 						},
-						"message" : "{Warehouse of Gold}\r\n\r\nThe owner of the storage makes haste to tell you: 'My Lord, I`ve gathered all gold from the nearby production points for you. Come next week for the new portion!'"
+						"message" : "{Warehouse of Gold}\n\nThe owner of the storage makes haste to tell you: 'My Lord, I`ve gathered all gold from the nearby production points for you. Come next week for the new portion!'"
 					}
 				],
-				"onVisitedMessage" : "{Warehouse of Gold}\r\n\r\nThe owner of the storage is apologising: 'I am sorry Milord, no gold here. Please, return next week!'",
+				"onVisitedMessage" : "{Warehouse of Gold}\n\nThe owner of the storage is apologising: 'I am sorry Milord, no gold here. Please, return next week!'",
 				"templates" : {
 					"avwrhsgl" : {
 						"animation" : "hota/warehouses/avwrhsgl"

--- a/mods/mapObjects/content/config/hotaMapObjects/wateringPlace.json
+++ b/mods/mapObjects/content/config/hotaMapObjects/wateringPlace.json
@@ -4,6 +4,7 @@
 		"name" : "Watering Place",
 		"types" : {
 			"wateringPlace" : {
+				"description" : "(+1000 movement points next day for all remaining movement)\n",
 				"aiValue" : 3000,
 				"rmg" : {
 					"value" : 500,
@@ -17,7 +18,7 @@
 				},
 				"rewards" : [
 					{
-						"message" : "{Watering Place}\r\n\r\nLooks like a nice place for an overnight stop. Tomorrow your troops will be as fresh as they never were. Would you like to call it a day?",
+						"message" : "{Watering Place}\n\nLooks like a nice place for an overnight stop. Tomorrow your troops will be as fresh as they never were. Would you like to call it a day?",
 						"movePercentage" : 0,
 						"bonuses" : [
 							{
@@ -31,7 +32,7 @@
 						]
 					}
 				],
-				"onVisitedMessage" : "{Watering Place}\r\n\r\nTroops are in a full blown recuperation mode. No chance of getting them into marching mood until tomorrow.",
+				"onVisitedMessage" : "{Watering Place}\n\nTroops are in a full blown recuperation mode. No chance of getting them into marching mood until tomorrow.",
 				"canRefuse" : true,
 				"visitMode" : "once",
 				"resetParameters" : {

--- a/mods/textPolishing/content/config/englishTextPolishing/objectDescriptions.json
+++ b/mods/textPolishing/content/config/englishTextPolishing/objectDescriptions.json
@@ -1,22 +1,22 @@
 {
 	// swanPond
-	"core.xtrainfo.1" : "(+2 luck until next battle for all remained movement)",
+	"core.xtrainfo.1" : "(+2 luck until next battle for all remained movement)\n",
 	// fountainOfFortune
-	"core.xtrainfo.3" : "(+1, +2, +3, or -1 luck until next battle)",
+	"core.xtrainfo.3" : "(+1, +2, +3, or -1 luck until next battle)\n",
 	// fountainOfYouth
-	"core.xtrainfo.13" : "(+1 morale until next battle and +400 movement points for one day)",
+	"core.xtrainfo.13" : "(+1 morale until next battle and +400 movement points for one day)\n",
 	// rallyFlag
-	"core.xtrainfo.17" : "(+1 luck and morale until next battle and +400 movement points for one day)",
+	"core.xtrainfo.17" : "(+1 luck and morale until next battle and +400 movement points for one day)\n",
 	// treeOfKnowledge
-	"core.xtrainfo.18" : "(+1 level for free, 2000 gold, or 10 gems)",
+	"core.xtrainfo.18" : "(+1 level for free, 2000 gold, or 10 gems)\n",
 	// idolOfFortune
-	"core.xtrainfo.22" : "(+1 luck and/or +1 morale until next battle)",
+	"core.xtrainfo.22" : "(+1 luck and/or +1 morale until next battle)\n",
 	// temple
-	"core.xtrainfo.23" : "(+1 or +2 morale until next battle)",
+	"core.xtrainfo.23" : "(+1 or +2 morale until next battle)\n",
 	// oasis
-	"core.xtrainfo.26" : "(+1 morale until next battle and +800 movement points for one day)",
+	"core.xtrainfo.26" : "(+1 morale until next battle and +800 movement points for one day)\n",
 	//wateringHole
-	"core.xtrainfo.27" : "(+1 morale until next battle and +400 movement points for one day)",
+	"core.xtrainfo.27" : "(+1 morale until next battle and +400 movement points for one day)\n",
 	// hillFort - will work once VCMI allows indirect strings in hillFort
-	"core.xtrainfo.14" : "(Upgrade creatures level 1 for free, 2 — for 25% price, 3 — for 50%, 4 — for 75%, 5–7 — for 100%)"
+	"core.xtrainfo.14" : "(Upgrade creatures level 1 for free, 2 — for 25% price, 3 — for 50%, 4 — for 75%, 5–7 — for 100%)\n"
 }

--- a/mods/wastelandTerrain/content/config/hota/wasteland/hotaInteractive/derrick.json
+++ b/mods/wastelandTerrain/content/config/hota/wasteland/hotaInteractive/derrick.json
@@ -5,7 +5,7 @@
 		"types" : {
 			"derrick" : {
 				"name" : "Derrick",
-				"description" : "(+500 gold on first week, 1000 gold on every other week)",
+				"description" : "(+500 gold on first week, 1000 gold on every other week)\n",
 				"rmg" : {
 					"value" : 750,
 					"rarity" : 30
@@ -23,19 +23,19 @@
 						"limiter" : {
 							"daysPassed" : 8
 						},
-						"message" : "{Derrick}\r\n\r\nThe drilling foreman rolls out a cart of valuables. \"We managed to sell our yield at a healthy profit. Hope we'll take in at least as much the next time — come for your share in a week.\"",
+						"message" : "{Derrick}\n\nThe drilling foreman rolls out a cart of valuables. \"We managed to sell our yield at a healthy profit. Hope we'll take in at least as much the next time - come for your share in a week.\"",
 						"resources" : {
 							"gold" : 1000
 						}
 					},
 					{
-						"message" : "{Derrick}\r\n\r\nThe drilling foreman rolls out a cart of valuables. \"We managed to sell our yield at a healthy profit. Hope we'll take in at least as much the next time — come for your share in a week.\"",
+						"message" : "{Derrick}\n\nThe drilling foreman rolls out a cart of valuables. \"We managed to sell our yield at a healthy profit. Hope we'll take in at least as much the next time - come for your share in a week.\"",
 						"resources" : {
 							"gold" : 500
 						}
 					}
 				],
-				"onVisitedMessage" : "{Derrick}\r\n\r\nThe drilling foreman is very busy. You are able to decipher his muttering as a claim that he has nothing to show yet. You've got to drop by again next week.",
+				"onVisitedMessage" : "{Derrick}\n\nThe drilling foreman is very busy. You are able to decipher his muttering as a claim that he has nothing to show yet. You've got to drop by again next week.",
 				"visitMode" : "once",
 				"selectMode" : "selectFirst",
 				"resetParameters" : {

--- a/mods/wastelandTerrain/content/config/hota/wasteland/hotaInteractive/grave.json
+++ b/mods/wastelandTerrain/content/config/hota/wasteland/hotaInteractive/grave.json
@@ -14,7 +14,7 @@
 		"types" : {
 			"grave" : {
 				"name" : "Grave",
-				"description" : "(Digging gives 1500-4000 gold, a random Treasure or Minor artifact, and -3 morale until the next battle.)",
+				"description" : "(Digging gives 1500-4000 gold, a random Treasure or Minor artifact, and -3 morale until the next battle)\n",
 				"rmg" : {
 					"value" : 500,
 					"rarity" : 30
@@ -92,7 +92,7 @@
 							"+++",
 							"+++",
 							"+++"
-						], //disabled for not spawning at random maps
+						],
 						"allowedTerrains" : [
 							"wasteland"
 						]

--- a/mods/wastelandTerrain/content/config/hota/wasteland/hotaInteractive/prospector.json
+++ b/mods/wastelandTerrain/content/config/hota/wasteland/hotaInteractive/prospector.json
@@ -24,7 +24,7 @@
 				"visitMode" : "once",
 				"rewards" : [
 					{
-						"message" : "{Prospector}\r\n\r\nThe tired prospector makes an effort to look tough, but you can see he is afraid of you after all. He is willing to pay you a small sum regularly for the permission to continue mining here.",
+						"message" : "{Prospector}\n\nThe tired prospector makes an effort to look tough, but you can see he is afraid of you after all. He is willing to pay you a small sum regularly for the permission to continue mining here.",
 						"appearChance" : {
 							"max" : 50
 						},
@@ -33,7 +33,7 @@
 						}
 					},
 					{
-						"message" : "{Prospector}\r\n\r\nThe tired prospector makes an effort to look tough, but you can see he is afraid of you after all. He is willing to pay you a small sum regularly for the permission to continue mining here.",
+						"message" : "{Prospector}\n\nThe tired prospector makes an effort to look tough, but you can see he is afraid of you after all. He is willing to pay you a small sum regularly for the permission to continue mining here.",
 						"appearChance" : {
 							"min" : 50
 						},
@@ -42,7 +42,7 @@
 						}
 					}
 				],
-				"onVisitedMessage" : "{Prospector}\r\n\r\nThe prospector curses the depleted vein, then wails and begs. Obviously, there's nothing else he can do for you this week.",
+				"onVisitedMessage" : "{Prospector}\n\nThe prospector curses the depleted vein, then wails and begs. Obviously, there's nothing else he can do for you this week.",
 				"templates" : {
 					"avtprosp" : {
 						"animation" : "hota/wasteland/hotaInteractive/prospector/avtprosp",

--- a/mods/wastelandTerrain/content/config/hota/wasteland/hotaInteractive/trailblazer.json
+++ b/mods/wastelandTerrain/content/config/hota/wasteland/hotaInteractive/trailblazer.json
@@ -12,7 +12,7 @@
 		"types" : {
 			"trailblazer" : {
 				"name" : "Trailblazer",
-				"description" : "\nReduces movement cost on wastelands down to 75% until the end of the week.\n",
+				"description" : "(Reduces movement cost on wastelands down to 75% until the end of the week)\n",
 				"aiValue" : 3000,
 				"rmg" : {
 					"value" : 200,


### PR DESCRIPTION
Going through all map objects introduced in HotA and fixing the descriptions and messages there. Mostly just replaying CRLF with LF, some small wording fixes.

@kdmcser and other translators (feel free to tag)

Added the following missing strings that require translation (can all be done in parent mod translation file):

+ "mapObject.hota.highlandsterrain.mineralSpring.mineralSpring.description" : "(+1 luck until next battle and +600 movement points for one day)\n"
+ "mapObject.hota.mapobjects.creatureBank.ivoryTower.onGuarded" : "You stand in front of an Ivory Tower. Mage foes keep the prisoners captured. Taking their side will allow you to gain valuable allies. Are you ready to test your fortune?"
+ "mapObject.hota.mapobjects.creatureBank.ivoryTower.onVisited" : "You enter the Ivory Tower, however nobody is home."
+ "mapObject.hota.mapobjects.observatory.observatory.description" : "(+2 scouting radius until the end of the week)\n"
+ "mapObject.hota.mapobjects.wateringPlace.wateringPlace.description" : "(+1000 movement points next day for all remaining movement)\n"
