### PR TITLE
Eagle Eye update

### DIFF
--- a/mods/gameBalance/mods/skills/mods/eagleEye/content/config/hotaGameBalance/skills.json
+++ b/mods/gameBalance/mods/skills/mods/eagleEye/content/config/hotaGameBalance/skills.json
@@ -1,47 +1,76 @@
 {
 	"core:eagleEye" : {
-		//"base" : {
-		//	"effects" : {
-		//		"main" : {
-		//			"type" : "LEARN_BATTLE_SPELL_CHANCE",
-		//			"valueType" : "BASE_NUMBER"
-		//		},
-		//		"val2" : {
-		//			"type" : "LEARN_BATTLE_SPELL_LEVEL_LIMIT",
-		//			"valueType" : "BASE_NUMBER"
-		//		}
-		//	}
-		//},
-		"basic" : {
-			"description" : "{Basic Eagle Eye}\n\nBasic Eagle Eye gives your hero a 40% chance to learn any 1st or 2nd level spell used in combat.",
+		"specialty" : [
+			"preBattleChance"
+		],
+		"base" : {
 			"effects" : {
-				"main" : {
-					"val" : 10
+			//	"main" : {
+			//		"type" : "LEARN_BATTLE_SPELL_CHANCE",
+			//		"valueType" : "BASE_NUMBER"
+			//	},
+			//	"val2" : {
+			//		"type" : "LEARN_BATTLE_SPELL_LEVEL_LIMIT",
+			//		"valueType" : "BASE_NUMBER"
+			//	}
+				"preBattleChance" : {
+					"type" : "LEARN_BATTLE_SPELL_CHANCE_PRE_BATTLE",
+					"valueType" : "BASE_NUMBER"
 				},
-				"val2" : {
-					"val" : 2
+				"preBattleLevel" : {
+					"type" : "LEARN_BATTLE_SPELL_LEVEL_LIMIT_PRE_BATTLE",
+					"valueType" : "BASE_NUMBER"
 				}
 			}
 		},
-		"advanced" : {
-			"description" : "{Advanced Eagle Eye}\n\nAdvanced Eagle Eye gives your hero a 50% chance to learn any spell up to 3rd level used in combat.",
+		"basic" : {
+			"description" : "{Basic Eagle Eye}\n\nBasic Eagle Eye gives the hero a 30% chance to learn any level 1–3 spell from the enemy hero at the start of combat and 100% chance of learning it afterwards, if the spell is used by an enemy in combat.",
 			"effects" : {
 				"main" : {
-					"val" : 20
+					"val" : 100
 				},
 				"val2" : {
+					"val" : 3
+				},
+				"preBattleChance" : {
+					"val" : 30
+				},
+				"preBattleLevel" : {
 					"val" : 3
 				}
 			}
 		},
-		"expert" : {
-			"description" : "{Expert Eagle Eye}\n\nExpert Eagle Eye gives your hero a 60% chance to learn any spell up to 4th level used in combat.",
+		"advanced" : {
+			"description" : "{Advanced Eagle Eye}\n\nAdvanced Eagle Eye gives the hero a 40% chance to learn any level 1–4 spell from the enemy hero at the start of combat and 100% chance of learning it afterwards, if the spell is used by an enemy in combat.",
 			"effects" : {
 				"main" : {
-					"val" : 30
+					"val" : 100
 				},
 				"val2" : {
 					"val" : 4
+				},
+				"preBattleChance" : {
+					"val" : 40
+				},
+				"preBattleLevel" : {
+					"val" : 4
+				}
+			}
+		},
+		"expert" : {
+			"description" : "{Expert Eagle Eye}\n\nExpert Eagle Eye gives the hero a 50% chance to learn any level 1–5 spell from the enemy hero at the start of combat and 100% chance of learning it afterwards, if the spell is used by an enemy in combat.",
+			"effects" : {
+				"main" : {
+					"val" : 100
+				},
+				"val2" : {
+					"val" : 5
+				},
+				"preBattleChance" : {
+					"val" : 50
+				},
+				"preBattleLevel" : {
+					"val" : 5
 				}
 			}
 		}


### PR DESCRIPTION
This PR adds the chance to learn a spell pre-battle to Eagle Eye.

I changed the description a bit to strip out the parts that are not implemented yet. Originally, the hero should learn a spell during battle immediately when used instead of after and should negate 1, 2 or 3 levels of opponent's Eagle Eye just like Tactics. Also the "I can check enemy spell book thing" is missing.