### PR TITLE
Correcting special weeks

### DIFF
--- a/mods/bulwark/content/config/hota/bulwark/creatures/mountainRam.json
+++ b/mods/bulwark/content/config/hota/bulwark/creatures/mountainRam.json
@@ -27,7 +27,6 @@
 			"max" : 30
 		},
 		"growth" : 9,
-		"hasDoubleWeek" : true,
 		"doubleWide" : true,
 		"graphics" : {
 			"iconLarge" : "hota/bulwark/creatures/iconsLarge/mountainRam.png",

--- a/mods/factory/content/config/hota/factory/creatures/armadillo.json
+++ b/mods/factory/content/config/hota/factory/creatures/armadillo.json
@@ -10,6 +10,7 @@
 		},
 		"faction" : "factory",
 		"doubleWide" : true,
+		"hasDoubleWeek" : true,
 		"aiValue" : 198,
 		"attack" : 5,
 		"cost" : {

--- a/mods/gameBalance/mods/creatures/content/config/hotaGameBalance/creatures.json
+++ b/mods/gameBalance/mods/creatures/content/config/hotaGameBalance/creatures.json
@@ -5,6 +5,9 @@
 	},
 
 	// conflux
+	"core:sprite" : {
+		"hasDoubleWeek" : true
+	},
 	"core:fireElemental" : {
 		"advMapAmount" : {
 			"min" : 10,

--- a/mods/neutralCreatures/content/config/hotaNeutralCreatures/fangarm.json
+++ b/mods/neutralCreatures/content/config/hotaNeutralCreatures/fangarm.json
@@ -24,7 +24,6 @@
 			"max" : 12
 		},
 		"growth" : 3,
-		"hasDoubleWeek" : true,
 		"abilities" : {
 			"spellpower" : {
 				"type" : "CREATURE_SPELL_POWER",

--- a/mods/neutralCreatures/content/config/hotaNeutralCreatures/leprechaun.json
+++ b/mods/neutralCreatures/content/config/hotaNeutralCreatures/leprechaun.json
@@ -24,7 +24,6 @@
 			"max" : 25
 		},
 		"growth" : 9,
-		"hasDoubleWeek" : true,
 		"abilities" : {
 			"castsFortune" : {
 				"type" : "SPELLCASTER",

--- a/mods/neutralCreatures/content/config/hotaNeutralCreatures/satyr.json
+++ b/mods/neutralCreatures/content/config/hotaNeutralCreatures/satyr.json
@@ -24,7 +24,6 @@
 			"max" : 16
 		},
 		"growth" : 4,
-		"hasDoubleWeek" : true,
 		"abilities" : {
 			"mirth" : {
 				"type" : "SPELLCASTER",

--- a/mods/neutralCreatures/content/config/hotaNeutralCreatures/steelGolem.json
+++ b/mods/neutralCreatures/content/config/hotaNeutralCreatures/steelGolem.json
@@ -24,7 +24,6 @@
 			"max" : 16
 		},
 		"growth" : 4,
-		"hasDoubleWeek" : false,
 		"abilities" : {
 			"magicResistance" : {
 				"type" : "SPELL_DAMAGE_REDUCTION",


### PR DESCRIPTION
When browsing [the wiki's creature growth page](https://heroes.thelazy.net/index.php/Growth), I noticed a mismatch of the current config with the wiki concerning the special weeks/months.

Changes in this PR:
+ added Sprite special week to gamebalance.creatures
+ removed Fangarm, Satyr, Leprechaun and Mountain Ram special weeks
+ added Armadillo special week in factory