### PR TITLE
Update config for recent core changes

### DIFF
--- a/mods/artifacts/Content/config/hotaArtifacts/ringOfOblivion.json
+++ b/mods/artifacts/Content/config/hotaArtifacts/ringOfOblivion.json
@@ -9,32 +9,37 @@
 		"bonuses" : {
 			"bonus1" : {
 				"type" : "GARGOYLE",
-				"propagator" : "BATTLE_WIDE"
+				"propagator" : "BATTLE_WIDE",
+				"hidden" : true
 			},
 			"bonus2" : {
 				"type" : "DISINTEGRATE",
-				"propagator" : "BATTLE_WIDE"
+				"propagator" : "BATTLE_WIDE",
+				"hidden" : true
 			},
 			"bonus3" : {
 				"type" : "SPELL_IMMUNITY",
 				"subtype" : "sacrifice",
 				"valueType" : "BASE_NUMBER",
 				"val" : 0,
-				"propagator" : "BATTLE_WIDE"
+				"propagator" : "BATTLE_WIDE",
+				"hidden" : true
 			},
 			"bonus4" : {
 				"type" : "SPELL_IMMUNITY",
 				"subtype" : "animateDead",
 				"valueType" : "BASE_NUMBER",
 				"val" : 0,
-				"propagator" : "BATTLE_WIDE"
+				"propagator" : "BATTLE_WIDE",
+				"hidden" : true
 			},
 			"bonus5" : {
 				"type" : "SPELL_IMMUNITY",
 				"subtype" : "resurrection",
 				"valueType" : "BASE_NUMBER",
 				"val" : 0,
-				"propagator" : "BATTLE_WIDE"
+				"propagator" : "BATTLE_WIDE",
+				"hidden" : true
 			},
 			"bonus6" : {
 				"type" : "LIFE_DRAIN",

--- a/mods/factory/content/config/hota/factory/artifacts/factoryRingOfOblivion.json
+++ b/mods/factory/content/config/hota/factory/artifacts/factoryRingOfOblivion.json
@@ -6,7 +6,8 @@
 				"subtype" : "hotaRepair",
 				"valueType" : "BASE_NUMBER",
 				"val" : 0,
-				"propagator" : "BATTLE_WIDE"
+				"propagator" : "BATTLE_WIDE",
+				"hidden" : true
 			}
 		}
 	}

--- a/mods/gameBalance/mod.json
+++ b/mods/gameBalance/mod.json
@@ -23,6 +23,8 @@
 				6
 			],
 			"areaShotCanTargetEmptyHex" : true,
+			"oneHexTriggersObstacles" : true,
+			"luckyStrikeAffectsAllTargets" : true,
 			"noSpellHitAndRunRounds" : 1
 		}
 	},


### PR DESCRIPTION
+ Adds new `luckyStrikeAffectsAllTargets` setting to gamebalance (no change, core just worked like HotA before)
+ Adds `oneHexTriggersObstacles` setting to gamebalance (must have been forgotten)
+ Sets the immunities and other bonuses from Ring of Oblivion to hidden (you shouldn't really be able to tell that it's in effect until you try casting a blocked spell)
