### PR TITLE
1.8.1 fixes - Balance

### DIFF
--- a/mods/bulwark/content/config/hota/bulwark/creatures/warMammoth.json
+++ b/mods/bulwark/content/config/hota/bulwark/creatures/warMammoth.json
@@ -17,8 +17,8 @@
 			"min" : 14,
 			"max" : 20
 		},
-		"fightValue" : 1601,
-		"aiValue" : 1601,
+		"fightValue" : 1672,
+		"aiValue" : 1672,
 		"growth" : 2,
 		"horde" : 1,
 		"advMapAmount" : {

--- a/mods/bulwark/content/config/hota/bulwark/heroes/dalton.json
+++ b/mods/bulwark/content/config/hota/bulwark/heroes/dalton.json
@@ -139,7 +139,7 @@
 			"biography" : "Plain weapons can barely scratch a Jotunn, but believing these hulks neglect protection exposes a fool. Dalton is the most adept armorer capable of forging equipment of such immense size. Lean as Vori's ores are, Dalton has penetrated the secrets of magic to ensure his creations can withstand anything, an ice demon's fury included.",
 			"specialty" : {
 				"name" : "Shield",
-				"description" : "Casts Shield with effect increased by 3% for every N hero levels, where N is the level of the target creature.",
+				"description" : "Casts Shield with effect increased by 3% for every N hero levels, where N is the level of the targeted creature.",
 				"tooltip" : "Spell Bonus: Shield"
 			}
 		}

--- a/mods/bulwark/content/config/hota/bulwark/heroes/ergon.json
+++ b/mods/bulwark/content/config/hota/bulwark/heroes/ergon.json
@@ -40,12 +40,22 @@
 				"baseTileCost" : {
 					"type" : "BASE_TILE_MOVEMENT_COST",
 					"valueType" : "ADDITIVE_VALUE",
-					"val" : -5
+					"val" : -10,
+					"limiters" : {
+						"type" : "HAS_ANOTHER_BONUS_LIMITER",
+						"bonusSourceType" : "SECONDARY_SKILL",
+						"bonusSourceID" : "pathfinding"
+					}
 				},
 				"terrainCostReduction" : {
 					"type" : "ROUGH_TERRAIN_DISCOUNT",
 					"valueType" : "ADDITIVE_VALUE",
-					"val" : 5
+					"val" : 10,
+					"limiters" : {
+						"type" : "HAS_ANOTHER_BONUS_LIMITER",
+						"bonusSourceType" : "SECONDARY_SKILL",
+						"bonusSourceID" : "pathfinding"
+					}
 				}
 			}
 		},
@@ -54,7 +64,7 @@
 			"biography" : "Ergon spent his long life in constant movement. He served in Lord Slayer's guard in Enroth, guarded elven caravans in Jadame, and sold his sword in Antagarich, only to realize in his later years that he yearned for the place whereto time itself seemed to come to rest. That said, his skill in arranging swift marches is still there, whenever need arises.",
 			"specialty" : {
 				"name" : "Pathfinding",
-				"description" : "Receives a 5% reduction to the cost of moving on rough terrain.",
+				"description" : "Enhances the effect of the Pathfinding skill, reducing the cost of moving on rough terrain by additional 10%.",
 				"tooltip" : "Secondary Skill Bonus: Pathfinding"
 			}
 		}

--- a/mods/bulwark/content/config/hota/bulwark/heroes/glacius.json
+++ b/mods/bulwark/content/config/hota/bulwark/heroes/glacius.json
@@ -53,7 +53,7 @@
 			"biography" : "The expanses of Vori, covered with years of snow, only seem lifeless; those who know what to look for will find out that the disembodied inhabitants of these lands make fine interlocutors, or maybe even sources of power. Glacius has a reputation for being the Bane of Spirits: their empty shells crumble into bursts of magical light, as he greedily devours their energy and unleashes it upon his enemies.",
 			"specialty" : {
 				"name" : "Frost Ring",
-				"description" : "Casts Frost Ring with Damage increased by 3% for every N hero levels, where N is the level of the target creature.",
+				"description" : "Casts Frost Ring with Damage increased by 3% for every N hero levels, where N is the level of the targeted creature.",
 				"tooltip" : "Spell Bonus: Frost Ring"
 			}
 		}

