### PR TITLE
Fix Arrow Tower damage

### DIFF
--- a/mods/gameBalance/mods/creatures/content/config/hotaGameBalance/creatures.json
+++ b/mods/gameBalance/mods/creatures/content/config/hotaGameBalance/creatures.json
@@ -212,5 +212,10 @@
 				"icon" : "hotaGameBalance/creatures/noLuck.png"
 			}
 		}
+	},
+	"core:arrowTower" : {
+		"abilities": {
+			"attackAlwaysZero" : null
+		}
 	}
 }

--- a/mods/gameBalance/mods/creatures/content/config/hotaGameBalance/creatures.json
+++ b/mods/gameBalance/mods/creatures/content/config/hotaGameBalance/creatures.json
@@ -215,7 +215,8 @@
 	},
 	"core:arrowTower" : {
 		"abilities": {
-			"attackAlwaysZero" : null
+			"attackAlwaysZero" : null,
+			"noArcheryBonuses" : null
 		}
 	}
 }


### PR DESCRIPTION
In HotA, Arrow Tower's innate attack of 10 and the attack of the defender are added together and used in damage calculation.

This PR reflects that change. I have tested it and got the following damage numbers after this PR with the following setup:
Kyrre is a dummy hero with no relevant skills (0 Attack, only Artillery to check tower damage)
Ivor has 10 Attack on and Expert Archery in addition to Artillery
Towns are fully built, except for the grail building. Damage ranges are main tower, secondary tower.
Rampart defense:
HotA:
Kyrre: 60-120, 30-60
Ivor: 100-200, 50-100

VCMI:
Kyrre: 63-126, 33-66
Ivor: 105-210, 55-110

Tower defense:
HotA:
Kyrre: 66-132, 33-66
Ivor: 110-220, 55-110

VCMI:
Kyrre: 69-138, 36-72
Ivor: 115-230, 60-120

I dunno where the offset in damage comes from, needs to be investigated. Edit, this is false I think, hard to test because damage preview is bugged in SoD: ~It seems to count 1 building too many in both cases.~ Also, in SoD, Archery is NOT supposed to increase the Arrow Tower's damage -that was a HotA change- but it apparently does, so I'm tagging you @IvanSavenko  