### PR TITLE
Fix default map limit of lvl4 shrine

### DIFF
--- a/mods/mapObjects/content/config/hotaMapObjects/shrineOfMagicMystery.json
+++ b/mods/mapObjects/content/config/hotaMapObjects/shrineOfMagicMystery.json
@@ -8,7 +8,8 @@
 				"rmg" : {
 					"value" : 7000,
 					"rarity" : 100,
-					"zoneLimit" : 1
+					"zoneLimit" : 1,
+					"mapLimit" : 32
 				},
 				"visitMode" : "limiter",
 				"visitedTooltip" : 354,


### PR DESCRIPTION
Was set to unlimited, should be 32.