--- a/mods/bulwark/content/config/hota/bulwark/heroes/sial.json
+++ b/mods/bulwark/content/config/hota/bulwark/heroes/sial.json
@@ -53,7 +53,7 @@
 			"biography" : "Sial can always be traced on the battlefield by shards of ice statues that once were her enemies. Legend says another doing of hers is the infamous Crystal Lake, which stays frozen even through the brief summers. Once, its waters swallowed an entire tribe whose chieftain had angered her; they remain eternally still since.",
 			"specialty" : {
 				"name" : "Ice Bolt",
-				"description" : "Casts Ice Bolt with Damage increased by 3% for every N hero levels, where N is the level of the target creature.",
+				"description" : "Casts Ice Bolt with Damage increased by 3% for every N hero levels, where N is the level of the targeted creature.",
 				"tooltip" : "Spell Bonus: Ice Bolt"
 			}
 		}

--- a/mods/bulwark/content/config/hota/bulwark/town/buildings.json
+++ b/mods/bulwark/content/config/hota/bulwark/town/buildings.json
@@ -122,8 +122,8 @@
 					"name" : "Fair",
 					"description" : "The Fair improves the market rate of Marketplace.",
 					"cost" : {
-						"gold" : 1000,
-						"wood" : 5
+						"gold" : 2000,
+						"wood" : 10
 					},
 					"requires" : [
 						"allOf",

--- a/mods/cove/Content/config/hota/cove/heroes/astra.json
+++ b/mods/cove/Content/config/hota/cove/heroes/astra.json
@@ -53,7 +53,7 @@
 			"biography" : "There is little known about Astra's past, and she does not hurry to tell much. The only detail known is that she visited almost every corner of the world in order to master the Water Magic. She fulfilled her wish of mastering this school after joining the Sea Priestesses.",
 			"specialty" : {
 				"name" : "Cure",
-				"description" : "Casts Cure with effect increased by 3% for every N hero levels, where N is the level of the target creature.",
+				"description" : "Casts Cure with effect increased by 3% for every N hero levels, where N is the level of the targeted creature.",
 				"tooltip" : "Spell Bonus: Cure"
 			}
 		}

--- a/mods/cove/Content/config/hota/cove/heroes/dargem.json
+++ b/mods/cove/Content/config/hota/cove/heroes/dargem.json
@@ -51,7 +51,7 @@
 			"biography" : "Dargem's past is quite legendary. They say that he alone captured a fort; the defenders' arrows simply could not reach him. Little is known of the time Dargem spent in the dungeons of Nighon as an apprentice warlock, but it's obvious that underworld magic is his ace. Barraging his ship with cannonballs and arrows is a notorious waste of time.",
 			"specialty" : {
 				"name" : "Air Shield",
-				"description" : "Casts Air Shield with effect increased by 3% for every N hero levels, where N is the level of the target creature.",
+				"description" : "Casts Air Shield with effect increased by 3% for every N hero levels, where N is the level of the targeted creature.",
 				"tooltip" : "Spell Bonus: Air Shield"
 			}
 		}

--- a/mods/cove/Content/config/hota/cove/heroes/manfred.json
+++ b/mods/cove/Content/config/hota/cove/heroes/manfred.json
@@ -52,7 +52,7 @@
 			"biography" : "Even the most vicious pirate hunters stay away from this outlander. Nobody knows where Manfred came, but it is known that he can wage fire on galleons with a single hand swing. Pirates dislike Manfred for his horrible accent and his not any less horrible character; however they respect him as a mercenary battle mage.",
 			"specialty" : {
 				"name" : "Fireball",
-				"description" : "Casts Fireball with Damage increased by 3% for every N hero levels, where N is the level of the target creature.",
+				"description" : "Casts Fireball with Damage increased by 3% for every N hero levels, where N is the level of the targeted creature.",
 				"tooltip" : "Spell Bonus: Fireball"
 			}
 		}

