### PR TITLE
Add rune levels on creature cast

### DIFF
--- a/mods/bulwark/content/config/hota/bulwark/runes/runesSkill.json
+++ b/mods/bulwark/content/config/hota/bulwark/runes/runesSkill.json
@@ -140,6 +140,23 @@
 						]
 					}
 				},
+				"combatCastRuneLevels" : {
+					"type" : "ON_COMBAT_EVENT",
+					"subtype" : "combatEventCast",
+					"addInfo" : {
+						"effect" : [
+							{
+								"action" : "bonus",
+								"targetEnemy" : false,
+								"bonus" : {
+									"type" : "RUNE_LEVEL_COUNTER",
+									"val" : 1,
+									"duration" : "ONE_BATTLE"
+								}
+							}
+						]
+					}
+				},
 				"combatAttackedRuneLevels" : {
 					"type" : "ON_COMBAT_EVENT",
 					"subtype" : "combatEventAfterAttacked",


### PR DESCRIPTION
Adds the missing rune level when a creature casts a spell instead of attacking.