### PR TITLE
Improve cloned units' positioning when cast with specialty

### DIFF
--- a/mods/airShip/content/config/airship/airship.json
+++ b/mods/airShip/content/config/airship/airship.json
@@ -36,15 +36,14 @@
 					"default" : {
 						"animation" : "airship/AVGairy0.def",
 						"visitableFrom" : [
-							"+++",
-							"+-+",
+							"---",
+							"---",
 							"+++"
 						],
 						"mask" : [
-							"VVV",
-							"VVV",
-							"VVV",
-							"VAV"
+							"VVVV",
+							"VVBV",
+							"VBAB"
 						]
 					}
 				}

--- a/mods/bulwark/content/config/hota/bulwark/town/buildings.json
+++ b/mods/bulwark/content/config/hota/bulwark/town/buildings.json
@@ -60,8 +60,7 @@
 						"ore" : 10
 					},
 					"fortifications" : {
-						// should be uncommented, but currently buggy - sets health to 1 instead
-						// "wallsHealth" : 4,
+						"wallsHealth" : 4,
 						"upperTowerHealth" : 3,
 						"lowerTowerHealth" : 3
 					}

--- a/mods/cannon/Content/config/hotaCannon/cannonYard.json
+++ b/mods/cannon/Content/config/hotaCannon/cannonYard.json
@@ -8,6 +8,7 @@
 						"cannon"
 					]
 				],
+				"bannedForRandomDwelling" : true,
 				"templates" : {
 					"base" : {
 						"animation" : "hota/map/avcnbksm",
@@ -20,7 +21,7 @@
 							"VVVV",
 							"VVVV",
 							"VVBV",
-							"VVBA"
+							"VBBA"
 						]
 					}
 				},

--- a/mods/cove/Content/scripts/patches/specialtyClone.lua
+++ b/mods/cove/Content/scripts/patches/specialtyClone.lua
@@ -52,7 +52,6 @@ function Script:apply(mechanics, server, target)
 				searchOrigin = isAttacker and unitPos:copyToSouthEast() or unitPos:copyToSouthWest()
 			end
 			if not searchOrigin:isValid() then
-				print("falling back to unitPos")
 				searchOrigin = unitPos
 			end
 

--- a/mods/cove/Content/scripts/patches/specialtyClone.lua
+++ b/mods/cove/Content/scripts/patches/specialtyClone.lua
@@ -20,21 +20,73 @@ local function shouldCastSpecialtyClone(mechanics)
 end
 
 function Script:apply(mechanics, server, target)
-    if shouldCastSpecialtyClone(mechanics) then
-		server:addBattleBonus(mechanics:getBattle(), {
-			type       = "SPECIALTY_CLONE",
-			sourceType = ENUM.BonusSource.other,
-			val        = -1,
-			valueType  = 0,
-			sourceID   = mechanics:getSpell():getJsonKey(),
-			propagator = BONUS_OWNER_PROPAGATOR,
-			limiters   = { noneOf, OPPOSITE_SIDE }
-		})
-        Base.apply(self, mechanics, server, target)
-        Base.apply(self, mechanics, server, target)
-    else
-        Base.apply(self, mechanics, server, target)
-    end
+	if not shouldCastSpecialtyClone(mechanics) then
+		Base.apply(self, mechanics, server, target)
+		return
+	end
+
+	local battle = mechanics:getBattle()
+	local casterSide = mechanics:getCasterSide()
+	local isAttacker = (casterSide == 0)
+
+	server:addBattleBonus(battle, {
+		type       = "SPECIALTY_CLONE",
+		sourceType = ENUM.BonusSource.other,
+		val        = -1,
+		valueType  = 0,
+		sourceID   = mechanics:getSpell():getJsonKey()
+	})
+
+	for _, dest in ipairs(target) do
+		local unit = dest.unit
+		if unit == nil or unit:getCount() < 1 then goto continue end
+
+		local creature = unit:getCreature()
+		local unitPos = unit:getPosition()
+
+		for cloneIndex = 1, 2 do
+			local searchOrigin
+			if cloneIndex == 1 then
+				searchOrigin = isAttacker and unitPos:copyToNorthEast() or unitPos:copyToNorthWest()
+			else
+				searchOrigin = isAttacker and unitPos:copyToSouthEast() or unitPos:copyToSouthWest()
+			end
+			if not searchOrigin:isValid() then
+				print("falling back to unitPos")
+				searchOrigin = unitPos
+			end
+
+			local hex = battle:getAvailableHex(creature, casterSide, searchOrigin)
+			if not hex:isValid() then break end
+
+			local cloneUnit = server:addUnit(battle, {
+				count    = unit:getCount(),
+				type     = creature,
+				side     = casterSide,
+				position = hex,
+				summoned = true
+			})
+			if cloneUnit == nil then break end
+
+			local cloneState = cloneUnit:copy()
+			cloneState:setCloned(true)
+			server:changeUnit(battle, cloneState)
+
+			local originalState = unit:copy()
+			originalState:setClone(cloneUnit)
+			server:changeUnit(battle, originalState)
+
+			server:addUnitBonus(battle, cloneUnit, {
+				duration   = ENUM.BonusDuration.nTurns,
+				type       = "NONE",
+				sourceType = ENUM.BonusSource.spellEffect,
+				val        = 0,
+				sourceID   = mechanics:getSpell():getJsonKey(),
+				turns      = mechanics:getEffectDuration()
+			}, true)
+		end
+		::continue::
+	end
 end
 
 return Script


### PR DESCRIPTION
In HotA, when Eovacius casts clone, the clones appear NE and SE (or NW and SW when Eovacius is defending) of the selected unit. 
The behavior in VCMI was thus slightly off (created the clones NE and E) and this PR corrects that. I have added a fallback should one of the preferred positions fall outside the battlefield and in that case it just searches a valid hex based on the unit's position.

Demo:
https://github.com/user-attachments/assets/276fae93-08e8-41da-b92d-9a92ca639872

Edit: 
+ also fixes Bulwark's wall health during siege because I just remembered this works now
+ also fixes masks for cannon yard and airship yard