--- a/mods/factory/content/config/hota/factory/heroes/wrathmont.json
+++ b/mods/factory/content/config/hota/factory/heroes/wrathmont.json
@@ -9,7 +9,7 @@
 			"specialty" : {
 				"tooltip" : "Spell Bonus: Frenzy",
 				"name" : "Frenzy",
-				"description" : "Casts Frenzy with effect increased by 3% for every N hero levels, where N is the level of the target creature."
+				"description" : "Casts Frenzy with effect increased by 3% for every N hero levels, where N is the level of the targeted creature."
 			}
 		},
 

--- a/mods/factory/content/config/hota/factory/heroes/ziph.json
+++ b/mods/factory/content/config/hota/factory/heroes/ziph.json
@@ -9,7 +9,7 @@
 			"specialty" : {
 				"tooltip" : "Spell Bonus: Lightning Bolt",
 				"name" : "Lightning Bolt",
-				"description" : "Casts Lightning Bolt with Damage increased by 3% for every N hero levels, where N is the level of the target creature."
+				"description" : "Casts Lightning Bolt with Damage increased by 3% for every N hero levels, where N is the level of the targeted creature."
 			}
 		},
 

--- a/mods/gameBalance/mods/creatures/content/config/hotaGameBalance/creatures.json
+++ b/mods/gameBalance/mods/creatures/content/config/hotaGameBalance/creatures.json
@@ -138,6 +138,20 @@
 		}
 	},
 	// necropolis
+	"core:wight" : {
+		"abilities": {
+			"regenerate" : {
+				"val" : 5000
+			}
+		}
+	},
+	"core:wraith" : {
+		"abilities": {
+			"regenerate" : {
+				"val" : 5000
+			}
+		}
+	},
 	"core:boneDragon" : {
 		"abilities" : {
 			"boneDragonSkeleton" : {

--- a/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/bulwark/dalton.json
+++ b/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/bulwark/dalton.json
@@ -3,13 +3,13 @@
 		"specialty" : {
 			"base" : {
 				"updater" : {
-					"valPer20" : 200
+					"valPer20" : 100
 				}
 			}
 		},
 		"texts" : {
 			"specialty" : {
-				"description" : "Casts Shield with effect increased by 10% for every N hero levels, where N is the level of the target creature."
+				"description" : "Casts Shield with effect increased by 5% for every N hero levels, where N is the level of the targeted creature."
 			}
 		}
 	}

--- a/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/bulwark/glacius.json
+++ b/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/bulwark/glacius.json
@@ -9,7 +9,7 @@
 		},
 		"texts" : {
 			"specialty" : {
-				"description" : "Casts Frost Ring with Damage increased by 10% for every N hero levels, where N is the level of the target creature."
+				"description" : "Casts Frost Ring with Damage increased by 10% for every N hero levels, where N is the level of the targeted creature."
 			}
 		}
 	}

--- a/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/bulwark/sial.json
+++ b/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/bulwark/sial.json
@@ -9,7 +9,7 @@
 		},
 		"texts" : {
 			"specialty" : {
-				"description" : "Casts Ice Bolt with Damage increased by 10% for every N hero levels, where N is the level of the target creature."
+				"description" : "Casts Ice Bolt with Damage increased by 10% for every N hero levels, where N is the level of the targeted creature."
 			}
 		}
 	}

--- a/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/castle/adela.json
+++ b/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/castle/adela.json
@@ -9,7 +9,7 @@
 		},
 		"texts" : {
 			"specialty" : {
-				"description" : "Increases the Damage of units affected by Bless by 10% for every N hero levels, where N is the level of the target creature."
+				"description" : "Increases the Damage of units affected by Bless by 10% for every N hero levels, where N is the level of the targeted creature."
 			}
 		}
 	}

--- a/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/castle/adelaide.json
+++ b/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/castle/adelaide.json
@@ -9,7 +9,7 @@
 		},
 		"texts" : {
 			"specialty" : {
-				"description" : "Casts Frost Ring with Damage increased by 10% for every N hero levels, where N is the level of the target creature."
+				"description" : "Casts Frost Ring with Damage increased by 10% for every N hero levels, where N is the level of the targeted creature."
 			}
 		}
 	}

