### PR TITLE
Disable Ancient Lamp on Jebus

### DIFF
--- a/mods/templates/content/config/hotaJebusCross.json
+++ b/mods/templates/content/config/hotaJebusCross.json
@@ -144,15 +144,16 @@
 								"value" : 500,
 								"zoneLimit" : 3
 							}
-						},
-						{
-							"type" : "hota.mapobjects:ancientLamp",
-							"subtype" : "hota.mapobjects:ancientLamp",
-							"rmg" : {
-								"rarity" : 200,
-								"value" : 5000
-							}
 						}
+						// FIXME: disabled until map objects can be limited to factions (should be Tower-only)
+						//{
+						//	"type" : "hota.mapobjects:ancientLamp",
+						//	"subtype" : "hota.mapobjects:ancientLamp",
+						//	"rmg" : {
+						//		"rarity" : 200,
+						//		"value" : 5000
+						//	}
+						//}
 					]
 				}
 			},


### PR DESCRIPTION
Jebus Cross should spawn Ancient Lamps in player starting zones, but only if the zone faction is Tower. This is not implemented in VCMI, so I commented out the Ancient Lamp spawn and added a FIXME.