### PR TITLE
Fix freezing shot not proccing on magic terrain

### DIFF
--- a/mods/bulwark/content/config/hota/bulwark/spells/freezingShot.json
+++ b/mods/bulwark/content/config/hota/bulwark/spells/freezingShot.json
@@ -27,10 +27,9 @@
 			"iconEffect" : "hota/bulwark/spells/freezingShot.png"
 		},
 		"levels" : {
-			"none" : {
-				"cost" : 0,
-				"description" : "{Frozen}\n\nIncapacitates the enemy for 3 turns. During the frozen period, the enemy receives 25% increased damage from attacks.\n",
+			"base" : {
 				"range" : "0",
+				"cost" : 0,
 				"power" : 0,
 				"targetModifier" : {
 					"smart" : true
@@ -61,6 +60,18 @@
 						}
 					}
 				}
+			},
+			"none" : {
+				"description" : "{Frozen}\n\nIncapacitates the enemy for 3 turns. During the frozen period, the enemy receives 25% increased damage from attacks.\n"
+			},
+			"basic" : {
+				"description" : "not shown"
+			},
+			"advanced" : {
+				"description" : "not shown"
+			},
+			"expert" : {
+				"description" : "not shown"
 			}
 		},
 		"targetCondition" : {


### PR DESCRIPTION
Missed an edge case.

Freezing shot actually needs its levels since it is a spell and not an ability (so it is blocked by Orb of Inhibition). Magic terrain boosts all spells, so they tried to cast it with a null spell level which did nothing. Abilities are not boosted by this, so magic terrain has no effect (I tested with Accurate Shot).

No change in strings, the levels above none do not need to be translated because VCMI only uses the "none" description string in the creature info window.