--- a/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/cove/dargem.json
+++ b/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/cove/dargem.json
@@ -99,7 +99,7 @@
 		},
 		"texts" : {
 			"specialty" : {
-				"description" : "Casts Air Shield with effect increased by 10% for every N hero levels, where N is the level of the target creature."
+				"description" : "Casts Air Shield with effect increased by 10% for every N hero levels, where N is the level of the targeted creature."
 			}
 		}
 	}

--- a/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/cove/manfred.json
+++ b/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/cove/manfred.json
@@ -9,7 +9,7 @@
 		},
 		"texts" : {
 			"specialty" : {
-				"description" : "Casts Fireball with Damage increased by 10% for every N hero levels, where N is the level of the target creature."
+				"description" : "Casts Fireball with Damage increased by 10% for every N hero levels, where N is the level of the targeted creature."
 			}
 		}
 	}

--- a/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/dungeon/alamar.json
+++ b/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/dungeon/alamar.json
@@ -9,7 +9,7 @@
 		},
 		"texts" : {
 			"specialty" : {
-				"description" : "Casts Resurrection with effect increased by 5% for every N hero levels, where N is the level of the target creature."
+				"description" : "Casts Resurrection with effect increased by 5% for every N hero levels, where N is the level of the targeted creature."
 			}
 		}
 	}

--- a/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/dungeon/deemer.json
+++ b/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/dungeon/deemer.json
@@ -9,7 +9,7 @@
 		},
 		"texts" : {
 			"specialty" : {
-				"description" : "Casts Meteor Shower with Damage increased by 5% for every N hero levels, where N is the level of the target creature."
+				"description" : "Casts Meteor Shower with Damage increased by 5% for every N hero levels, where N is the level of the targeted creature."
 			}
 		},
 		"skills" : [

--- a/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/dungeon/jeddite.json
+++ b/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/dungeon/jeddite.json
@@ -9,7 +9,7 @@
 		},
 		"texts" : {
 			"specialty" : {
-				"description" : "Casts Resurrection with effect increased by 5% for every N hero levels, where N is the level of the target creature."
+				"description" : "Casts Resurrection with effect increased by 5% for every N hero levels, where N is the level of the targeted creature."
 			}
 		}
 	}

--- a/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/factory/wrathmont.json
+++ b/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/factory/wrathmont.json
@@ -9,7 +9,7 @@
 		},
 		"texts" : {
 			"specialty" : {
-				"description" : "Casts Frenzy with effect increased by 10% for every N hero levels, where N is the level of the target creature."
+				"description" : "Casts Frenzy with effect increased by 10% for every N hero levels, where N is the level of the targeted creature."
 			}
 		}
 	}

--- a/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/inferno/miseria.json
+++ b/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/inferno/miseria.json
@@ -9,7 +9,7 @@
 		},
 		"texts" : {
 			"specialty" : {
-				"description" : "Casts Resurrection with effect increased by 5% for every N hero levels, where N is the level of the target creature."
+				"description" : "Casts Resurrection with effect increased by 5% for every N hero levels, where N is the level of the targeted creature."
 			}
 		}
 	}

--- a/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/inferno/xarfax.json
+++ b/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/inferno/xarfax.json
@@ -9,7 +9,7 @@
 		},
 		"texts" : {
 			"specialty" : {
-				"description" : "Casts Fireball with Damage increased by 10% for every N hero levels, where N is the level of the target creature."
+				"description" : "Casts Fireball with Damage increased by 10% for every N hero levels, where N is the level of the targeted creature."
 			}
 		}
 	}

--- a/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/inferno/xyron.json
+++ b/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/inferno/xyron.json
@@ -9,7 +9,7 @@
 		},
 		"texts" : {
 			"specialty" : {
-				"description" : "Casts Inferno with Damage increased by 10% for every N hero levels, where N is the level of the target creature."
+				"description" : "Casts Inferno with Damage increased by 10% for every N hero levels, where N is the level of the targeted creature."
 			}
 		}
 	}

--- a/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/necropolis/aislinn.json
+++ b/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/necropolis/aislinn.json
@@ -9,7 +9,7 @@
 		},
 		"texts" : {
 			"specialty" : {
-				"description" : "Casts Meteor Shower with Damage increased by 5% for every N hero levels, where N is the level of the target creature."
+				"description" : "Casts Meteor Shower with Damage increased by 5% for every N hero levels, where N is the level of the targeted creature."
 			}
 		}
 	}

