### PR TITLE
Added hero biography fixes to Text Polishing

### DIFF
--- a/mods/textPolishing/content/config/englishTextPolishing/heroTexts.json
+++ b/mods/textPolishing/content/config/englishTextPolishing/heroTexts.json
@@ -1,0 +1,6 @@
+{
+	"hero.core.edric.biography" : "Edric's ancestor was the first man in Erathia to domesticate and train a wild Griffin. Now, Edric's family maintains Erathia's largest Griffin breeding grounds for use in the King's armies.",
+	"hero.core.josephine.biography" : "Josephine was the first to successfully animate a modern stone golem, creating a process that was much more sophisticated than that used for the gargoyle, on which her research was based.",
+	"hero.core.sephinroth.biography" : "Sephinroth claims to be the illegitimate child of King Gryphonheart. His refusal to acknowledge her has served to fuel her hatred against the Throne of Erathia, which she one day hopes to claim for herself. Having joined the ranks of the Warlocks, she is the first (and for a long time, only) known female ever to bear that title.",
+	"hero.core.undeadHaart.biography" : "Resurrected by his cult of necromantic followers, Haart has emerged a more powerful foe than before."
+}

--- a/mods/textPolishing/mod.json
+++ b/mods/textPolishing/mod.json
@@ -25,6 +25,7 @@
 		"translations" : [
 			"config/englishTextPolishing/artifactDescriptions.json",
 			"config/englishTextPolishing/gameTextChanges.json",
+			"config/englishTextPolishing/heroTexts.json",
 			"config/englishTextPolishing/objectDescriptions.json",
 			"config/englishTextPolishing/spellDescriptions.json"
 		]


### PR DESCRIPTION
This PR adds the biography changes to text polishing as suggested in #622.

The various typo fixes are already reflected in the English translation mod, so no need to add them here as well.