### PR TITLE
Fix pre-emptive shot against war machines

### DIFF
--- a/mods/cannon/Content/config/hotaCannon/cannonCreature.json
+++ b/mods/cannon/Content/config/hotaCannon/cannonCreature.json
@@ -75,8 +75,11 @@
 				"subtype" : "cannonSiegeShot"
 			},
 			"noRetaliation" : {
-				"type" : "NO_RETALIATION",
-				"val" : 0
+				"type" : "NO_RETALIATION"
+			},
+			"blocksRangedRetaliation" : {
+				"type" : "BLOCKS_RANGED_RETALIATION",
+				"hidden" : true
 			},
 			"cpuControlledCannon" : {
 				"hidden" : true,

--- a/mods/factory/content/config/hota/factory/creatures/ballistaPatch.json
+++ b/mods/factory/content/config/hota/factory/creatures/ballistaPatch.json
@@ -1,0 +1,10 @@
+{
+	"core:ballista" : {
+		"abilities" : {
+			"blocksRangedRetaliation" : {
+				"type" : "BLOCKS_RANGED_RETALIATION",
+				"hidden" : true
+			}
+		}
+	}
+}

--- a/mods/factory/mod.json
+++ b/mods/factory/mod.json
@@ -47,6 +47,7 @@
 		"config/hota/factory/creatures/hotaCouatl.json",
 		"config/hota/factory/creatures/crimsonCouatl.json",
 		"config/hota/factory/creatures/stackExperience",
+		"config/hota/factory/creatures/ballistaPatch.json",
 		"config/hota/factory/commander/cowboy.json"
 	],
 


### PR DESCRIPTION
This PR fixes Gunslinger's/Bounty Hunter's preemptive shot so it doesn't trigger against the Ballista/Cannon.