--- a/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/necropolis/septienna.json
+++ b/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/necropolis/septienna.json
@@ -9,7 +9,7 @@
 		},
 		"texts" : {
 			"specialty" : {
-				"description" : "Casts Death Ripple with Damage increased by 10% for every N hero levels, where N is the level of the target creature."
+				"description" : "Casts Death Ripple with Damage increased by 10% for every N hero levels, where N is the level of the targeted creature."
 			}
 		}
 	}

--- a/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/necropolis/thant.json
+++ b/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/necropolis/thant.json
@@ -9,7 +9,7 @@
 		},
 		"texts" : {
 			"specialty" : {
-				"description" : "Casts Animate Dead with effect increased by 5% for every N hero levels, where N is the level of the target creature."
+				"description" : "Casts Animate Dead with effect increased by 5% for every N hero levels, where N is the level of the targeted creature."
 			}
 		}
 	}

--- a/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/rampart/alagar.json
+++ b/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/rampart/alagar.json
@@ -9,7 +9,7 @@
 		},
 		"texts" : {
 			"specialty" : {
-				"description" : "Casts Ice Bolt with Damage increased by 10% for every N hero levels, where N is the level of the target creature."
+				"description" : "Casts Ice Bolt with Damage increased by 10% for every N hero levels, where N is the level of the targeted creature."
 			}
 		}
 	}

--- a/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/tower/solmyr.json
+++ b/mods/gameBalance/mods/heroes/content/config/hotaGameBalance/tower/solmyr.json
@@ -10,7 +10,7 @@
 		"texts" : {
 			"specialty" : {
 				"name" : "Chain Lightning",
-				"description" : "Casts Chain Lightning with Damage increased by 5% for every N hero levels, where N is the level of the target creature."
+				"description" : "Casts Chain Lightning with Damage increased by 5% for every N hero levels, where N is the level of the targeted creature."
 			}
 		}
 	}

--- a/mods/heroes/Content/config/inferno/heroes/miseria.json
+++ b/mods/heroes/Content/config/inferno/heroes/miseria.json
@@ -55,7 +55,7 @@
 			"specialty" : {
 				"tooltip" : "Spell Bonus: Resurrection",
 				"name" : "Resurrection",
-				"description" : "Casts Resurrection with effect increased by 3% for every N hero levels, where N is the level of the target creature."
+				"description" : "Casts Resurrection with effect increased by 3% for every N hero levels, where N is the level of the targeted creature."
 			}
 		}
 	}

--- a/mods/templates/content/config/hota2sm2c(2).json
+++ b/mods/templates/content/config/hota2sm2c(2).json
@@ -34,7 +34,8 @@
 			"luna",
 			"hota.cove:02jeremy",
 			"hota.heroes:kinkeria",
-			"hota.factory:17victoria"
+			"hota.factory:17victoria",
+			"hota.bulwark:10glacius"
 		],
 		"zones" : {
 			"1" : {

--- a/mods/templates/content/config/hotaNineDayWonder.json
+++ b/mods/templates/content/config/hotaNineDayWonder.json
@@ -53,7 +53,8 @@
 			"ciele",
 			"hota.cove:02jeremy",
 			"hota.heroes:kinkeria",
-			"hota.factory:17victoria"
+			"hota.factory:17victoria",
+			"hota.bulwark:10glacius"
 		],
 		"zones" : {
 			"1" : {

--- a/mods/templates/content/config/hotaSkirmish(M).json
+++ b/mods/templates/content/config/hotaSkirmish(M).json
@@ -34,7 +34,8 @@
 			"luna",
 			"hota.cove:02jeremy",
 			"hota.heroes:kinkeria",
-			"hota.factory:17victoria"
+			"hota.factory:17victoria",
+			"hota.bulwark:10glacius"
 		],
 		"zones" : {
 			"1" : {


### PR DESCRIPTION
#689  Balance section

Also included is the Wraith/Wight fix and one of the vague "text fix" entries. The fixed text was spell specialists now saying "where N is the level of the targeted creature" instead of just "target creature". Doesn't add any new strings and doesn't affect translations of most languages, so merging is fine.