### PR TITLE
Fix github workflow error

### DIFF
--- a/.github/install_mod_dependencies.py
+++ b/.github/install_mod_dependencies.py
@@ -7,6 +7,7 @@ import sys
 import urllib.request
 import zipfile
 import tempfile
+import jstyleson
 from pathlib import Path
 
 
@@ -30,7 +31,7 @@ def collect_dependencies(root: Path) -> set:
     deps = set()
     for mod_file in find_mod_json_files(root):
         with open(mod_file) as f:
-            data = json.load(f)
+            data = jstyleson.load(f)
         for dep in data.get("depends", []):
             deps.add(dep.split(".")[0])
     return deps

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install VCMI
         run: sudo apt install vcmi
-        
+
       - name: Install H3 Data Placeholder
         run: |
           data_url="https://github.com/vcmi-mods/vcmi-test-data/releases/download/v2.0/heroes3.7z"
@@ -48,6 +48,9 @@ jobs:
       - name: Install Mod
         run: |
           ln -sf "$(pwd)" ~/.local/share/vcmi/Mods/${MOD_NAME}
+
+      - name: Install jstyleson
+        run: pip install jstyleson
 
       - name: Install Mod Dependencies
         run: python3 .github/install_mod_dependencies.py "${GITHUB_BASE_REF:-$GITHUB_REF_NAME}"


### PR DESCRIPTION
Mod dependency install errors out because it expects strict JSON syntax in the mod.json files while VCMI uses relaxed json.

Solution: use jstyleson to install mod dependencies (validator uses that one as well)