### PR TITLE
Fix for non-functioning scaling of First Aid specialty

### DIFF
--- a/mods/gameBalance/mods/skills/mods/firstAid/content/config/hotaGameBalance/skills.json
+++ b/mods/gameBalance/mods/skills/mods/firstAid/content/config/hotaGameBalance/skills.json
@@ -20,7 +20,6 @@
 				"stackhp" : {
 					"type" : "STACK_HEALTH",
 					"valueType" : "PERCENT_TO_BASE",
-					"propagator" : "ARMY",
 					"limiters" : [
 						{
 							"type" : "HAS_ANOTHER_BONUS_LIMITER",


### PR DESCRIPTION
Dunno why the propagator makes this not function, but luckily, we don't need it.