### PR TITLE
Configuration for newly supported objects

### DIFF
--- a/mods/bulwark/content/config/hota/bulwark/creatures/steelElf.json
+++ b/mods/bulwark/content/config/hota/bulwark/creatures/steelElf.json
@@ -33,7 +33,8 @@
 				"type" : "NO_MELEE_PENALTY"
 			},
 			"noRangeBlock" : {
-				"type" : "FREE_SHOOTING"
+				"type" : "FREE_SHOOTING",
+				"subtype" : "freeShootingExceptAdjacent"
 			}
 		},
 		"graphics" : {

--- a/mods/gameBalance/mods/artifacts/content/config/hotaGameBalance/artifacts.json
+++ b/mods/gameBalance/mods/artifacts/content/config/hotaGameBalance/artifacts.json
@@ -61,21 +61,6 @@
 			"mindImmunity" : null
 		}
 	},
-	"core:angelicAlliance" : {
-		"bonuses" : {
-			"evilPenalty" : {
-				"type" : "MORALE",
-				"val" : -1,
-				"valueType" : "BASE_NUMBER",
-				"limiters" : [
-					{
-						"type" : "CREATURE_ALIGNMENT_LIMITER",
-						"alignment" : "evil"
-					}
-				]
-			}
-		}
-	},
 	// 1.7.2:
 	// [+] Ballista price reduced from 2500 to 1500; Cannon price reduced from 4000 to 3000
 	"core:ballista" : {

--- a/mods/gameBalance/mods/artifacts/mod.json
+++ b/mods/gameBalance/mods/artifacts/mod.json
@@ -11,7 +11,13 @@
 	"artifacts" : [
 		"config/hotaGameBalance/artifacts.json"
 	],
-
+	"settings" : {
+		"creatures" : {
+			// Emulates SoD bug where Conflux creatures can not be mixed with other alignments under Angelic Alliance / troop-mixing effects.
+			// If this option is off, Conflux is treated as a regular neutral-alignment faction and can be mixed normally
+			"h3BugConfluxAlignmentMix" : false
+		}
+	},
 	"chinese" : {
 		"name" : "宝物",
 		"description" : "",

--- a/mods/gameBalance/mods/artifacts/mod.json
+++ b/mods/gameBalance/mods/artifacts/mod.json
@@ -11,13 +11,6 @@
 	"artifacts" : [
 		"config/hotaGameBalance/artifacts.json"
 	],
-	"settings" : {
-		"creatures" : {
-			// Emulates SoD bug where Conflux creatures can not be mixed with other alignments under Angelic Alliance / troop-mixing effects.
-			// If this option is off, Conflux is treated as a regular neutral-alignment faction and can be mixed normally
-			"h3BugConfluxAlignmentMix" : false
-		}
-	},
 	"chinese" : {
 		"name" : "宝物",
 		"description" : "",

--- a/mods/gameBalance/mods/factions/content/config/hotaGameBalance/factions.json
+++ b/mods/gameBalance/mods/factions/content/config/hotaGameBalance/factions.json
@@ -145,6 +145,7 @@
 		}
 	},
 	"core:conflux" : {
+		"alignment" : "neutral",
 		"town" : {
 			"buildings" : {
 				"dwellingUpLvl1" : {

--- a/mods/mapObjects/content/config/hotaMapObjects/templeOfLoyalty.json
+++ b/mods/mapObjects/content/config/hotaMapObjects/templeOfLoyalty.json
@@ -23,8 +23,7 @@
 						"bonuses" : [
 							{
 								"type" : "ALIGNMENT_MIX",
-								"duration" : "N_DAYS",
-								"turns" : 1
+								"duration" : "ONE_DAY"
 							}
 						]
 					}

--- a/mods/mapObjects/content/config/hotaMapObjects/templeOfLoyalty.json
+++ b/mods/mapObjects/content/config/hotaMapObjects/templeOfLoyalty.json
@@ -1,20 +1,34 @@
 {
 	"templeOfLoyalty" : {
-		"handler" : "generic",
+		"handler" : "configurable",
 		"name" : "Temple of Loyalty",
 		"types" : {
 			"templeOfLoyalty" : {
-				//				"aiValue" : 1000,
-				//				"rmg" : {
-				//					"value"		: 100,
-				//					"rarity"	: 20,
-				//					"zoneLimit" : 1
-				//				},
+				"description" : "(Mixed faction morale penalty negated until next turn)\n",
+				"rmg" : {
+					"value" : 100,
+					"rarity" : 20,
+					"zoneLimit" : 1
+				},
 				"sounds" : {
 					"visit" : [
 						"TEMPLE"
 					]
 				},
+				"visitMode" : "bonus",
+				"onVisitedMessage" : "{Temple of Loyalty}\n\nThe prayer at the Temple of Loyalty helps to bring the troops together, however your army is united already.",
+				"rewards" : [
+					{
+						"message" : "{Temple of Loyalty}\n\nYou pray in an unusual temple and suddenly feel it has strengthened your troops' resolve.",
+						"bonuses" : [
+							{
+								"type" : "ALIGNMENT_MIX",
+								"duration" : "N_DAYS",
+								"turns" : 1
+							}
+						]
+					}
+				],
 				"templates" : {
 					"AVStmplt" : {
 						"animation" : "hota/templeOfLoyalty/AVStmplt",

--- a/mods/mapObjects/content/config/hotaMapObjects/templeOfLoyalty.json
+++ b/mods/mapObjects/content/config/hotaMapObjects/templeOfLoyalty.json
@@ -23,6 +23,22 @@
 						"bonuses" : [
 							{
 								"type" : "ALIGNMENT_MIX",
+								"subtype" : "alignmentGood",
+								"duration" : "ONE_DAY"
+							},
+							{
+								"type" : "ALIGNMENT_MIX",
+								"subtype" : "alignmentNeutral",
+								"duration" : "ONE_DAY"
+							},
+							{
+								"type" : "ALIGNMENT_MIX",
+								"subtype" : "alignmentEvil",
+								"duration" : "ONE_DAY"
+							},
+							{
+								"type" : "ALIGNMENT_MIX",
+								"subtype" : "alignmentNone",
 								"duration" : "ONE_DAY"
 							}
 						]

--- a/mods/mapObjects/content/config/hotaMapObjects/warlocksLab.json
+++ b/mods/mapObjects/content/config/hotaMapObjects/warlocksLab.json
@@ -1,14 +1,24 @@
 {
 	"warlocksLab" : {
-		"handler" : "generic",
+		"handler" : "market",
 		"name" : "Warlock's Lab",
 		"types" : {
 			"warlocksLab" : {
-				//				"rmg" : {
-				//					"value"	: 10000,
-				//					"rarity" : 100,
-				//					"zoneLimit" : 1
-				//				},
+				"modes" : [
+					"resource-resource"
+				],
+				"resources" : [
+					"mercury",
+					"sulfur",
+					"crystal",
+					"gems"
+				],
+				"rate" : 1,
+				"rmg" : {
+					"value" : 10000,
+					"rarity" : 100,
+					"zoneLimit" : 1
+				},
 				"sounds" : {
 					"visit" : [
 						"STORE"

--- a/mods/mapObjects/content/config/hotaMapObjects/warlocksLab.json
+++ b/mods/mapObjects/content/config/hotaMapObjects/warlocksLab.json
@@ -13,7 +13,7 @@
 					"crystal",
 					"gems"
 				],
-				"rate" : 1,
+				"effectiveness" : 1.0,
 				"rmg" : {
 					"value" : 10000,
 					"rarity" : 100,


### PR DESCRIPTION
With vcmi/vcmi#7661, Warlock's Lab and Temple of Loyalty are now functional. Also Steel Elves can now only melee attack the targets that block them (they can still choose to shoot a different target).