### PR TITLE
Swap Automaton defs to default

### DIFF
--- a/mods/factory/content/config/hota/factory/creatures/automaton.json
+++ b/mods/factory/content/config/hota/factory/creatures/automaton.json
@@ -22,7 +22,7 @@
 		"defense" : 10,
 		"fightValue" : 553,
 		"graphics" : {
-			"animation" : "hota/factory/creatures/battle/CAUTO2.def",
+			"animation" : "hota/factory/creatures/battle/CAUTO.def",
 			"map" : "hota/factory/creatures/adventureMap/AVWauto.def",
 			"mapMask" : [
 				"VVV",

--- a/mods/factory/content/config/hota/factory/creatures/sentinelAutomaton.json
+++ b/mods/factory/content/config/hota/factory/creatures/sentinelAutomaton.json
@@ -22,7 +22,7 @@
 		"defense" : 10,
 		"fightValue" : 672,
 		"graphics" : {
-			"animation" : "hota/factory/creatures/battle/CHAUTO2.def",
+			"animation" : "hota/factory/creatures/battle/CHAUTO.def",
 			"map" : "hota/factory/creatures/adventureMap/AVWauth.def",
 			"mapMask" : [
 				"VVV",

--- a/mods/factory/content/config/hota/factory/spells/detonates01.json
+++ b/mods/factory/content/config/hota/factory/spells/detonates01.json
@@ -17,7 +17,6 @@
 			"conflux" : 0
 		},
 
-		//forgetfulness animation
 		"animation" : {
 			"affect" : [
 				{
@@ -27,6 +26,7 @@
 		},
 
 		"flags" : {
+			"persistent" : true,
 			"positive" : true,
 			"nonMagical" : true,
 			"rising" : true
@@ -62,12 +62,6 @@
 				},
 
 				"battleEffects" : {
-					"heal" : {
-						"type" : "core:heal",
-						"healLevel" : "heal",
-						"healPower" : "permanent",
-						"optional" : true
-					},
 					"blockHelp" : {
 						"type" : "core:timed",
 						"cumulative" : false,
@@ -76,29 +70,17 @@
 								"type" : "SPELL_AFTER_ATTACK",
 								"subtype" : "detonation",
 								"val" : 100,
-								"duration" : "PERMANENT"
+								"duration" : "ONE_BATTLE"
 							},
 							"giftStrength" : {
 								"type" : "SPECIFIC_SPELL_POWER",
 								"subtype" : "detonation",
 								"val" : 40,
-								"duration" : "PERMANENT"
-							},
-							"immnunityDispel" : {
-								"type" : "SPELL_IMMUNITY",
-								"subtype" : "dispel",
-								"duration" : "PERMANENT"
-							},
-							"immnunityDispelHelpful" : {
-								"type" : "SPELL_IMMUNITY",
-								"subtype" : "dispelHelpful",
-								"duration" : "PERMANENT"
+								"duration" : "ONE_BATTLE"
 							},
 							"redeem2" : {
-								"type" : "HP_REGENERATION",
-								"val" : 100,
-								"valueType" : "BASE_NUMBER",
-								"duration" : "PERMANENT"
+								"type" : "DISINTEGRATE",
+								"duration" : "ONE_BATTLE"
 							}
 						}
 					}

--- a/mods/factory/content/config/hota/factory/spells/detonates02.json
+++ b/mods/factory/content/config/hota/factory/spells/detonates02.json
@@ -17,7 +17,6 @@
 			"conflux" : 0
 		},
 
-		//forgetfulness animation
 		"animation" : {
 			"affect" : [
 				{
@@ -27,6 +26,7 @@
 		},
 
 		"flags" : {
+			"persistent" : true,
 			"positive" : true,
 			"nonMagical" : true,
 			"rising" : true
@@ -62,12 +62,6 @@
 				},
 
 				"battleEffects" : {
-					"heal" : {
-						"type" : "core:heal",
-						"healLevel" : "heal",
-						"healPower" : "permanent",
-						"optional" : true
-					},
 					"blockHelp" : {
 						"type" : "core:timed",
 						"cumulative" : false,
@@ -76,29 +70,17 @@
 								"type" : "SPELL_AFTER_ATTACK",
 								"subtype" : "detonation",
 								"val" : 100,
-								"duration" : "PERMANENT"
+								"duration" : "ONE_BATTLE"
 							},
 							"giftStrength" : {
 								"type" : "SPECIFIC_SPELL_POWER",
 								"subtype" : "detonation",
 								"val" : 40,
-								"duration" : "PERMANENT"
-							},
-							"immnunityDispel" : {
-								"type" : "SPELL_IMMUNITY",
-								"subtype" : "dispel",
-								"duration" : "PERMANENT"
-							},
-							"immnunityDispelHelpful" : {
-								"type" : "SPELL_IMMUNITY",
-								"subtype" : "dispelHelpful",
-								"duration" : "PERMANENT"
+								"duration" : "ONE_BATTLE"
 							},
 							"redeem2" : {
-								"type" : "HP_REGENERATION",
-								"val" : 100,
-								"valueType" : "BASE_NUMBER",
-								"duration" : "PERMANENT"
+								"type" : "DISINTEGRATE",
+								"duration" : "ONE_BATTLE"
 							}
 						}
 					}


### PR DESCRIPTION
Addresses #594 as a temporary fix until we can swap defs.

+ swaps the Automaton/Sentinel Automaton defs from the Detonation-active one to the regular one
    + Detonation-exclusive leads to invisible corpses.
+ Automatons now disappear from the battlefield when Detonation is active and they are killed
    + also makes Detonation undispellable
    + removed the HP regen part of it (why did they even have this lol)