### PR TITLE
Add battle log message for Greater Shaman's Freezing Shot

### DIFF
--- a/mods/bulwark/content/config/hota/bulwark/spells/freezingShot.json
+++ b/mods/bulwark/content/config/hota/bulwark/spells/freezingShot.json
@@ -38,6 +38,10 @@
 				"battleEffects" : {
 					"frozen" : {
 						"type" : "core:timed",
+						"battleLogMessage" : {
+							"singular" : "The %s is frozen.",
+							"plural" : "The %s are frozen."
+						},
 						"bonus" : {
 							"notActive" : {
 								"val" : 0,


### PR DESCRIPTION
Adds a battle log message for the Freezing Shot ability so that it appears in the combat log when triggered, similar to Medusa's Stone Gaze or Basilisk's Petrification.

Requires https://github.com/vcmi/vcmi/pull/7188 and https://github.com/vcmi/vcmi/pull/7226 (singular/plural object format).

Closes #551